### PR TITLE
Escaped special characters $ and ' from string macros.

### DIFF
--- a/lib/src/header_parser/sub_parsers/macro_parser.dart
+++ b/lib/src/header_parser/sub_parsers/macro_parser.dart
@@ -132,12 +132,16 @@ int _macroVariablevisitor(Pointer<clang_types.CXCursor> cursor,
           );
           break;
         case clang_types.CXEvalResultKind.CXEval_StrLiteral:
+          var value = Utf8.fromUtf8(clang.clang_EvalResult_getAsStr(e).cast());
+          // Escape $ character.
+          value = value.replaceAll(r'$', r'\$');
+          // Escape ' character, because our strings are enclosed with '.
+          value = value.replaceAll("'", r"\'");
           constant = Constant(
             originalName: _savedMacros[macroName],
             name: macroName,
             rawType: 'String',
-            rawValue:
-                "'${Utf8.fromUtf8(clang.clang_EvalResult_getAsStr(e).cast())}'",
+            rawValue: "'${value}'",
           );
           break;
       }

--- a/test/header_parser_tests/macros.h
+++ b/test/header_parser_tests/macros.h
@@ -14,3 +14,7 @@
 #define TEST7(x, y) x *y
 
 #define TEST8 5,2,3
+
+// These tests that special characters are escaped properly.
+#define TEST9 "$dollar"
+#define TEST10 "test's"

--- a/test/header_parser_tests/macros_test.dart
+++ b/test/header_parser_tests/macros_test.dart
@@ -64,6 +64,14 @@ ${strings.headers}:
       expect(actual.getBindingAsString('TEST8'),
           expected.getBindingAsString('TEST8'));
     });
+    test('TEST9', () {
+      expect(actual.getBindingAsString('TEST9'),
+          expected.getBindingAsString('TEST9'));
+    });
+    test('TEST10', () {
+      expect(actual.getBindingAsString('TEST10'),
+          expected.getBindingAsString('TEST10'));
+    });
   });
 }
 
@@ -78,6 +86,8 @@ Library expectedLibrary() {
       Constant(name: 'TEST5', rawType: 'int', rawValue: '4'),
       Constant(name: 'TEST6', rawType: 'int', rawValue: '1'),
       Constant(name: 'TEST8', rawType: 'int', rawValue: '5'),
+      Constant(name: 'TEST9', rawType: 'String', rawValue: r"'\$dollar'"),
+      Constant(name: 'TEST10', rawType: 'String', rawValue: r"'test\'s'"),
     ],
   );
 }


### PR DESCRIPTION
closes #63 
- `$` and `'` in string macros are escaped by replacing them with `\$` or `\'`
- Added tests to macro_tests