### PR TITLE
Updated parsing of typedef enclosed declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.2
+- Fixed multiple generation of typedef enclosed declarations.
+
 # 0.2.1+1
 - Added FAQ to readme.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.2.2
-- Fixed multiple generation of typedef enclosed declarations.
+- Fixed multiple generation/skipping of typedef enclosed declarations.
+- Typedef names are now given higher preference over inner names, See [#83](https://github.com/dart-lang/ffigen/pull/83).
 
 # 0.2.1+1
 - Added FAQ to readme.

--- a/lib/src/clang_library/wrapper.c
+++ b/lib/src/clang_library/wrapper.c
@@ -358,4 +358,9 @@ unsigned clang_Cursor_isAnonymousRecordDecl_wrap(CXCursor *cursor)
     return clang_Cursor_isAnonymousRecordDecl(*cursor);
 }
 
+CXString *clang_getCursorUSR_wrap(CXCursor *cursor)
+{
+    return ptrToCXString(clang_getCursorUSR(*cursor));
+}
+
 // END ===== WRAPPER FUNCTIONS =====================

--- a/lib/src/clang_library/wrapper.def
+++ b/lib/src/clang_library/wrapper.def
@@ -358,3 +358,4 @@ clang_Cursor_isMacroBuiltin_wrap
 clang_Cursor_Evaluate_wrap
 clang_Cursor_isAnonymous_wrap
 clang_Cursor_isAnonymousRecordDecl_wrap
+clang_getCursorUSR_wrap

--- a/lib/src/code_generator/binding.dart
+++ b/lib/src/code_generator/binding.dart
@@ -48,7 +48,7 @@ abstract class LookUpBinding extends Binding {
     @required String name,
     String dartDoc,
   }) : super(
-          usr: usr,
+          usr: usr ?? name,
           originalName: originalName ?? name,
           name: name,
           dartDoc: dartDoc,

--- a/lib/src/code_generator/binding.dart
+++ b/lib/src/code_generator/binding.dart
@@ -12,13 +12,23 @@ import 'writer.dart';
 ///
 /// Do not extend directly, use [LookUpBinding] or [NoLookUpBinding].
 abstract class Binding {
+  /// Holds the Unified Symbol Resolution string obtained from libclang.
+  final String usr;
+
+  /// The name as it was in C.
   final String originalName;
 
+  /// Binding name to generate, may get changed to resolve name conflicts.
   String name;
 
   final String dartDoc;
 
-  Binding({@required this.originalName, @required this.name, this.dartDoc});
+  Binding({
+    @required this.usr,
+    @required this.originalName,
+    @required this.name,
+    this.dartDoc,
+  });
 
   /// Return typedef dependencies.
   List<Typedef> getTypedefDependencies(Writer w);
@@ -33,17 +43,29 @@ abstract class Binding {
 /// Base class for bindings which look up symbols in dynamic library.
 abstract class LookUpBinding extends Binding {
   LookUpBinding({
-    @required String originalName,
+    String usr,
+    String originalName,
     @required String name,
     String dartDoc,
-  }) : super(originalName: originalName, name: name, dartDoc: dartDoc);
+  }) : super(
+          usr: usr,
+          originalName: originalName ?? name,
+          name: name,
+          dartDoc: dartDoc,
+        );
 }
 
 /// Base class for bindings which don't look up symbols in dynamic library.
 abstract class NoLookUpBinding extends Binding {
   NoLookUpBinding({
-    @required String originalName,
+    String usr,
+    String originalName,
     @required String name,
     String dartDoc,
-  }) : super(originalName: originalName, name: name, dartDoc: dartDoc);
+  }) : super(
+          usr: usr ?? name,
+          originalName: originalName ?? name,
+          name: name,
+          dartDoc: dartDoc,
+        );
 }

