### PR TITLE
Regexp based Member renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Updated header config. Header `entry-points` and `include-directives` are now specified under `headers` key. Glob syntax is allowed.
 - Updated declaration `include`/`exclude` config. These are now specified as a list.
 - Added Regexp based declaration renaming using `rename` subkey.
+- Added Regexp based member renaming for structs, enums and functions using `member-rename` subkey. `prefix` and `prefix-replacement` subkeys have been removed.
 
 # 0.1.5
 - Added support for parsing macros and anonymous unnamed enums. These are generated as top level constants.

--- a/README.md
+++ b/README.md
@@ -112,11 +112,17 @@ functions:
     - [a-z][a-zA-Z0-9]* # Matches using regexp.
     - prefix.* # '.' matches any character.
     - someFuncName # Matches with exact name
-    - anotherName # full names have higher priority.
+    - anotherName # Full names have higher priority.
   rename:
     'clang_(.*)': '$1' # Regexp groups based replacement.
     'clang_dispose': 'dispose' # full name matches have higher priority.
     '_(.*)': '$1' # Removes '_' from beginning of a name.
+enums:
+  member-rename:
+    '(.*)': # Matches any enum.
+      '_(.*)': '$1' # Removes '_' from beginning enum member name.
+    'CXTypeKind': # Full names have higher priority.
+      'CXType(.*)': '$1' # $1 keeps only the 1st group i.e '(.*)'.
     </code></pre></td>
   </tr>
   <tr>

