### PR TITLE
Updated tool to use dart format when sdk >=2.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - export PATH="/usr/lib/llvm-10/bin:$PATH"
 
 before_script:
-  - 'pub run ffigen:setup'
+  - 'dart pub run ffigen:setup'
   - cd test/native_test && dart build_test_dylib.dart && cd ../..
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.4
+- Updated code to use `dart format` instead of `dartfmt` for sdk version `>= 2.10.0`.
+
 # 1.0.3
 - Fixed errors due to extended ASCII and control characters in macro strings.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 
@@ -20,6 +20,7 @@ dependencies:
   glob: ^1.2.0
   path: ^1.7.0
   quiver: ^2.1.3
+  pub_semver: ^1.4.4
 
 dev_dependencies:
   pedantic: ^1.9.2


### PR DESCRIPTION
Related issue - #109 
- Calls `dart format` instead of `dartfmt` for formatting files for sdk versions `>=2.10.0`
- Updated travis.yml file to use `dart pub get`
- Updated changelog, version

Updating readmes(or comments or print statements) should probably be done after these smaller tools have been removed (or at least deprecated).