### PR TITLE
Wrapper not found fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.1.2
-- Fixed wrapper not found error.
+- Fixed wrapper not found error when running `pub run ffigen`.
 
 # 0.1.1
 - Address pub score: follow dart File conventions, provide documentation, and pass static analysis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.2
+- Fixed wrapper not found error.
+
 # 0.1.1
 - Address pub score: follow dart File conventions, provide documentation, and pass static analysis.
 

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -27,7 +27,7 @@
 import 'dart:io';
 import 'package:args/args.dart';
 import 'package:meta/meta.dart';
-import 'package:ffigen/src/find_dot_dart_tool.dart';
+import 'package:ffigen/src/find_resource.dart';
 import 'package:ffigen/src/strings.dart' as strings;
 import 'package:path/path.dart' as path;
 
@@ -137,14 +137,7 @@ String _dylibPath() {
 ///
 /// Throws error if not found.
 String _getWrapperPath(String wrapperName) {
-  final file = File(path.join(
-    Platform.script
-        .resolve(path.posix.join('..', 'lib', 'src', 'clang_library'))
-        // This needs to be in posix style or illegal character exception is
-        // thrown on windows.
-        .toFilePath(),
-    wrapperName,
-  ));
+  final file = File.fromUri(findWrapper(wrapperName));
   if (file.existsSync()) {
     return file.absolute.path;
   } else {

--- a/lib/src/code_generator.dart
+++ b/lib/src/code_generator.dart
@@ -14,4 +14,3 @@ export 'code_generator/library.dart';
 export 'code_generator/struc.dart';
 export 'code_generator/type.dart';
 export 'code_generator/typedef.dart';
-

--- a/lib/src/find_resource.dart
+++ b/lib/src/find_resource.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library finddotdarttool;
+library find_resource;
 
-export 'find_dot_dart_tool/finddotdarttool_fallback.dart'
-    if (dart.library.cli) 'find_dot_dart_tool/finddotdarttool_cli.dart';
+export 'find_resource/find_resource_fallback.dart'
+    if (dart.library.cli) 'find_resource/find_resource_cli.dart';

--- a/lib/src/find_resource/find_resource_cli.dart
+++ b/lib/src/find_resource/find_resource_cli.dart
@@ -5,7 +5,7 @@
 import 'dart:cli' as cli;
 import 'dart:io' show File;
 import 'dart:isolate' show Isolate;
-import 'finddotdarttool_fallback.dart' as fallback;
+import 'find_resource_fallback.dart' as fallback;
 
 /// Find the `.dart_tool/` folder, returns `null` if unable to find it.
 Uri findDotDartTool() {
@@ -26,4 +26,12 @@ Uri findDotDartTool() {
   // If [Isolate.packageConfig] isn't helpful we fallback to looking at the
   // current script location and traverse up from there.
   return fallback.findDotDartTool();
+}
+
+Uri findWrapper(String wrapperName) {
+  final wrapperUri = cli.waitFor(Isolate.resolvePackageUri(
+      Uri.parse('package:ffigen/src/clang_library/$wrapperName')));
+  // If [Isolate.packageConfig] isn't helpful we fallback to looking at the
+  // current script location and traverse up from there.
+  return wrapperUri ?? fallback.findWrapper(wrapperName);
 }

--- a/lib/src/find_resource/find_resource_fallback.dart
+++ b/lib/src/find_resource/find_resource_fallback.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert' show jsonDecode;
-import 'dart:io' show Platform, File, Directory;
+import 'dart:io' show File, Directory;
 
 /// Find the `.dart_tool/` folder, returns `null` if unable to find it.
 Uri findDotDartTool() {

--- a/lib/src/header_parser/parser.dart
+++ b/lib/src/header_parser/parser.dart
@@ -7,7 +7,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/config_provider.dart';
-import 'package:ffigen/src/find_dot_dart_tool.dart';
+import 'package:ffigen/src/find_resource.dart';
 import 'package:ffigen/src/header_parser/translation_unit_parser.dart';
 import 'package:ffigen/src/strings.dart' as strings;
 import 'package:logging/logging.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C/C++ header files.
 


### PR DESCRIPTION
Possibly fixes #41 (Needs to be tested after publishing).

- Using `dart:cli` to resolve package uri and get wrapper.c for running `pub run ffigen:setup`.
- If `dart:cli` is unavailable, fallback tries to work up the current directory to find `.dart_tool/package_config.json` and get rootUri of `package:ffigen` and find wrapper.c from there.