--- a/lib/src/code_generator/enum_class.dart
+++ b/lib/src/code_generator/enum_class.dart
@@ -72,8 +72,14 @@ class EnumClass extends NoLookUpBinding {
 
 /// Represents a single value in an enum.
 class EnumConstant {
+  final String originalName;
   final String dartDoc;
   final String name;
   final int value;
-  const EnumConstant({@required this.name, @required this.value, this.dartDoc});
+  const EnumConstant({
+    String originalName,
+    @required this.name,
+    @required this.value,
+    this.dartDoc,
+  }) : originalName = originalName ?? name;
 }

--- a/lib/src/code_generator/func.dart
+++ b/lib/src/code_generator/func.dart
@@ -147,8 +147,10 @@ class Func extends LookUpBinding {
 
 /// Represents a Function's parameter.
 class Parameter {
+  final String originalName;
   String name;
   final Type type;
 
-  Parameter({this.name, @required this.type});
+  Parameter({String originalName, this.name, @required this.type})
+      : originalName = originalName ?? name;
 }

--- a/lib/src/code_generator/struc.dart
+++ b/lib/src/code_generator/struc.dart
@@ -151,10 +151,16 @@ class Struc extends NoLookUpBinding {
 
 class Member {
   final String dartDoc;
+  final String originalName;
   final String name;
   final Type type;
 
-  const Member({@required this.name, @required this.type, this.dartDoc});
+  const Member({
+    String originalName,
+    @required this.name,
+    @required this.type,
+    this.dartDoc,
+  }) : originalName = originalName ?? name;
 }
 
 // Helper bindings for struct array.

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -182,9 +182,9 @@ Declaration declarationConfigExtractor(dynamic yamlMap) {
       includeFull = <String>{},
       excludeMatchers = <RegExp>[],
       excludeFull = <String>{};
-  final renamePatterns = <RenamePattern>[];
+  final renamePatterns = <RegExpRenamer>[];
   final renameFull = <String, String>{};
-  final memberRenamePatterns = <MemberRenamePattern>[];
+  final memberRenamePatterns = <RegExpMemberRenamer>[];
   final memberRenamerFull = <String, Renamer>{};
 
   final include = (yamlMap[strings.include] as YamlList)?.cast<String>();
@@ -217,7 +217,7 @@ Declaration declarationConfigExtractor(dynamic yamlMap) {
         renameFull[str] = rename[str];
       } else {
         renamePatterns
-            .add(RenamePattern(RegExp(str, dotAll: true), rename[str]));
+            .add(RegExpRenamer(RegExp(str, dotAll: true), rename[str]));
       }
     }
   }
@@ -227,7 +227,7 @@ Declaration declarationConfigExtractor(dynamic yamlMap) {
 
   if (memberRename != null) {
     for (final decl in memberRename.keys) {
-      final renamePatterns = <RenamePattern>[];
+      final renamePatterns = <RegExpRenamer>[];
       final renameFull = <String, String>{};
 
       final memberRenameMap = memberRename[decl].cast<String, String>();
@@ -235,7 +235,7 @@ Declaration declarationConfigExtractor(dynamic yamlMap) {
         if (isFullDeclarationName(member)) {
           renameFull[member] = memberRenameMap[member];
         } else {
-          renamePatterns.add(RenamePattern(
+          renamePatterns.add(RegExpRenamer(
               RegExp(member, dotAll: true), memberRenameMap[member]));
         }
       }
@@ -246,7 +246,7 @@ Declaration declarationConfigExtractor(dynamic yamlMap) {
         );
       } else {
         memberRenamePatterns.add(
-          MemberRenamePattern(
+          RegExpMemberRenamer(
             RegExp(decl, dotAll: true),
             Renamer(
               renameFull: renameFull,

--- a/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -100,7 +100,11 @@ void _addEnumConstantToEnumClass(Pointer<clang_types.CXCursor> cursor) {
           cursor,
           nesting.length + commentPrefix.length,
         ),
-        name: cursor.spelling(),
+        originalName: cursor.spelling(),
+        name: config.enumClassDecl.renameMemberUsingConfig(
+          _stack.top.enumClass.originalName,
+          cursor.spelling(),
+        ),
         value: clang.clang_getEnumConstantDeclValue_wrap(cursor)),
   );
 }

--- a/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -36,7 +36,7 @@ Func parseFunctionDeclaration(Pointer<clang_types.CXCursor> cursor) {
     _logger.fine('++++ Adding Function: ${cursor.completeStringRepr()}');
 
     final rt = _getFunctionReturnType(cursor);
-    final parameters = _getParameters(cursor);
+    final parameters = _getParameters(cursor, funcName);
 
     //TODO(3): Remove this when support for Structs by value arrives.
     if (rt.broadType == BroadType.Struct || _stack.top.structByValueParameter) {
@@ -80,7 +80,8 @@ Type _getFunctionReturnType(Pointer<clang_types.CXCursor> cursor) {
   return cursor.returnType().toCodeGenTypeAndDispose();
 }
 
-List<Parameter> _getParameters(Pointer<clang_types.CXCursor> cursor) {
+List<Parameter> _getParameters(
+    Pointer<clang_types.CXCursor> cursor, String funcName) {
   final parameters = <Parameter>[];
 
   final totalArgs = clang.clang_Cursor_getNumArguments_wrap(cursor);
@@ -102,7 +103,8 @@ List<Parameter> _getParameters(Pointer<clang_types.CXCursor> cursor) {
     /// If [pn] is null or empty, its set to `arg$i` by code_generator.
     parameters.add(
       Parameter(
-        name: pn,
+        originalName: pn,
+        name: config.functionDecl.renameMemberUsingConfig(funcName, pn),
         type: pt,
       ),
     );

--- a/lib/src/header_parser/sub_parsers/structdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/structdecl_parser.dart
@@ -130,7 +130,11 @@ int _structMembersVisitor(Pointer<clang_types.CXCursor> cursor,
             cursor,
             nesting.length + commentPrefix.length,
           ),
-          name: cursor.spelling(),
+          originalName: cursor.spelling(),
+          name: config.structDecl.renameMemberUsingConfig(
+            _stack.top.struc.originalName,
+            cursor.spelling(),
+          ),
           type: mt,
         ),
       );

--- a/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
@@ -60,7 +60,11 @@ int _unnamedenumCursorVisitor(Pointer<clang_types.CXCursor> cursor,
 void _addUnNamedEnumConstant(Pointer<clang_types.CXCursor> cursor) {
   _constants.add(
     Constant(
-      name: cursor.spelling(),
+      originalName: cursor.spelling(),
+      name: config.enumClassDecl.renameMemberUsingConfig(
+        '', // Un-named enum constants have an empty declaration name.
+        cursor.spelling(),
+      ),
       rawType: 'int',
       rawValue: clang.clang_getEnumConstantDeclValue_wrap(cursor).toString(),
     ),

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -46,6 +46,7 @@ const macros = 'macros';
 const include = 'include';
 const exclude = 'exclude';
 const rename = 'rename';
+const memberRename = 'member-rename';
 const sizemap = 'size-map';
 
 // Sizemap values.

--- a/test/rename_tests/rename.h
+++ b/test/rename_tests/rename.h
@@ -15,10 +15,21 @@ struct Test_Struct2
 struct FullMatchStruct3
 {
 };
+struct MemberRenameStruct4
+{
+    int _underscore;
+    float fullMatch;
+};
+
+struct AnyMatchStruct5
+{
+    int _underscore;
+};
 
 void func1(struct Struct1 *s);
 void test_func2(struct Test_Struct2 *s);
 void fullMatch_func3(struct FullMatchStruct3 *s);
+void memberRename_func4(int _underscore, float fullMatch, int);
 
 enum Enum1
 {
@@ -37,4 +48,14 @@ enum FullMatchEnum3
     i = 0,
     j = 1,
     k = 2
+};
+enum MemberRenameEnum4
+{
+    _underscore = 0,
+    fullMatch = 1
+};
+enum
+{
+    _unnamed_underscore = 0,
+    unnamedFullMatch = 1
 };

--- a/test/rename_tests/rename_test.dart
+++ b/test/rename_tests/rename_test.dart
@@ -36,19 +36,36 @@ functions:
     'test_(.*)': '\$1'
     '.*': '$functionPrefix\$0'
     'fullMatch_func3': 'func3'
-
+  ${strings.memberRename}:
+    'memberRename_.*':
+      '_(.*)': '\$1'
+      'fullMatch': 'fullMatchSuccess'
+      '': 'unnamed'
 
 structs:
   ${strings.rename}:
     'Test_(.*)': '\$1'
     '.*': '$structPrefix\$0'
     'FullMatchStruct3': 'Struct3'
+  ${strings.memberRename}:
+    'MemberRenameStruct4':
+      '_(.*)': '\$1'
+      'fullMatch': 'fullMatchSuccess'
+    '.*':
+      '_(.*)': '\$1'
 
 enums:
   ${strings.rename}:
     'Test_(.*)': '\$1'
     '.*': '$enumPrefix\$0'
     'FullMatchEnum3': 'Enum3'
+  ${strings.memberRename}:
+    'MemberRenameEnum4':
+      '_(.*)': '\$1'
+      'fullMatch': 'fullMatchSuccess'
+    '':
+      '_(.*)': '\$1'
+      'unnamedFullMatch': 'unnamedFullMatchSuccess'
 
 macros:
   ${strings.rename}:
@@ -107,6 +124,30 @@ macros:
       expect(actual.getBindingAsString('Macro3'),
           expected.getBindingAsString('Macro3'));
     });
+    test('Struct member rename', () {
+      expect(actual.getBindingAsString('${structPrefix}MemberRenameStruct4'),
+          expected.getBindingAsString('${structPrefix}MemberRenameStruct4'));
+    });
+    test('Any Struct member rename', () {
+      expect(actual.getBindingAsString('${structPrefix}AnyMatchStruct5'),
+          expected.getBindingAsString('${structPrefix}AnyMatchStruct5'));
+    });
+    test('Function member rename', () {
+      expect(actual.getBindingAsString('${functionPrefix}memberRename_func4'),
+          expected.getBindingAsString('${functionPrefix}memberRename_func4'));
+    });
+    test('Enum member rename', () {
+      expect(actual.getBindingAsString('${enumPrefix}MemberRenameEnum4'),
+          expected.getBindingAsString('${enumPrefix}MemberRenameEnum4'));
+    });
+    test('unnamed Enum regexp rename', () {
+      expect(actual.getBindingAsString('unnamed_underscore'),
+          expected.getBindingAsString('unnamed_underscore'));
+    });
+    test('unnamed Enum full match rename', () {
+      expect(actual.getBindingAsString('unnamedFullMatchSuccess'),
+          expected.getBindingAsString('unnamedFullMatchSuccess'));
+    });
   });
 }
 
@@ -156,9 +197,52 @@ Library expectedLibrary() {
           ),
         ],
       ),
+      Func(
+        name: '${functionPrefix}memberRename_func4',
+        originalName: 'memberRename_func4',
+        returnType: Type.nativeType(
+          SupportedNativeType.Void,
+        ),
+        parameters: [
+          Parameter(
+            name: 'underscore',
+            type: Type.nativeType(SupportedNativeType.Int32),
+          ),
+          Parameter(
+            name: 'fullMatchSuccess',
+            type: Type.nativeType(SupportedNativeType.Float),
+          ),
+          Parameter(
+            name: 'unnamed',
+            type: Type.nativeType(SupportedNativeType.Int32),
+          ),
+        ],
+      ),
       struc1,
       struc2,
       struc3,
+      Struc(
+        name: '${structPrefix}MemberRenameStruct4',
+        members: [
+          Member(
+            name: 'underscore',
+            type: Type.nativeType(SupportedNativeType.Int32),
+          ),
+          Member(
+            name: 'fullMatchSuccess',
+            type: Type.nativeType(SupportedNativeType.Float),
+          ),
+        ],
+      ),
+      Struc(
+        name: '${structPrefix}AnyMatchStruct5',
+        members: [
+          Member(
+            name: 'underscore',
+            type: Type.nativeType(SupportedNativeType.Int32),
+          ),
+        ],
+      ),
       EnumClass(
         name: '${enumPrefix}Enum1',
         enumConstants: [
@@ -183,6 +267,13 @@ Library expectedLibrary() {
           EnumConstant(name: 'k', value: 2),
         ],
       ),
+      EnumClass(
+        name: '${enumPrefix}MemberRenameEnum4',
+        enumConstants: [
+          EnumConstant(name: 'underscore', value: 0),
+          EnumConstant(name: 'fullMatchSuccess', value: 1),
+        ],
+      ),
       Constant(
         name: '${macroPrefix}Macro1',
         rawType: 'int',
@@ -197,6 +288,16 @@ Library expectedLibrary() {
         name: 'Macro3',
         rawType: 'int',
         rawValue: '3',
+      ),
+      Constant(
+        name: 'unnamed_underscore',
+        rawType: 'int',
+        rawValue: '0',
+      ),
+      Constant(
+        name: 'unnamedFullMatchSuccess',
+        rawType: 'int',
+        rawValue: '1',
       ),
     ],
   );


### PR DESCRIPTION
Closes #28 
- Added Member renaming using `member-rename` subkey in declarations.
- Renames struct/enum members and function parameter names using regexp/full matching.
- Added/Updated renaming tests.

Renaming can be done like this (example) -
```yaml
enums:
  member-rename:
    '(.*)': # Matches any enum.
      '_(.*)': '$1' # Removes '_' from beginning enum member name.
    'CXTypeKind': # Full names have higher priority.
      'CXType(.*)': '$1' # $1 keeps only the 1st group i.e '(.*)'.
```
