### PR TITLE
Downgrade `package:meta` version to `^1.1.8` for compatibility with flutter sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.1+2
+- Updated `package:meta` version to `^1.1.8` for compatibility with flutter sdk.
+
 # 0.2.1+1
 - Added FAQ to readme.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 0.2.1+1
+version: 0.2.1+2
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C/C++ header files.
 
@@ -13,7 +13,7 @@ environment:
 dependencies:
   ffi: ^0.1.3
   yaml: ^2.2.1
-  meta: ^1.2.2
+  meta: ^1.1.8
   args: ^1.6.0
   logging: ^0.11.4
   glob: ^1.2.0


### PR DESCRIPTION
closes #81 
- Updated `package:meta` version from `^1.2.2` to `^1.1.8` for compatibility with flutter sdk.
- updated package version and changelog.