--- a/lib/src/code_generator/constant.dart
+++ b/lib/src/code_generator/constant.dart
@@ -31,12 +31,18 @@ class Constant extends NoLookUpBinding {
   final String rawValue;
 
   Constant({
+    String usr,
     String originalName,
     @required String name,
     String dartDoc,
     @required this.rawType,
     @required this.rawValue,
-  }) : super(originalName: originalName ?? name, name: name, dartDoc: dartDoc);
+  }) : super(
+          usr: usr,
+          originalName: originalName,
+          name: name,
+          dartDoc: dartDoc,
+        );
 
   @override
   BindingString toBindingString(Writer w) {

--- a/lib/src/code_generator/enum_class.dart
+++ b/lib/src/code_generator/enum_class.dart
@@ -28,12 +28,18 @@ class EnumClass extends NoLookUpBinding {
   final List<EnumConstant> enumConstants;
 
   EnumClass({
+    String usr,
     String originalName,
     @required String name,
     String dartDoc,
     List<EnumConstant> enumConstants,
   })  : enumConstants = enumConstants ?? [],
-        super(originalName: originalName ?? name, name: name, dartDoc: dartDoc);
+        super(
+          usr: usr,
+          originalName: originalName,
+          name: name,
+          dartDoc: dartDoc,
+        );
 
   @override
   BindingString toBindingString(Writer w) {

--- a/lib/src/code_generator/func.dart
+++ b/lib/src/code_generator/func.dart
@@ -36,6 +36,7 @@ class Func extends LookUpBinding {
   /// [originalName] is looked up in dynamic library, if not
   /// provided, takes the value of [name].
   Func({
+    String usr,
     @required String name,
     String originalName,
     String dartDoc,
@@ -43,7 +44,11 @@ class Func extends LookUpBinding {
     List<Parameter> parameters,
   })  : parameters = parameters ?? [],
         super(
-            originalName: originalName ?? name, name: name, dartDoc: dartDoc) {
+          usr: usr,
+          originalName: originalName,
+          name: name,
+          dartDoc: dartDoc,
+        ) {
     for (var i = 0; i < this.parameters.length; i++) {
       if (this.parameters[i].name == null ||
           this.parameters[i].name.trim() == '') {

--- a/lib/src/code_generator/global.dart
+++ b/lib/src/code_generator/global.dart
@@ -25,11 +25,17 @@ class Global extends LookUpBinding {
   final Type type;
 
   Global({
+    String usr,
     String originalName,
     @required String name,
     @required this.type,
     String dartDoc,
-  }) : super(originalName: originalName ?? name, name: name, dartDoc: dartDoc);
+  }) : super(
+          usr: usr,
+          originalName: originalName,
+          name: name,
+          dartDoc: dartDoc,
+        );
 
   @override
   BindingString toBindingString(Writer w) {

--- a/lib/src/code_generator/struc.dart
+++ b/lib/src/code_generator/struc.dart
@@ -39,12 +39,18 @@ class Struc extends NoLookUpBinding {
   List<Member> members;
 
   Struc({
+    String usr,
     String originalName,
     @required String name,
     String dartDoc,
     List<Member> members,
   })  : members = members ?? [],
-        super(originalName: originalName ?? name, name: name, dartDoc: dartDoc);
+        super(
+          usr: usr,
+          originalName: originalName,
+          name: name,
+          dartDoc: dartDoc,
+        );
 
   List<int> _getArrayDimensionLengths(Type type) {
     final array = <int>[];

--- a/lib/src/header_parser/clang_bindings/clang_bindings.dart
+++ b/lib/src/header_parser/clang_bindings/clang_bindings.dart
@@ -489,7 +489,7 @@ class Clang {
   /// instead of cxcursor by default.
   int clang_visitChildren_wrap(
     ffi.Pointer<CXCursor> parent,
-    ffi.Pointer<ffi.NativeFunction<ModifiedCXCursorVisitor_1>> _modifiedVisitor,
+    ffi.Pointer<ffi.NativeFunction<ModifiedCXCursorVisitor>> _modifiedVisitor,
     int uid,
   ) {
     _clang_visitChildren_wrap ??= _dylib.lookupFunction<
@@ -778,6 +778,19 @@ class Clang {
 
   _dart_clang_Cursor_isAnonymousRecordDecl_wrap
       _clang_Cursor_isAnonymousRecordDecl_wrap;
+
+  ffi.Pointer<CXString> clang_getCursorUSR_wrap(
+    ffi.Pointer<CXCursor> cursor,
+  ) {
+    _clang_getCursorUSR_wrap ??= _dylib.lookupFunction<
+        _c_clang_getCursorUSR_wrap,
+        _dart_clang_getCursorUSR_wrap>('clang_getCursorUSR_wrap');
+    return _clang_getCursorUSR_wrap(
+      cursor,
+    );
+  }
+
+  _dart_clang_getCursorUSR_wrap _clang_getCursorUSR_wrap;
 }
 
 /// A character string.
@@ -2451,7 +2464,7 @@ typedef _dart_clang_formatDiagnostic_wrap = ffi.Pointer<CXString> Function(
   int opts,
 );
 
-typedef ModifiedCXCursorVisitor_1 = ffi.Int32 Function(
+typedef ModifiedCXCursorVisitor = ffi.Int32 Function(
   ffi.Pointer<CXCursor>,
   ffi.Pointer<CXCursor>,
   ffi.Pointer<ffi.Void>,
@@ -2459,13 +2472,13 @@ typedef ModifiedCXCursorVisitor_1 = ffi.Int32 Function(
 
 typedef _c_clang_visitChildren_wrap = ffi.Uint32 Function(
   ffi.Pointer<CXCursor> parent,
-  ffi.Pointer<ffi.NativeFunction<ModifiedCXCursorVisitor_1>> _modifiedVisitor,
+  ffi.Pointer<ffi.NativeFunction<ModifiedCXCursorVisitor>> _modifiedVisitor,
   ffi.Int64 uid,
 );
 
 typedef _dart_clang_visitChildren_wrap = int Function(
   ffi.Pointer<CXCursor> parent,
-  ffi.Pointer<ffi.NativeFunction<ModifiedCXCursorVisitor_1>> _modifiedVisitor,
+  ffi.Pointer<ffi.NativeFunction<ModifiedCXCursorVisitor>> _modifiedVisitor,
   int uid,
 );
 
@@ -2639,5 +2652,13 @@ typedef _c_clang_Cursor_isAnonymousRecordDecl_wrap = ffi.Uint32 Function(
 );
 
 typedef _dart_clang_Cursor_isAnonymousRecordDecl_wrap = int Function(
+  ffi.Pointer<CXCursor> cursor,
+);
+
+typedef _c_clang_getCursorUSR_wrap = ffi.Pointer<CXString> Function(
+  ffi.Pointer<CXCursor> cursor,
+);
+
+typedef _dart_clang_getCursorUSR_wrap = ffi.Pointer<CXString> Function(
   ffi.Pointer<CXCursor> cursor,
 );

--- a/lib/src/header_parser/data.dart
+++ b/lib/src/header_parser/data.dart
@@ -37,8 +37,8 @@ IncrementalNamer _incrementalNamer;
 final uid = Isolate.current.controlPort.nativePort;
 
 /// Saved macros, Key: prefixedName, Value originalName.
-Map<String, String> get savedMacros => _savedMacros;
-Map<String, String> _savedMacros;
+Map<String, Macro> get savedMacros => _savedMacros;
+Map<String, Macro> _savedMacros;
 
 /// Saved unnamed EnumConstants.
 List<Constant> get unnamedEnumConstants => _unnamedEnumConstants;

--- a/lib/src/header_parser/includer.dart
+++ b/lib/src/header_parser/includer.dart
@@ -7,8 +7,8 @@ import 'data.dart';
 /// Utility functions to check whether a binding should be parsed or not
 /// based on filters.
 
-bool shouldIncludeStruct(String name) {
-  if (bindingsIndex.isSeenStruct(name) || name == '') {
+bool shouldIncludeStruct(String usr, String name) {
+  if (bindingsIndex.isSeenStruct(usr) || name == '') {
     return false;
   } else if (config.structDecl == null ||
       config.structDecl.shouldInclude(name)) {
@@ -18,8 +18,8 @@ bool shouldIncludeStruct(String name) {
   }
 }
 
-bool shouldIncludeFunc(String name) {
-  if (bindingsIndex.isSeenFunc(name) || name == '') {
+bool shouldIncludeFunc(String usr, String name) {
+  if (bindingsIndex.isSeenFunc(usr) || name == '') {
     return false;
   } else if (config.functionDecl == null ||
       config.functionDecl.shouldInclude(name)) {
@@ -29,8 +29,8 @@ bool shouldIncludeFunc(String name) {
   }
 }
 
-bool shouldIncludeEnumClass(String name) {
-  if (bindingsIndex.isSeenEnumClass(name) || name == '') {
+bool shouldIncludeEnumClass(String usr, String name) {
+  if (bindingsIndex.isSeenEnumClass(usr) || name == '') {
     return false;
   } else if (config.enumClassDecl == null ||
       config.enumClassDecl.shouldInclude(name)) {
@@ -40,8 +40,8 @@ bool shouldIncludeEnumClass(String name) {
   }
 }
 
-bool shouldIncludeMacro(String name) {
-  if (bindingsIndex.isSeenMacro(name) || name == '') {
+bool shouldIncludeMacro(String usr, String name) {
+  if (bindingsIndex.isSeenMacro(usr) || name == '') {
     return false;
   } else if (config.macroDecl == null || config.macroDecl.shouldInclude(name)) {
     return true;

--- a/lib/src/header_parser/parser.dart
+++ b/lib/src/header_parser/parser.dart
@@ -82,7 +82,7 @@ List<Binding> parseToBindings() {
     cmdLen = config.compilerOpts.length;
   }
 
-  // Contains all bindings. A set is used so that we have no object duplicates.
+  // Contains all bindings. A set ensures we never have duplicates.
   final bindings = <Binding>{};
 
   // Log all headers for user.

--- a/lib/src/header_parser/parser.dart
+++ b/lib/src/header_parser/parser.dart
@@ -82,8 +82,8 @@ List<Binding> parseToBindings() {
     cmdLen = config.compilerOpts.length;
   }
 
-  // Contains all bindings.
-  final bindings = <Binding>[];
+  // Contains all bindings. A set is used so that we have no object duplicates.
+  final bindings = <Binding>{};
 
   // Log all headers for user.
   _logger.info('Input Headers: ${config.headers.entryPoints}');
@@ -130,5 +130,5 @@ List<Binding> parseToBindings() {
     clangCmdArgs.dispose(config.compilerOpts.length);
   }
   clang.clang_disposeIndex(index);
-  return bindings;
+  return bindings.toList();
 }

--- a/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -32,6 +32,7 @@ EnumClass parseEnumDeclaration(
   String name,
 }) {
   _stack.push(_ParsedEnum());
+  final enumUsr = cursor.usr();
   final enumName = name ?? cursor.spelling();
   if (enumName == '') {
     // Save this unnamed enum if it is anonymous (therefore not in a typedef).
@@ -42,15 +43,15 @@ EnumClass parseEnumDeclaration(
     } else {
       _logger.fine('Unnamed enum inside a typedef.');
     }
-  } else if (shouldIncludeEnumClass(enumName) &&
-      !bindingsIndex.isSeenEnumClass(enumName)) {
+  } else if (shouldIncludeEnumClass(enumUsr, enumName)) {
     _logger.fine('++++ Adding Enum: ${cursor.completeStringRepr()}');
     _stack.top.enumClass = EnumClass(
+      usr: enumUsr,
       dartDoc: getCursorDocComment(cursor),
       originalName: enumName,
       name: config.enumClassDecl.renameUsingConfig(enumName),
     );
-    bindingsIndex.addEnumClassToSeen(enumName, _stack.top.enumClass);
+    bindingsIndex.addEnumClassToSeen(enumUsr, _stack.top.enumClass);
     _addEnumConstant(cursor);
   }
 

--- a/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -56,11 +56,10 @@ EnumClass parseEnumDeclaration(
   }
   if (bindingsIndex.isSeenEnumClass(enumUsr)) {
     _stack.top.enumClass = bindingsIndex.getSeenEnumClass(enumUsr);
-  }
-  // If enum is seen, update it's name.
-  if (bindingsIndex.isSeenEnumClass(enumUsr)) {
-    final enumClass = bindingsIndex.getSeenEnumClass(enumUsr);
-    enumClass.name = config.enumClassDecl.renameUsingConfig(enumName);
+
+    // If enum is seen, update it's name.
+    _stack.top.enumClass.name =
+        config.enumClassDecl.renameUsingConfig(enumName);
   }
 
   return _stack.pop().enumClass;

--- a/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -55,16 +55,22 @@ EnumClass parseEnumDeclaration(
     bindingsIndex.addEnumClassToSeen(enumUsr, _stack.top.enumClass);
     _addEnumConstant(cursor);
   }
+  if (bindingsIndex.isSeenEnumClass(enumUsr)) {
+    _stack.top.enumClass = bindingsIndex.getSeenEnumClass(enumUsr);
+  }
+  updateEnumClassPreferredName(enumUsr, enumName);
+  return _stack.pop().enumClass;
+}
 
-  // If enum is seen, update name if enumName is unseen.
+void updateEnumClassPreferredName(String enumUsr, String prefferedName) {
+// If enum is seen, update name if enumName is unseen.
   if (bindingsIndex.isSeenEnumClass(enumUsr)) {
     final holder = bindingsIndex.getSeenEnumClassBindingHolder(enumUsr);
-    if (!holder.isNameSeen(enumName)) {
+    if (!holder.isNameSeen(prefferedName)) {
       holder.binding.name = config.enumClassDecl
-          .renameUsingConfig(holder.getPrefferedName(enumName));
+          .renameUsingConfig(holder.getPrefferedName(prefferedName));
     }
   }
-  return _stack.pop().enumClass;
 }
 
 void _addEnumConstant(Pointer<clang_types.CXCursor> cursor) {

--- a/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -31,8 +31,9 @@ Func parseFunctionDeclaration(Pointer<clang_types.CXCursor> cursor) {
   _stack.top.structByValueParameter = false;
   _stack.top.unimplementedParameterType = false;
 
+  final funcUsr = cursor.usr();
   final funcName = cursor.spelling();
-  if (shouldIncludeFunc(funcName) && !bindingsIndex.isSeenFunc(funcName)) {
+  if (shouldIncludeFunc(funcUsr, funcName)) {
     _logger.fine('++++ Adding Function: ${cursor.completeStringRepr()}');
 
     final rt = _getFunctionReturnType(cursor);
@@ -65,12 +66,13 @@ Func parseFunctionDeclaration(Pointer<clang_types.CXCursor> cursor) {
         cursor,
         nesting.length + commentPrefix.length,
       ),
+      usr: funcUsr,
       name: config.functionDecl.renameUsingConfig(funcName),
       originalName: funcName,
       returnType: rt,
       parameters: parameters,
     );
-    bindingsIndex.addFuncToSeen(funcName, _stack.top.func);
+    bindingsIndex.addFuncToSeen(funcUsr, _stack.top.func);
   }
 
   return _stack.pop().func;

--- a/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -73,6 +73,8 @@ Func parseFunctionDeclaration(Pointer<clang_types.CXCursor> cursor) {
       parameters: parameters,
     );
     bindingsIndex.addFuncToSeen(funcUsr, _stack.top.func);
+  } else if (bindingsIndex.isSeenFunc(funcUsr)) {
+    _stack.top.func = bindingsIndex.getSeenFunc(funcUsr);
   }
 
   return _stack.pop().func;

--- a/lib/src/header_parser/sub_parsers/structdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/structdecl_parser.dart
@@ -38,22 +38,25 @@ Struc parseStructDeclaration(
   bool ignoreFilter = false,
 }) {
   _stack.push(_ParsedStruc());
+
+  final structUsr = cursor.usr();
   final structName = name ?? cursor.spelling();
 
   if (structName.isEmpty) {
     _logger.finest('unnamed structure or typedef structure declaration');
-  } else if ((ignoreFilter || shouldIncludeStruct(structName)) &&
-      (!bindingsIndex.isSeenStruct(structName))) {
+  } else if ((ignoreFilter || shouldIncludeStruct(structUsr, structName)) &&
+      (!bindingsIndex.isSeenStruct(structUsr))) {
     _logger.fine(
         '++++ Adding Structure: structName: ${structName}, ${cursor.completeStringRepr()}');
     _stack.top.struc = Struc(
+      usr: structUsr,
       originalName: structName,
       name: config.structDecl.renameUsingConfig(structName),
       dartDoc: getCursorDocComment(cursor),
     );
     // Adding to seen here to stop recursion if a struct has itself as a
     // member, members are updated later.
-    bindingsIndex.addStructToSeen(structName, _stack.top.struc);
+    bindingsIndex.addStructToSeen(structUsr, _stack.top.struc);
     _setStructMembers(cursor);
   }
 

--- a/lib/src/header_parser/sub_parsers/structdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/structdecl_parser.dart
@@ -40,8 +40,7 @@ Struc parseStructDeclaration(
   _stack.push(_ParsedStruc());
 
   final structUsr = cursor.usr();
-  final baseName = cursor.spelling();
-  final structName = name ?? baseName;
+  final structName = name ?? cursor.spelling();
 
   if (structName.isEmpty) {
     _logger.finest('unnamed structure or typedef structure declaration');
@@ -51,7 +50,7 @@ Struc parseStructDeclaration(
         '++++ Adding Structure: structName: ${structName}, ${cursor.completeStringRepr()}');
     _stack.top.struc = Struc(
       usr: structUsr,
-      originalName: baseName.isEmpty ? structName : baseName,
+      originalName: structName,
       name: config.structDecl.renameUsingConfig(structName),
       dartDoc: getCursorDocComment(cursor),
     );
@@ -64,21 +63,12 @@ Struc parseStructDeclaration(
   if (bindingsIndex.isSeenStruct(structUsr)) {
     _stack.top.struc = bindingsIndex.getSeenStruct(structUsr);
   }
-
-  updateStructPreferredName(structUsr, structName);
-
-  return _stack.pop().struc;
-}
-
-/// Updates the struct name according to preffered name [prefferedName].
-void updateStructPreferredName(String structUsr, String prefferedName) {
+  // If struct is seen, update it's name.
   if (bindingsIndex.isSeenStruct(structUsr)) {
-    final holder = bindingsIndex.getSeenStructBindingHolder(structUsr);
-    if (!holder.isNameSeen(prefferedName)) {
-      holder.binding.name = config.structDecl
-          .renameUsingConfig(holder.getPrefferedName(prefferedName));
-    }
+    final struc = bindingsIndex.getSeenStruct(structUsr);
+    struc.name = config.structDecl.renameUsingConfig(structName);
   }
+  return _stack.pop().struc;
 }
 
 void _setStructMembers(Pointer<clang_types.CXCursor> cursor) {

--- a/lib/src/header_parser/sub_parsers/structdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/structdecl_parser.dart
@@ -61,15 +61,24 @@ Struc parseStructDeclaration(
     _setStructMembers(cursor);
   }
 
-  // If struct is seen, update name if structName is unseen.
+  if (bindingsIndex.isSeenStruct(structUsr)) {
+    _stack.top.struc = bindingsIndex.getSeenStruct(structUsr);
+  }
+
+  updateStructPreferredName(structUsr, structName);
+
+  return _stack.pop().struc;
+}
+
+/// Updates the struct name according to preffered name [prefferedName].
+void updateStructPreferredName(String structUsr, String prefferedName) {
   if (bindingsIndex.isSeenStruct(structUsr)) {
     final holder = bindingsIndex.getSeenStructBindingHolder(structUsr);
-    if (!holder.isNameSeen(structName)) {
+    if (!holder.isNameSeen(prefferedName)) {
       holder.binding.name = config.structDecl
-          .renameUsingConfig(holder.getPrefferedName(structName));
+          .renameUsingConfig(holder.getPrefferedName(prefferedName));
     }
   }
-  return _stack.pop().struc;
 }
 
 void _setStructMembers(Pointer<clang_types.CXCursor> cursor) {

--- a/lib/src/header_parser/sub_parsers/structdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/structdecl_parser.dart
@@ -62,11 +62,9 @@ Struc parseStructDeclaration(
 
   if (bindingsIndex.isSeenStruct(structUsr)) {
     _stack.top.struc = bindingsIndex.getSeenStruct(structUsr);
-  }
-  // If struct is seen, update it's name.
-  if (bindingsIndex.isSeenStruct(structUsr)) {
-    final struc = bindingsIndex.getSeenStruct(structUsr);
-    struc.name = config.structDecl.renameUsingConfig(structName);
+
+    // If struct is seen, update it's name.
+    _stack.top.struc.name = config.structDecl.renameUsingConfig(structName);
   }
   return _stack.pop().struc;
 }

--- a/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
@@ -56,6 +56,7 @@ int _unnamedenumCursorVisitor(Pointer<clang_types.CXCursor> cursor,
 void _addUnNamedEnumConstant(Pointer<clang_types.CXCursor> cursor) {
   unnamedEnumConstants.add(
     Constant(
+      usr: cursor.usr(),
       originalName: cursor.spelling(),
       name: config.enumClassDecl.renameMemberUsingConfig(
         '', // Un-named enum constants have an empty declaration name.

--- a/lib/src/header_parser/translation_unit_parser.dart
+++ b/lib/src/header_parser/translation_unit_parser.dart
@@ -19,12 +19,12 @@ import 'utils.dart';
 
 var _logger = Logger('ffigen.header_parser.translation_unit_parser');
 
-List<Binding> _bindings;
+Set<Binding> _bindings;
 
 /// Parses the translation unit and returns the generated bindings.
-List<Binding> parseTranslationUnit(
+Set<Binding> parseTranslationUnit(
     Pointer<clang_types.CXCursor> translationUnitCursor) {
-  _bindings = [];
+  _bindings = {};
   final resultCode = clang.clang_visitChildren_wrap(
     translationUnitCursor,
     Pointer.fromFunction(
@@ -77,9 +77,10 @@ int _rootCursorVisitor(Pointer<clang_types.CXCursor> cursor,
   return clang_types.CXChildVisitResult.CXChildVisit_Continue;
 }
 
-/// Adds to binding if not null.
+/// Adds to binding if not null and unseen.
 void addToBindings(Binding b) {
   if (b != null) {
+    // This is a set, and hence will not have duplicates.
     _bindings.add(b);
   }
 }

--- a/lib/src/header_parser/translation_unit_parser.dart
+++ b/lib/src/header_parser/translation_unit_parser.dart
@@ -77,7 +77,7 @@ int _rootCursorVisitor(Pointer<clang_types.CXCursor> cursor,
   return clang_types.CXChildVisitResult.CXChildVisit_Continue;
 }
 
-/// Adds to binding if not null and unseen.
+/// Adds to binding if unseen and not null.
 void addToBindings(Binding b) {
   if (b != null) {
     // This is a set, and hence will not have duplicates.

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -96,6 +96,7 @@ Type _extractfromRecord(Pointer<clang_types.CXType> cxtype) {
   switch (clang.clang_getCursorKind_wrap(cursor)) {
     case clang_types.CXCursorKind.CXCursor_StructDecl:
       final cxtype = cursor.type();
+      final structUsr = cursor.usr();
       var structName = cursor.spelling();
       if (structName == '') {
         // Incase of anonymous structs defined inside a typedef.
@@ -106,16 +107,14 @@ Type _extractfromRecord(Pointer<clang_types.CXType> cxtype) {
 
       // Also add a struct binding, if its unseen.
       // TODO(23): Check if we should auto add struct.
-      if (bindingsIndex.isSeenStruct(structName)) {
-        type = Type.struct(bindingsIndex.getSeenStruct(structName));
+      if (bindingsIndex.isSeenStruct(structUsr)) {
+        type = Type.struct(bindingsIndex.getSeenStruct(structUsr));
       } else {
         final struc = parseStructDeclaration(cursor,
             name: fixedStructName, ignoreFilter: true);
         type = Type.struct(struc);
         // Add to bindings.
         addToBindings(struc);
-        // Add to seen.
-        bindingsIndex.addStructToSeen(structName, struc);
       }
 
       cxtype.dispose();

--- a/lib/src/header_parser/utils.dart
+++ b/lib/src/header_parser/utils.dart
@@ -334,43 +334,12 @@ class Macro {
   Macro(this.usr, this.originalName);
 }
 
-/// Holds a binding of type [T] with alternate names.
-///
-/// Certain bindings, like structs and enums, can have different names defined
-/// as typedefs. This holder is useful for working with these names.
-class BindingHolder<T extends Binding> {
-  /// Holds all names used for this Binding.
-  ///
-  /// Names will be put in the order -
-  /// 1. Struct name (if any, not available in case of anonymous structs)
-  /// 2. Typedef name 1, typedef name 2, typedef name 3...
-  final Set<String> _names;
-  final T binding;
-
-  BindingHolder(String name, this.binding) : _names = {name};
-
-  bool isNameSeen(String newName) => _names.contains(newName);
-
-  /// Gets the preffered names of all the names supplied till now.
-  ///
-  /// For choice between exactly 2, the 2nd name will be used(i.e typedef name)
-  /// else, the 1st name (struct name) is used.
-  String getPrefferedName(String newName) {
-    _names.add(newName);
-    if (_names.length == 2) {
-      return _names.last;
-    } else {
-      return _names.first;
-    }
-  }
-}
-
 /// Tracks if a binding is 'seen' or not.
 class BindingsIndex {
   // Tracks if bindings are already seen, Map key is USR obtained from libclang.
-  final Map<String, BindingHolder<Struc>> _structs = {};
+  final Map<String, Struc> _structs = {};
   final Map<String, Func> _functions = {};
-  final Map<String, BindingHolder<EnumClass>> _enumClass = {};
+  final Map<String, EnumClass> _enumClass = {};
   final Map<String, String> _macros = {};
   // Stores only named typedefC used in NativeFunc.
   final Map<String, Typedef> _functionTypedefs = {};
@@ -380,14 +349,10 @@ class BindingsIndex {
   }
 
   void addStructToSeen(String usr, Struc struc) {
-    _structs[usr] = BindingHolder<Struc>(struc.originalName, struc);
+    _structs[usr] = struc;
   }
 
   Struc getSeenStruct(String usr) {
-    return _structs[usr].binding;
-  }
-
-  BindingHolder<Struc> getSeenStructBindingHolder(String usr) {
     return _structs[usr];
   }
 
@@ -408,14 +373,10 @@ class BindingsIndex {
   }
 
   void addEnumClassToSeen(String usr, EnumClass enumClass) {
-    _enumClass[usr] = BindingHolder<EnumClass>(enumClass.name, enumClass);
+    _enumClass[usr] = enumClass;
   }
 
   EnumClass getSeenEnumClass(String usr) {
-    return _enumClass[usr].binding;
-  }
-
-  BindingHolder<EnumClass> getSeenEnumClassBindingHolder(String usr) {
     return _enumClass[usr];
   }
 

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -7,7 +7,7 @@ import 'package:ffigen/src/header_parser/clang_bindings/clang_bindings.dart'
     as clang;
 
 // This version must be updated whenever we update the libclang wrapper.
-const dylibVersion = 'v2';
+const dylibVersion = 'v3';
 
 /// Name of the dynamic library file according to current platform.
 String get dylibFileName {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 0.2.1+1
+version: 0.2.2
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C/C++ header files.
 

--- a/test/header_parser_tests/typedef.h
+++ b/test/header_parser_tests/typedef.h
@@ -11,3 +11,43 @@ struct Struct1
 };
 
 extern NamedFunctionProto func1(NamedFunctionProto named, void (*unnamed)(int));
+
+typedef struct
+{
+
+} AnonymousStructInTypedef;
+// These typerefs do not affect the name of AnonymousStructInTypedef.
+typedef AnonymousStructInTypedef Typeref1;
+typedef AnonymousStructInTypedef Typeref2;
+
+// Name from global namespace is used.
+typedef struct _NamedStructInTypedef
+{
+
+} NamedStructInTypedef;
+
+// Both these names must be exlucded or this struct will be generated.
+typedef struct _ExcludedStruct
+{
+
+} ExcludedStruct;
+typedef ExcludedStruct NTyperef1;
+
+// Because `struct _ExcludedStruct` is excluded, the type name used
+// in this function (the first function) will be used.
+// Therefore, _ExcludedStruct will be generated as NTyperef1.
+void func2(NTyperef1 *);
+
+typedef enum
+{
+
+} AnonymousEnumInTypedef;
+// These typerefs do not affect the name of AnonymousEnumInTypedef.
+typedef AnonymousEnumInTypedef Typeref1;
+typedef AnonymousEnumInTypedef Typeref2;
+
+// Name from global namespace is used.
+typedef enum _NamedEnumInTypedef
+{
+
+} NamedEnumInTypedef;

--- a/test/header_parser_tests/typedef_test.dart
+++ b/test/header_parser_tests/typedef_test.dart
@@ -27,6 +27,10 @@ ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
     - 'test/header_parser_tests/typedef.h'
+${strings.structs}:
+  ${strings.exclude}:
+    - ExcludedStruct
+    - _ExcludedStruct
         ''') as yaml.YamlMap),
       );
     });
@@ -43,6 +47,8 @@ Library expectedLibrary() {
     typedefType: TypedefType.C,
     returnType: Type.nativeType(SupportedNativeType.Void),
   );
+
+  final excludedNtyperef = Struc(name: 'NTyperef1');
   return Library(
     name: 'Bindings',
     bindings: [
@@ -81,6 +87,18 @@ Library expectedLibrary() {
         ],
         returnType: Type.pointer(Type.nativeFunc(namedTypedef)),
       ),
+      Struc(name: 'AnonymousStructInTypedef'),
+      Struc(name: 'NamedStructInTypedef'),
+      excludedNtyperef,
+      Func(
+        name: 'func2',
+        returnType: Type.nativeType(SupportedNativeType.Void),
+        parameters: [
+          Parameter(type: Type.pointer(Type.struct(excludedNtyperef)))
+        ],
+      ),
+      EnumClass(name: 'AnonymousEnumInTypedef'),
+      EnumClass(name: 'NamedEnumInTypedef'),
     ],
   );
 }

--- a/test/test_coverage.dart
+++ b/test/test_coverage.dart
@@ -21,6 +21,8 @@ import 'header_parser_tests/macros_test.dart'
     as header_parser_tests_macros_test;
 import 'header_parser_tests/nested_parsing_test.dart'
     as header_parser_tests_nested_parsing_test;
+import 'header_parser_tests/typedef_test.dart'
+    as header_parser_tests_typedef_test;
 import 'header_parser_tests/unnamed_enums_test.dart'
     as header_parser_tests_unnamed_enums_test;
 import 'large_integration_tests/large_test.dart'
@@ -39,6 +41,7 @@ void main() {
   header_parser_tests_macros_test.main();
   header_parser_tests_function_n_struct_test.main();
   header_parser_tests_nested_parsing_test.main();
+  header_parser_tests_typedef_test.main();
   header_parser_tests_unnamed_enums_test.main();
   native_test_native_test.main();
   rename_tests_rename_test.main();

--- a/tool/libclang_config.yaml
+++ b/tool/libclang_config.yaml
@@ -99,3 +99,4 @@ functions:
     - clang_Cursor_Evaluate_wrap
     - clang_Cursor_isAnonymous_wrap
     - clang_Cursor_isAnonymousRecordDecl_wrap
+    - clang_getCursorUSR_wrap


### PR DESCRIPTION
- Added `getCursorUSR_wrap` to `wrapper.c`, updated wrapper version to `v3`,
- Updated code to use USR obtained via libclang to uniquely identify declarations. This prevents skipping of struct and typedefs with similar names (closes #79).
- Name from the global namespace is used (affects structs and enums as they can be inside a typedef) (closes #73).
- If declaration is excluded according to config the above rule isn't followed and the name used in the first function parsed is used.
- Added tests, updated `test_coverage.dart`.
### Example -
Suppose we have a `struct _S`(struct namespace) enclosed in `typedef S`(global namespace), some typerefs and a function using struct via a typeref.
```C
typedef struct _S{

} S; // S is in global namespace, _S is in struct namespace.

// These typerefs are not considered.
typedef S S1;
typedef S S2;
typedef S S3;

void func(S1*);
```
#### Ffigen follows the following rules
- If only `_S` or `S` is included according to config, that particular name is used.
- If both `_S` and `S` are included according to config, name in the global namespace, `S` is used.
- If both `_S` and `S are excluded according to config, the name used by the first function parsed (`S1` in the example) will be used.

