### PR TITLE
Bump version to 1.0.0, minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0
+- Bump version to 1.0.0.
+- Handle unimplememnted function pointers causing errors.
+- Log lexical/semantic issues in headers as SEVERE.
+
 # 0.3.0
 - Added support for including/excluding/renaming _un-named enums_ using key `unnamed_enums`.
 

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -143,7 +143,7 @@ Type _extractFromFunctionProto(
 
     if (pt.broadType == BroadType.Struct) {
       return Type.unimplemented('Struct by value in function parameter.');
-    } else if (pt.broadType == BroadType.Unimplemented) {
+    } else if (pt.getBaseType().broadType == BroadType.Unimplemented) {
       return Type.unimplemented('Function parameter has an unsupported type.');
     }
 

--- a/lib/src/header_parser/utils.dart
+++ b/lib/src/header_parser/utils.dart
@@ -34,7 +34,7 @@ void logTuDiagnostics(
     return;
   }
 
-  logger.warning('Header $header: Total errors/warnings: $total.');
+  logger.severe('Header $header: Total errors/warnings: $total.');
   for (var i = 0; i < total; i++) {
     final diag = clang.clang_getDiagnostic(tu, i);
     final cxstring = clang.clang_formatDiagnostic_wrap(
@@ -45,7 +45,7 @@ void logTuDiagnostics(
           clang_types
               .CXDiagnosticDisplayOptions.CXDiagnostic_DisplayCategoryName,
     );
-    logger.warning('    ' + cxstring.toStringAndDispose());
+    logger.severe('    ' + cxstring.toStringAndDispose());
     clang.clang_disposeDiagnostic(diag);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 0.3.0
+version: 1.0.0
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/native_func_typedef.h
+++ b/test/header_parser_tests/native_func_typedef.h
@@ -8,3 +8,6 @@ struct struc
 };
 
 void func(void (*unnamed1)(void (*unnamed2)()));
+
+// This will be removed because 'long double' is unsupported.
+void funcNestedUnimplemented(void (*unnamed1)(void (*unnamed2)(long double)));

--- a/test/header_parser_tests/native_func_typedef_test.dart
+++ b/test/header_parser_tests/native_func_typedef_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser.dart' as parser;
 import 'package:ffigen/src/config_provider.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart' as yaml;
 import 'package:ffigen/src/strings.dart' as strings;
@@ -17,7 +18,7 @@ Library actual;
 void main() {
   group('unnamed_enums_test', () {
     setUpAll(() {
-      logWarnings();
+      logWarnings(Level.SEVERE);
       actual = parser.parse(
         Config.fromYaml(yaml.loadYaml('''
 ${strings.name}: 'NativeLibrary'
@@ -28,6 +29,11 @@ ${strings.headers}:
     - 'test/header_parser_tests/native_func_typedef.h'
         ''') as yaml.YamlMap),
       );
+    });
+
+    test('Remove deeply nested unsupported types', () {
+      expect(() => actual.getBindingAsString('funcNestedUnimplemented'),
+          throwsA(TypeMatcher<NotFoundException>()));
     });
 
     test('Expected bindings', () {

--- a/test/header_parser_tests/typedef.h
+++ b/test/header_parser_tests/typedef.h
@@ -40,14 +40,11 @@ void func2(NTyperef1 *);
 
 typedef enum
 {
-
+    a=0
 } AnonymousEnumInTypedef;
-// These typerefs do not affect the name of AnonymousEnumInTypedef.
-typedef AnonymousEnumInTypedef Typeref1;
-typedef AnonymousEnumInTypedef Typeref2;
 
 // Name from global namespace is used.
 typedef enum _NamedEnumInTypedef
 {
-
+    b=0
 } NamedEnumInTypedef;

--- a/test/header_parser_tests/typedef_test.dart
+++ b/test/header_parser_tests/typedef_test.dart
@@ -97,8 +97,18 @@ Library expectedLibrary() {
           Parameter(type: Type.pointer(Type.struct(excludedNtyperef)))
         ],
       ),
-      EnumClass(name: 'AnonymousEnumInTypedef'),
-      EnumClass(name: 'NamedEnumInTypedef'),
+      EnumClass(
+        name: 'AnonymousEnumInTypedef',
+        enumConstants: [
+          EnumConstant(name: 'a', value: 0),
+        ],
+      ),
+      EnumClass(
+        name: 'NamedEnumInTypedef',
+        enumConstants: [
+          EnumConstant(name: 'b', value: 0),
+        ],
+      ),
     ],
   );
 }

--- a/test/large_integration_tests/large_test.dart
+++ b/test/large_integration_tests/large_test.dart
@@ -79,6 +79,8 @@ ${strings.name}: SQLite
 ${strings.description}: Bindings to SQLite.
 ${strings.output}: unused
 ${strings.arrayWorkaround}: true
+# Needed for stdarg.h in MacOS
+${strings.compilerOpts}: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/'
 ${strings.comments}:
   ${strings.style}: ${strings.any}
   ${strings.length}: ${strings.full}


### PR DESCRIPTION
- Bumped version to 1.0.0 for pub release, Update changelog.
- Fixed errors caused by deeply nested unsupported types in function pointers.
- Log lexical/semantic issues in headers as SEVERE (instead of WARNING) because these issues can potentially change what bindings are generated.
- Added/Updated/Fixed tests.