### PR TITLE
Handle function types in functions/typedefs as function pointers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.1
+- Fixed generation of `NativeFunction` parameters instead of `Pointer<NativeFunction>` in type signatures.
+
 # 1.0.0
 - Bump version to 1.0.0.
 - Handle unimplememnted function pointers causing errors.

--- a/lib/src/code_generator/func.dart
+++ b/lib/src/code_generator/func.dart
@@ -156,12 +156,17 @@ class Func extends LookUpBinding {
   }
 }
 
-/// Represents a Function's parameter.
+/// Represents a Parameter, used in [Func] and [Typedef].
 class Parameter {
   final String originalName;
   String name;
   final Type type;
 
-  Parameter({String originalName, this.name = '', @required this.type})
-      : originalName = originalName ?? name;
+  Parameter({String originalName, this.name = '', @required Type type})
+      : originalName = originalName ?? name,
+        // A type with broadtype [BroadType.NativeFunction] is wrapped with a
+        // pointer because this is a shorthand used in C for Pointer to function.
+        type = type.broadType == BroadType.NativeFunction
+            ? Type.pointer(type)
+            : type;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/functions.h
+++ b/test/header_parser_tests/functions.h
@@ -11,3 +11,8 @@ double func3(float, int8_t a, int64_t, int32_t b);
 
 // Tests with pointers to primitives.
 void *func4(int8_t **, double, int32_t ***);
+
+// Would be treated as `typedef void shortHand(void (*b)())`.
+typedef void shortHand(void(b)());
+// Would be treated as `void func5(shortHand *a, void (*b)())`.
+void func5(shortHand a, void(b)());

--- a/test/header_parser_tests/functions_test.dart
+++ b/test/header_parser_tests/functions_test.dart
@@ -53,6 +53,11 @@ ${strings.headers}:
       expect(actual.getBindingAsString('func4'),
           expected.getBindingAsString('func4'));
     });
+
+    test('func5', () {
+      expect(actual.getBindingAsString('func5'),
+          expected.getBindingAsString('func5'));
+    });
   });
 }
 
