### PR TITLE
Added support for including/excluding/renaming unnamed_enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.3.0
-- Added support for including/excluding un-namedenums unsing key `unnamed_enums`.
+- Added support for including/excluding/renaming _un-named enums_ using key `unnamed_enums`.
 
 # 0.2.4+1
 - Minor changes to dylib creation error log.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.0
+- Added support for including/excluding un-namedenums unsing key `unnamed_enums`.
+
 # 0.2.4+1
 - Minor changes to dylib creation error log.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ headers:
     <td><pre lang="yaml">compiler-opts: '-I/usr/lib/llvm-9/include/'</pre></td>
   </tr>
   <tr>
-    <td>functions<br>structs<br>enums<br>macros</td>
+    <td>functions<br>structs<br>enums<br>unnamed-enums<br>macros</td>
     <td>Filters for declarations.<br><b>Default: all are included</b></td>
     <td><pre lang="yaml">
 functions:
@@ -180,13 +180,6 @@ comments:
     <b>Default: true</b>
     </td>
     <td><pre lang="yaml">dart-bool: true</pre></td>
-  </tr>
-  <tr>
-    <td>unnamed-enums</td>
-    <td>Should generate constants for anonymous unnamed enums.<br>
-    <b>Default: true</b>
-    </td>
-    <td><pre lang="yaml">unnamed-enums: true</pre></td>
   </tr>
    <tr>
     <td>preamble</td>
