### PR TITLE
Remove members of structs with bit fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.3
+- Fixed parsing structs with bitfields, all members of structs with bit field members will now be removed. See [#84](https://github.com/dart-lang/ffigen/issues/84)
+
 # 0.2.2+1
 - Updated `package:meta` version to `^1.1.8` for compatibility with flutter sdk.
 

--- a/lib/src/clang_library/wrapper.c
+++ b/lib/src/clang_library/wrapper.c
@@ -363,4 +363,8 @@ CXString *clang_getCursorUSR_wrap(CXCursor *cursor)
     return ptrToCXString(clang_getCursorUSR(*cursor));
 }
 
+int clang_getFieldDeclBitWidth_wrap(CXCursor *cursor){
+    return clang_getFieldDeclBitWidth(*cursor);
+}
+
 // END ===== WRAPPER FUNCTIONS =====================

--- a/lib/src/clang_library/wrapper.def
+++ b/lib/src/clang_library/wrapper.def
@@ -359,3 +359,4 @@ clang_Cursor_Evaluate_wrap
 clang_Cursor_isAnonymous_wrap
 clang_Cursor_isAnonymousRecordDecl_wrap
 clang_getCursorUSR_wrap
+clang_getFieldDeclBitWidth_wrap

--- a/lib/src/header_parser/clang_bindings/clang_bindings.dart
+++ b/lib/src/header_parser/clang_bindings/clang_bindings.dart
@@ -791,6 +791,20 @@ class Clang {
   }
 
   _dart_clang_getCursorUSR_wrap _clang_getCursorUSR_wrap;
+
+  int clang_getFieldDeclBitWidth_wrap(
+    ffi.Pointer<CXCursor> cursor,
+  ) {
+    _clang_getFieldDeclBitWidth_wrap ??= _dylib.lookupFunction<
+            _c_clang_getFieldDeclBitWidth_wrap,
+            _dart_clang_getFieldDeclBitWidth_wrap>(
+        'clang_getFieldDeclBitWidth_wrap');
+    return _clang_getFieldDeclBitWidth_wrap(
+      cursor,
+    );
+  }
+
+  _dart_clang_getFieldDeclBitWidth_wrap _clang_getFieldDeclBitWidth_wrap;
 }
 
 /// A character string.
@@ -2660,5 +2674,13 @@ typedef _c_clang_getCursorUSR_wrap = ffi.Pointer<CXString> Function(
 );
 
 typedef _dart_clang_getCursorUSR_wrap = ffi.Pointer<CXString> Function(
+  ffi.Pointer<CXCursor> cursor,
+);
+
+typedef _c_clang_getFieldDeclBitWidth_wrap = ffi.Int32 Function(
+  ffi.Pointer<CXCursor> cursor,
+);
+
+typedef _dart_clang_getFieldDeclBitWidth_wrap = int Function(
   ffi.Pointer<CXCursor> cursor,
 );

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -7,7 +7,7 @@ import 'package:ffigen/src/header_parser/clang_bindings/clang_bindings.dart'
     as clang;
 
 // This version must be updated whenever we update the libclang wrapper.
-const dylibVersion = 'v3';
+const dylibVersion = 'v4';
 
 /// Name of the dynamic library file according to current platform.
 String get dylibFileName {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 0.2.2+1
+version: 0.2.3
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C/C++ header files.
 

--- a/test/header_parser_tests/function_n_struct.h
+++ b/test/header_parser_tests/function_n_struct.h
@@ -18,6 +18,13 @@ struct Struct3
     int b[]; // Flexible array member.
 };
 
+// All members should be removed, Bit fields are not supported.
+struct Struct4
+{
+    int a:3;
+    int :2; // Unnamed bit field.
+};
+
 void func1(struct Struct2 *s);
 
 // Incomplete array parameter will be treated as a pointer.

--- a/test/header_parser_tests/function_n_struct_test.dart
+++ b/test/header_parser_tests/function_n_struct_test.dart
@@ -46,6 +46,9 @@ ${strings.headers}:
     test('Struct3 flexible array member', () {
       expect((actual.getBinding('Struct3') as Struc).members.isEmpty, true);
     });
+    test('Struct4 bit field member', () {
+      expect((actual.getBinding('Struct4') as Struc).members.isEmpty, true);
+    });
   });
 }
 
@@ -81,6 +84,7 @@ Library expectedLibrary() {
           SupportedNativeType.Void,
         ),
       ),
+      Struc(name: 'Struct4'),
     ],
   );
 }

--- a/tool/libclang_config.yaml
+++ b/tool/libclang_config.yaml
@@ -100,3 +100,4 @@ functions:
     - clang_Cursor_isAnonymous_wrap
     - clang_Cursor_isAnonymousRecordDecl_wrap
     - clang_getCursorUSR_wrap
+    - clang_getFieldDeclBitWidth_wrap


### PR DESCRIPTION
- Remove structs members for bit-field members
- Added tests, updated version, changelog.

This is needed until we generate workarounds for #84 