@@ -112,18 +117,63 @@ Library expectedLibrary() {
         ],
       ),
       Func(
-          name: 'func4',
-          returnType: Type.pointer(Type.nativeType(SupportedNativeType.Void)),
-          parameters: [
-            Parameter(
-                type: Type.pointer(
-                    Type.pointer(Type.nativeType(SupportedNativeType.Int8)))),
-            Parameter(type: Type.nativeType(SupportedNativeType.Double)),
-            Parameter(
-              type: Type.pointer(Type.pointer(
-                  Type.pointer(Type.nativeType(SupportedNativeType.Int32)))),
-            )
-          ]),
+        name: 'func4',
+        returnType: Type.pointer(Type.nativeType(SupportedNativeType.Void)),
+        parameters: [
+          Parameter(
+              type: Type.pointer(
+                  Type.pointer(Type.nativeType(SupportedNativeType.Int8)))),
+          Parameter(type: Type.nativeType(SupportedNativeType.Double)),
+          Parameter(
+            type: Type.pointer(Type.pointer(
+                Type.pointer(Type.nativeType(SupportedNativeType.Int32)))),
+          ),
+        ],
+      ),
+      Func(
+        name: 'func5',
+        returnType: Type.nativeType(SupportedNativeType.Void),
+        parameters: [
+          Parameter(
+            name: 'a',
+            type: Type.pointer(
+              Type.nativeFunc(
+                Typedef(
+                  name: 'shortHand',
+                  returnType: Type.nativeType(SupportedNativeType.Void),
+                  typedefType: TypedefType.C,
+                  parameters: [
+                    Parameter(
+                      type: Type.pointer(
+                        Type.nativeFunc(
+                          Typedef(
+                            name: 'b',
+                            returnType:
+                                Type.nativeType(SupportedNativeType.Void),
+                            typedefType: TypedefType.C,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Parameter(
+            name: 'b',
+            type: Type.pointer(
+              Type.nativeFunc(
+                Typedef(
+                  name: '_typedefC_2',
+                  returnType: Type.nativeType(SupportedNativeType.Void),
+                  typedefType: TypedefType.C,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     ],
   );
 }

--- a/test/header_parser_tests/functions_test.dart
+++ b/test/header_parser_tests/functions_test.dart
@@ -117,61 +117,44 @@ Library expectedLibrary() {
         ],
       ),
       Func(
-        name: 'func4',
-        returnType: Type.pointer(Type.nativeType(SupportedNativeType.Void)),
-        parameters: [
-          Parameter(
-              type: Type.pointer(
-                  Type.pointer(Type.nativeType(SupportedNativeType.Int8)))),
-          Parameter(type: Type.nativeType(SupportedNativeType.Double)),
-          Parameter(
-            type: Type.pointer(Type.pointer(
-                Type.pointer(Type.nativeType(SupportedNativeType.Int32)))),
-          ),
-        ],
-      ),
+          name: 'func4',
+          returnType: Type.pointer(Type.nativeType(SupportedNativeType.Void)),
+          parameters: [
+            Parameter(
+                type: Type.pointer(
+                    Type.pointer(Type.nativeType(SupportedNativeType.Int8)))),
+            Parameter(type: Type.nativeType(SupportedNativeType.Double)),
+            Parameter(
+              type: Type.pointer(Type.pointer(
+                  Type.pointer(Type.nativeType(SupportedNativeType.Int32)))),
+            ),
+          ]),
       Func(
         name: 'func5',
         returnType: Type.nativeType(SupportedNativeType.Void),
         parameters: [
           Parameter(
-            name: 'a',
-            type: Type.pointer(
-              Type.nativeFunc(
-                Typedef(
-                  name: 'shortHand',
-                  returnType: Type.nativeType(SupportedNativeType.Void),
-                  typedefType: TypedefType.C,
-                  parameters: [
-                    Parameter(
-                      type: Type.pointer(
-                        Type.nativeFunc(
-                          Typedef(
-                            name: 'b',
-                            returnType:
-                                Type.nativeType(SupportedNativeType.Void),
-                            typedefType: TypedefType.C,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
+              name: 'a',
+              type: Type.pointer(Type.nativeFunc(Typedef(
+                name: 'shortHand',
+                returnType: Type.nativeType(SupportedNativeType.Void),
+                typedefType: TypedefType.C,
+                parameters: [
+                  Parameter(
+                      type: Type.pointer(Type.nativeFunc(Typedef(
+                    name: 'b',
+                    returnType: Type.nativeType(SupportedNativeType.Void),
+                    typedefType: TypedefType.C,
+                  )))),
+                ],
+              )))),
           Parameter(
-            name: 'b',
-            type: Type.pointer(
-              Type.nativeFunc(
-                Typedef(
-                  name: '_typedefC_2',
-                  returnType: Type.nativeType(SupportedNativeType.Void),
-                  typedefType: TypedefType.C,
-                ),
-              ),
-            ),
-          ),
+              name: 'b',
+              type: Type.pointer(Type.nativeFunc(Typedef(
+                name: '_typedefC_2',
+                returnType: Type.nativeType(SupportedNativeType.Void),
+                typedefType: TypedefType.C,
+              )))),
         ],
       ),
     ],


### PR DESCRIPTION
Closes #102 
- Fixed generation of `NativeFunction` parameters instead of `Pointer<NativeFunction>` in type signatures.
- Added tests, updated version, and changelog
---
I couldn't find a way to make LibClang return us a pointer in these cases, So the simplest solution is to wrap the NativeFunc's in Parameters(used in Func and Typedefs) with a Pointer type.

This conversion is not needed for structs or function return types because using a `function` instead of `pointer to function` is a semantic error in C (not for structs in C++ though, see [this comment](https://github.com/dart-lang/ffigen/issues/102#issue-694334615)).