@@ -367,3 +360,23 @@ To convert these to/from `String`, you can use [package:ffi](https://pub.dev/pac
 Although `dart:ffi` doesn't have a NativeType for `bool`, they can be implemented as `Uint8`.
 Ffigen generates dart `bool` for function parameters and return type by default.
 To disable this, and use `int` instead, set `dart-bool: false` in configurations.
+
+### How are unnamed enums handled?
+
+Unnamed enums are handled separately, under the key `unnamed-enums`, and are generated as top level constants.
+
+Here's an example that shows how to include/exclude/rename unnamed enums
+```yaml
+unnamed-enums:
+  include:
+    - 'CX_.*'
+  exclude:
+    - '.*Flag'
+  rename:
+    'CXType_(.*)': '$1'
+```
+
+### Why are some struct declarations generated even after excluded them in config?
+
+This happens when an excluded struct is a dependency to some included declaration.
+(A dependency means a struct is being passed/returned by a function or is member of another struct in some way)

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -43,7 +43,11 @@ class Config {
   Declaration get enumClassDecl => _enumClassDecl;
   Declaration _enumClassDecl;
 
-  /// Declaration config for Enums.
+  /// Declaration config for Unnamed enum constants.
+  Declaration get unnamedEnumConstants => _unnamedEnumConstants;
+  Declaration _unnamedEnumConstants;
+
+  /// Declaration config for Macro constants.
   Declaration get macroDecl => _macroDecl;
   Declaration _macroDecl;
 
@@ -65,10 +69,6 @@ class Config {
   /// members removed.
   bool get arrayWorkaround => _arrayWorkaround;
   bool _arrayWorkaround;
-
-  /// If constants should be generated for unnamed enums.
-  bool get unnamedEnums => _unnamedEnums;
-  bool _unnamedEnums;
 
   /// If dart bool should be generated for C booleans.
   bool get dartBool => _dartBool;
@@ -193,6 +193,14 @@ class Config {
           _enumClassDecl = result as Declaration;
         },
       ),
+      strings.unnamedEnums: Specification<Declaration>(
+        requirement: Requirement.no,
+        validator: declarationConfigValidator,
+        extractor: declarationConfigExtractor,
+        defaultValue: () => Declaration(),
+        extractedResult: (dynamic result) =>
+            _unnamedEnumConstants = result as Declaration,
+      ),
       strings.macros: Specification<Declaration>(
         requirement: Requirement.no,
         validator: declarationConfigValidator,
@@ -244,13 +252,6 @@ class Config {
         extractor: booleanExtractor,
         defaultValue: () => false,
         extractedResult: (dynamic result) => _arrayWorkaround = result as bool,
-      ),
-      strings.unnamedEnums: Specification<bool>(
-        requirement: Requirement.no,
-        validator: booleanValidator,
-        extractor: booleanExtractor,
-        defaultValue: () => true,
-        extractedResult: (dynamic result) => _unnamedEnums = result as bool,
       ),
       strings.dartBool: Specification<bool>(
         requirement: Requirement.no,

--- a/lib/src/header_parser/includer.dart
+++ b/lib/src/header_parser/includer.dart
@@ -40,6 +40,17 @@ bool shouldIncludeEnumClass(String usr, String name) {
   }
 }
 
+bool shouldIncludeUnnamedEnumConstant(String usr, String name) {
+  if (bindingsIndex.isSeenUnnamedEnumConstant(usr) || name == '') {
+    return false;
+  } else if (config.unnamedEnumConstants == null ||
+      config.unnamedEnumConstants.shouldInclude(name)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 bool shouldIncludeMacro(String usr, String name) {
   if (bindingsIndex.isSeenMacro(usr) || name == '') {
     return false;

--- a/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -36,8 +36,7 @@ EnumClass parseEnumDeclaration(
   final enumName = name ?? cursor.spelling();
   if (enumName == '') {
     // Save this unnamed enum if it is anonymous (therefore not in a typedef).
-    if (config.unnamedEnums &&
-        clang.clang_Cursor_isAnonymous_wrap(cursor) != 0) {
+    if (clang.clang_Cursor_isAnonymous_wrap(cursor) != 0) {
       _logger.fine('Saving anonymous enum.');
       saveUnNamedEnum(cursor);
     } else {

--- a/lib/src/header_parser/utils.dart
+++ b/lib/src/header_parser/utils.dart
@@ -340,6 +340,7 @@ class BindingsIndex {
   final Map<String, Struc> _structs = {};
   final Map<String, Func> _functions = {};
   final Map<String, EnumClass> _enumClass = {};
+  final Map<String, Constant> _unnamedEnumConstants = {};
   final Map<String, String> _macros = {};
   // Stores only named typedefC used in NativeFunc.
   final Map<String, Typedef> _functionTypedefs = {};
@@ -378,6 +379,18 @@ class BindingsIndex {
 
   EnumClass getSeenEnumClass(String usr) {
     return _enumClass[usr];
+  }
+
+  bool isSeenUnnamedEnumConstant(String usr) {
+    return _unnamedEnumConstants.containsKey(usr);
+  }
+
+  void addUnnamedEnumConstantToSeen(String usr, Constant enumConstant) {
+    _unnamedEnumConstants[usr] = enumConstant;
+  }
+
+  Constant getSeenUnnamedEnumConstant(String usr) {
+    return _unnamedEnumConstants[usr];
   }
 
   bool isSeenMacro(String usr) {

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -40,6 +40,7 @@ const compilerOpts = 'compiler-opts';
 const functions = 'functions';
 const structs = 'structs';
 const enums = 'enums';
+const unnamedEnums = 'unnamed-enums';
 const macros = 'macros';
 
 // Sub-fields of Declarations.
@@ -82,7 +83,6 @@ const sort = 'sort';
 const useSupportedTypedefs = 'use-supported-typedefs';
 const warnWhenRemoving = 'warn-when-removing';
 const arrayWorkaround = 'array-workaround';
-const unnamedEnums = 'unnamed-enums';
 const dartBool = 'dart-bool';
 
 const comments = 'comments';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 0.2.4+1
+version: 0.3.0
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/unnamed_enums.h
+++ b/test/header_parser_tests/unnamed_enums.h
@@ -1,7 +1,7 @@
 // Only this should be parsed.
 enum{
     A=1,
-    B=2,
+    B=2, // This will be excluded by config.
     C=3
 };
 

--- a/test/header_parser_tests/unnamed_enums_test.dart
+++ b/test/header_parser_tests/unnamed_enums_test.dart
@@ -29,6 +29,9 @@ ${strings.headers}:
 ${strings.enums}:
   ${strings.exclude}:
     - Named
+${strings.unnamedEnums}:
+  ${strings.exclude}:
+    - B
         ''') as yaml.YamlMap),
       );
     });
@@ -39,7 +42,6 @@ ${strings.enums}:
 
     test('Parse unnamed enum Values', () {
       expect(actual.getBindingAsString('A'), expected.getBindingAsString('A'));
-      expect(actual.getBindingAsString('B'), expected.getBindingAsString('B'));
       expect(actual.getBindingAsString('C'), expected.getBindingAsString('C'));
     });
 
@@ -62,11 +64,6 @@ Library expectedLibrary() {
         name: 'A',
         rawType: 'int',
         rawValue: '1',
-      ),
-      Constant(
-        name: 'B',
-        rawType: 'int',
-        rawValue: '2',
       ),
       Constant(
         name: 'C',

--- a/test/rename_tests/rename_test.dart
+++ b/test/rename_tests/rename_test.dart
@@ -63,9 +63,11 @@ enums:
     'MemberRenameEnum4':
       '_(.*)': '\$1'
       'fullMatch': 'fullMatchSuccess'
-    '':
-      '_(.*)': '\$1'
-      'unnamedFullMatch': 'unnamedFullMatchSuccess'
+
+unnamed-enums:
+  ${strings.rename}:
+    '_(.*)': '\$1'
+    'unnamedFullMatch': 'unnamedFullMatchSuccess'
 
 macros:
   ${strings.rename}:


### PR DESCRIPTION
Closes #94  
- breaking change: `unnamed-enums` config key are now treated like any other declaration (function/struct/enum/macro)
- added FAQ to the readme, update version, changelog, update tests
