### PR TITLE
Handle Incomplete array members in structs

### DIFF
--- a/lib/src/code_generator/type.dart
+++ b/lib/src/code_generator/type.dart
@@ -116,7 +116,7 @@ class Type {
   }
   factory Type.incompleteArray(Type elementType) {
     return Type._(
-      broadType: BroadType.ConstantArray,
+      broadType: BroadType.IncompleteArray,
       child: elementType,
     );
   }

--- a/test/header_parser_tests/function_n_struct.h
+++ b/test/header_parser_tests/function_n_struct.h
@@ -12,4 +12,13 @@ struct Struct2
     struct Struct1 a;
 };
 
+struct Struct3
+{
+    int a;
+    int b[]; // Flexible array member.
+};
+
 void func1(struct Struct2 *s);
+
+// Incomplete array parameter will be treated as a pointer.
+void func2(struct Struct3 s[]);

--- a/test/header_parser_tests/function_n_struct_test.dart
+++ b/test/header_parser_tests/function_n_struct_test.dart
@@ -32,22 +32,31 @@ ${strings.headers}:
       );
     });
 
-    test('func1', () {
+    test('func1 struct pointer parameter', () {
       expect(actual.getBindingAsString('func1'),
           expected.getBindingAsString('func1'));
     });
-    test('Struct2', () {
+    test('func2 incomplete array parameter', () {
+      expect(actual.getBindingAsString('func2'),
+          expected.getBindingAsString('func2'));
+    });
+    test('Struct2 nested struct member', () {
       expect((actual.getBinding('Struct2') as Struc).members.isEmpty, true);
+    });
+    test('Struct3 flexible array member', () {
+      expect((actual.getBinding('Struct3') as Struc).members.isEmpty, true);
     });
   });
 }
 
 Library expectedLibrary() {
   final struc2 = Struc(name: 'Struct2', members: []);
+  final struc3 = Struc(name: 'Struct3', members: []);
   return Library(
     name: 'Bindings',
     bindings: [
       struc2,
+      struc3,
       Struc(name: 'Struct1', members: [
         Member(
           name: 'a',
@@ -58,6 +67,15 @@ Library expectedLibrary() {
         name: 'func1',
         parameters: [
           Parameter(name: 's', type: Type.pointer(Type.struct(struc2))),
+        ],
+        returnType: Type.nativeType(
+          SupportedNativeType.Void,
+        ),
+      ),
+      Func(
+        name: 'func2',
+        parameters: [
+          Parameter(name: 's', type: Type.pointer(Type.struct(struc3))),
         ],
         returnType: Type.nativeType(
           SupportedNativeType.Void,


### PR DESCRIPTION
closes #55 
- Handle `NoSuchMethodError: The method '_mulFromInteger' was called on null` caused by incomplete array member in struct. As these are not currently supported in dart (#68) so struct all members are removed.
- Added tests.