### PR TITLE
Fixes for typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.1
+- Fixed missing/duplicate typedef generation.
+
 # 0.2.0
 - Updated header config. Header `entry-points` and `include-directives` are now specified under `headers` key. Glob syntax is allowed.
 - Updated declaration `include`/`exclude` config. These are now specified as a list.

--- a/example/libclang-example/generated_bindings.dart
+++ b/example/libclang-example/generated_bindings.dart
@@ -1889,7 +1889,7 @@ class LibClang {
   /// is inspecting the inclusions in the PCH file itself).
   void clang_getInclusions(
     ffi.Pointer<CXTranslationUnitImpl> tu,
-    ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_1>> visitor,
+    ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
     _clang_getInclusions ??= _dylib.lookupFunction<_c_clang_getInclusions,
@@ -3266,15 +3266,15 @@ class CXIdxEntityRefInfo extends ffi.Struct {}
 class IndexerCallbacks extends ffi.Struct {
   /// Called periodically to check whether indexing should be aborted.
   /// Should return 0 to continue, and non-zero to abort.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_3>> abortQuery;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_2>> abortQuery;
 
   /// Called at the end of indexing; passes the complete diagnostic set.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_4>> diagnostic;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_3>> diagnostic;
 
-  ffi.Pointer<ffi.NativeFunction<_typedefC_5>> enteredMainFile;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_4>> enteredMainFile;
 
   /// Called when a file gets \#included/\#imported.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> ppIncludedFile;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_5>> ppIncludedFile;
 
   /// Called when a AST file (PCH or module) gets imported.
   ///
@@ -3282,15 +3282,15 @@ class IndexerCallbacks extends ffi.Struct {
   /// the entities in an AST file). The recommended action is that, if the AST
   /// file is not already indexed, to initiate a new indexing job specific to
   /// the AST file.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> importedASTFile;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> importedASTFile;
 
   /// Called at the beginning of indexing a translation unit.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> startedTranslationUnit;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> startedTranslationUnit;
 
-  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> indexDeclaration;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> indexDeclaration;
 
   /// Called to index a reference of an entity.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> indexEntityReference;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> indexEntityReference;
 }
 
 const int CINDEX_VERSION_MAJOR = 0;
@@ -4147,7 +4147,7 @@ typedef _dart_clang_toggleCrashRecovery = void Function(
   int isEnabled,
 );
 
-typedef CXInclusionVisitor_1 = ffi.Void Function(
+typedef CXInclusionVisitor = ffi.Void Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<CXSourceLocation>,
   ffi.Uint32,
@@ -4156,13 +4156,13 @@ typedef CXInclusionVisitor_1 = ffi.Void Function(
 
 typedef _c_clang_getInclusions = ffi.Void Function(
   ffi.Pointer<CXTranslationUnitImpl> tu,
-  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_1>> visitor,
+  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
   ffi.Pointer<ffi.Void> client_data,
 );
 
 typedef _dart_clang_getInclusions = void Function(
   ffi.Pointer<CXTranslationUnitImpl> tu,
-  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_1>> visitor,
+  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
   ffi.Pointer<ffi.Void> client_data,
 );
 
@@ -4486,12 +4486,18 @@ typedef _dart_clang_indexTranslationUnit = int Function(
   ffi.Pointer<CXTranslationUnitImpl> arg5,
 );
 
-typedef _typedefC_3 = ffi.Int32 Function(
+typedef _typedefC_2 = ffi.Int32 Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
 );
 
-typedef _typedefC_4 = ffi.Void Function(
+typedef _typedefC_3 = ffi.Void Function(
+  ffi.Pointer<ffi.Void>,
+  ffi.Pointer<ffi.Void>,
+  ffi.Pointer<ffi.Void>,
+);
+
+typedef _typedefC_4 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
@@ -4499,31 +4505,25 @@ typedef _typedefC_4 = ffi.Void Function(
 
 typedef _typedefC_5 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
-  ffi.Pointer<ffi.Void>,
-  ffi.Pointer<ffi.Void>,
+  ffi.Pointer<CXIdxIncludedFileInfo>,
 );
 
 typedef _typedefC_6 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
-  ffi.Pointer<CXIdxIncludedFileInfo>,
+  ffi.Pointer<CXIdxImportedASTFileInfo>,
 );
 
 typedef _typedefC_7 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
-  ffi.Pointer<CXIdxImportedASTFileInfo>,
-);
-
-typedef _typedefC_8 = ffi.Pointer<ffi.Void> Function(
-  ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
 );
 
-typedef _typedefC_9 = ffi.Void Function(
+typedef _typedefC_8 = ffi.Void Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<CXIdxDeclInfo>,
 );
 
-typedef _typedefC_10 = ffi.Void Function(
+typedef _typedefC_9 = ffi.Void Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<CXIdxEntityRefInfo>,
 );

--- a/lib/src/code_generator/struc.dart
+++ b/lib/src/code_generator/struc.dart
@@ -66,8 +66,6 @@ class Struc extends NoLookUpBinding {
       for (final m in members) {
         final base = m.type.getBaseType();
         if (base.broadType == BroadType.NativeFunction) {
-          base.nativeFunc.name =
-              w.topLevelUniqueNamer.makeUnique(base.nativeFunc.name);
           _typedefDependencies.add(base.nativeFunc);
         }
       }

--- a/lib/src/code_generator/typedef.dart
+++ b/lib/src/code_generator/typedef.dart
@@ -65,19 +65,6 @@ class Typedef {
 
     return s.toString();
   }
-
-  @override
-  bool operator ==(Object a) {
-    if (a is Typedef) {
-      if (name != a.name || name.isEmpty) {
-        return false;
-      } else {
-        return typedefType == a.typedefType;
-      }
-    } else {
-      return false;
-    }
-  }
 }
 
 enum TypedefType { C, Dart }

--- a/lib/src/code_generator/typedef.dart
+++ b/lib/src/code_generator/typedef.dart
@@ -65,6 +65,19 @@ class Typedef {
 
     return s.toString();
   }
+
+  @override
+  bool operator ==(Object a) {
+    if (a is Typedef) {
+      if (name != a.name || name.isEmpty) {
+        return false;
+      } else {
+        return typedefType == a.typedefType;
+      }
+    } else {
+      return false;
+    }
+  }
 }
 
 enum TypedefType { C, Dart }

--- a/lib/src/header_parser/utils.dart
+++ b/lib/src/header_parser/utils.dart
@@ -330,6 +330,8 @@ class BindingsIndex {
   final Map<String, Func> _functions = {};
   final Map<String, EnumClass> _enumClass = {};
   final Map<String, String> _macros = {};
+  // Stores only named typedefC used in NativeFunc.
+  final Map<String, Typedef> _functionTypedefs = {};
 
   bool isSeenStruct(String originalName) {
     return _structs.containsKey(originalName);
@@ -377,5 +379,17 @@ class BindingsIndex {
 
   String getSeenMacro(String originalName) {
     return _macros[originalName];
+  }
+
+  bool isSeenFunctionTypedef(String originalName) {
+    return _functionTypedefs.containsKey(originalName);
+  }
+
+  void addFunctionTypedefToSeen(String originalName, Typedef t) {
+    _functionTypedefs[originalName] = t;
+  }
+
+  Typedef getSeenFunctionTypedef(String originalName) {
+    return _functionTypedefs[originalName];
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C/C++ header files.
 

--- a/test/header_parser_tests/typedef.h
+++ b/test/header_parser_tests/typedef.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+typedef void (*NamedFunctionProto)();
+
+struct Struct1
+{
+    NamedFunctionProto named;
+    void (*unnamed)();
+};
+
+NamedFunctionProto func1(NamedFunctionProto named, void (*unnamed)(int));

--- a/test/header_parser_tests/typedef.h
+++ b/test/header_parser_tests/typedef.h
@@ -10,4 +10,4 @@ struct Struct1
     void (*unnamed)();
 };
 
-NamedFunctionProto func1(NamedFunctionProto named, void (*unnamed)(int));
+extern NamedFunctionProto func1(NamedFunctionProto named, void (*unnamed)(int));

--- a/test/header_parser_tests/typedef_test.dart
+++ b/test/header_parser_tests/typedef_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:ffigen/src/code_generator.dart';
+import 'package:ffigen/src/header_parser.dart' as parser;
+import 'package:ffigen/src/config_provider.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart' as yaml;
+import 'package:ffigen/src/strings.dart' as strings;
+
+import '../test_utils.dart';
+
+Library actual, expected;
+
+void main() {
+  group('typedef_test', () {
+    setUpAll(() {
+      logWarnings(Level.SEVERE);
+      expected = expectedLibrary();
+      actual = parser.parse(
+        Config.fromYaml(yaml.loadYaml('''
+${strings.name}: 'Bindings'
+${strings.output}: 'unused'
+
+${strings.headers}:
+  ${strings.entryPoints}:
+    - 'test/header_parser_tests/typedef.h'
+        ''') as yaml.YamlMap),
+      );
+    });
+
+    test('Library output', () {
+      expect(actual.generate(), expected.generate());
+    });
+  });
+}
+
+Library expectedLibrary() {
+  final namedTypedef = Typedef(
+    name: 'NamedFunctionProto',
+    typedefType: TypedefType.C,
+    returnType: Type.nativeType(SupportedNativeType.Void),
+  );
+  return Library(
+    name: 'Bindings',
+    bindings: [
+      Struc(name: 'Struct1', members: [
+        Member(
+          name: 'named',
+          type: Type.pointer(Type.nativeFunc(namedTypedef)),
+        ),
+        Member(
+          name: 'unnamed',
+          type: Type.pointer(Type.nativeFunc(Typedef(
+            name: '_typedefC_1',
+            typedefType: TypedefType.C,
+            returnType: Type.nativeType(SupportedNativeType.Void),
+          ))),
+        ),
+      ]),
+      Func(
+        name: 'func1',
+        parameters: [
+          Parameter(
+            name: 'named',
+            type: Type.pointer(Type.nativeFunc(namedTypedef)),
+          ),
+          Parameter(
+            name: 'unnamed',
+            type: Type.pointer(Type.nativeFunc(Typedef(
+              name: '_typedefC_2',
+              typedefType: TypedefType.C,
+              parameters: [
+                Parameter(type: Type.nativeType(SupportedNativeType.Int32)),
+              ],
+              returnType: Type.nativeType(SupportedNativeType.Void),
+            ))),
+          ),
+        ],
+        returnType: Type.pointer(Type.nativeFunc(namedTypedef)),
+      ),
+    ],
+  );
+}

--- a/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -1628,7 +1628,7 @@ class LibClang {
   /// inspecting the inclusions in the PCH file itself).
   void clang_getInclusions(
     ffi.Pointer<CXTranslationUnitImpl> tu,
-    ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_1>> visitor,
+    ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
     _clang_getInclusions ??= _dylib.lookupFunction<_c_clang_getInclusions,
@@ -4370,26 +4370,26 @@ class CXIdxEntityRefInfo extends ffi.Struct {}
 class IndexerCallbacks extends ffi.Struct {
   /// Called periodically to check whether indexing should be aborted. Should
   /// return 0 to continue, and non-zero to abort.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_3>> abortQuery;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_2>> abortQuery;
 
   /// Called at the end of indexing; passes the complete diagnostic set.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_4>> diagnostic;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_3>> diagnostic;
 
-  ffi.Pointer<ffi.NativeFunction<_typedefC_5>> enteredMainFile;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_4>> enteredMainFile;
 
   /// Called when a file gets #included/#imported.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> ppIncludedFile;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_5>> ppIncludedFile;
 
   /// Called when a AST file (PCH or module) gets imported.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> importedASTFile;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> importedASTFile;
 
   /// Called at the beginning of indexing a translation unit.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> startedTranslationUnit;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> startedTranslationUnit;
 
-  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> indexDeclaration;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> indexDeclaration;
 
   /// Called to index a reference of an entity.
-  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> indexEntityReference;
+  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> indexEntityReference;
 }
 
 abstract class CXIndexOptFlags {
@@ -5391,7 +5391,7 @@ typedef _dart_clang_toggleCrashRecovery = void Function(
   int isEnabled,
 );
 
-typedef CXInclusionVisitor_1 = ffi.Void Function(
+typedef CXInclusionVisitor = ffi.Void Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<CXSourceLocation>,
   ffi.Uint32,
@@ -5400,13 +5400,13 @@ typedef CXInclusionVisitor_1 = ffi.Void Function(
 
 typedef _c_clang_getInclusions = ffi.Void Function(
   ffi.Pointer<CXTranslationUnitImpl> tu,
-  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_1>> visitor,
+  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
   ffi.Pointer<ffi.Void> client_data,
 );
 
 typedef _dart_clang_getInclusions = void Function(
   ffi.Pointer<CXTranslationUnitImpl> tu,
-  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_1>> visitor,
+  ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
   ffi.Pointer<ffi.Void> client_data,
 );
 
@@ -5730,12 +5730,18 @@ typedef _dart_clang_indexTranslationUnit = int Function(
   ffi.Pointer<CXTranslationUnitImpl> arg5,
 );
 
-typedef _typedefC_3 = ffi.Int32 Function(
+typedef _typedefC_2 = ffi.Int32 Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
 );
 
-typedef _typedefC_4 = ffi.Void Function(
+typedef _typedefC_3 = ffi.Void Function(
+  ffi.Pointer<ffi.Void>,
+  ffi.Pointer<ffi.Void>,
+  ffi.Pointer<ffi.Void>,
+);
+
+typedef _typedefC_4 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
@@ -5743,31 +5749,25 @@ typedef _typedefC_4 = ffi.Void Function(
 
 typedef _typedefC_5 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
-  ffi.Pointer<ffi.Void>,
-  ffi.Pointer<ffi.Void>,
+  ffi.Pointer<CXIdxIncludedFileInfo>,
 );
 
 typedef _typedefC_6 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
-  ffi.Pointer<CXIdxIncludedFileInfo>,
+  ffi.Pointer<CXIdxImportedASTFileInfo>,
 );
 
 typedef _typedefC_7 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<ffi.Void>,
-  ffi.Pointer<CXIdxImportedASTFileInfo>,
-);
-
-typedef _typedefC_8 = ffi.Pointer<ffi.Void> Function(
-  ffi.Pointer<ffi.Void>,
   ffi.Pointer<ffi.Void>,
 );
 
-typedef _typedefC_9 = ffi.Void Function(
+typedef _typedefC_8 = ffi.Void Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<CXIdxDeclInfo>,
 );
 
-typedef _typedefC_10 = ffi.Void Function(
+typedef _typedefC_9 = ffi.Void Function(
   ffi.Pointer<ffi.Void>,
   ffi.Pointer<CXIdxEntityRefInfo>,
 );


### PR DESCRIPTION
closes #71 
- Fixed missing typedef used in function's return type.
- Named function typedefs are now reused.
- Added tests for typedef generation.