### PR TITLE
Handled proper conversion of macro doubles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.5
+- Fixed issues with generating macros of type `double.Infinity` and `double.NaN`.
+
 # 1.0.4
 - Updated code to use `dart format` instead of `dartfmt` for sdk version `>= 2.10.0`.
 

--- a/lib/src/header_parser/sub_parsers/macro_parser.dart
+++ b/lib/src/header_parser/sub_parsers/macro_parser.dart
@@ -128,7 +128,8 @@ int _macroVariablevisitor(Pointer<clang_types.CXCursor> cursor,
             originalName: savedMacros[macroName].originalName,
             name: macroName,
             rawType: 'double',
-            rawValue: clang.clang_EvalResult_getAsDouble(e).toString(),
+            rawValue:
+                _writeDoubleAsString(clang.clang_EvalResult_getAsDouble(e)),
           );
           break;
         case clang_types.CXEvalResultKind.CXEval_StrLiteral:
@@ -321,4 +322,16 @@ String _getWritableChar(int char, {bool utf8 = true}) {
 
   /// In all other cases, simply convert to string.
   return String.fromCharCode(char);
+}
+
+/// Converts a double to a string, handling cases like Infinity and NaN.
+String _writeDoubleAsString(double d) {
+  if (d.isInfinite) {
+    return d.isNegative ? 'double.negativeInfinity' : 'double.infinity';
+  }
+  if (d.isNaN) {
+    return 'double.nan';
+  }
+
+  return d.toString();
 }

--- a/lib/src/header_parser/sub_parsers/macro_parser.dart
+++ b/lib/src/header_parser/sub_parsers/macro_parser.dart
@@ -6,7 +6,7 @@ import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:ffigen/src/strings.dart';
+import 'package:ffigen/src/strings.dart' as strings;
 import 'package:path/path.dart' as p;
 import 'package:ffi/ffi.dart';
 import 'package:ffigen/src/code_generator.dart';
@@ -332,8 +332,10 @@ String _writeDoubleAsString(double d) {
   } else {
     // The only Non-Finite numbers are Infinity, NegativeInfinity and NaN.
     if (d.isInfinite) {
-      return d.isNegative ? doubleNegativeInfinity : doubleInfinity;
+      return d.isNegative
+          ? strings.doubleNegativeInfinity
+          : strings.doubleInfinity;
     }
-    return doubleNaN;
+    return strings.doubleNaN;
   }
 }

--- a/lib/src/header_parser/sub_parsers/macro_parser.dart
+++ b/lib/src/header_parser/sub_parsers/macro_parser.dart
@@ -6,6 +6,7 @@ import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:ffigen/src/strings.dart';
 import 'package:path/path.dart' as p;
 import 'package:ffi/ffi.dart';
 import 'package:ffigen/src/code_generator.dart';
@@ -326,12 +327,13 @@ String _getWritableChar(int char, {bool utf8 = true}) {
 
 /// Converts a double to a string, handling cases like Infinity and NaN.
 String _writeDoubleAsString(double d) {
-  if (d.isInfinite) {
-    return d.isNegative ? 'double.negativeInfinity' : 'double.infinity';
+  if (d.isFinite) {
+    return d.toString();
+  } else {
+    // The only Non-Finite numbers are Infinity, NegativeInfinity and NaN.
+    if (d.isInfinite) {
+      return d.isNegative ? doubleNegativeInfinity : doubleInfinity;
+    }
+    return doubleNaN;
   }
-  if (d.isNaN) {
-    return 'double.nan';
-  }
-
-  return d.toString();
 }

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -108,3 +108,8 @@ const preamble = 'preamble';
 const libclang_dylib_linux = 'libwrapped_clang.so';
 const libclang_dylib_macos = 'libwrapped_clang.dylib';
 const libclang_dylib_windows = 'wrapped_clang.dll';
+
+// Writen doubles
+const doubleInfinity = 'double.infinity';
+const doubleNegativeInfinity = 'double.negativeInfinity';
+const doubleNaN = 'double.nan';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/macros.h
+++ b/test/header_parser_tests/macros.h
@@ -1,3 +1,5 @@
+#include<math.h>
+
 #define TEST1 1.1
 #define TEST2 10
 #define TEST3 (TEST1 + TEST2)
@@ -23,3 +25,8 @@
 #define TEST11 "\x80"
 #define TEST12 "hello\n\t\r\v\b"
 #define TEST13 "test\\"
+
+// Infinity, NaN and Negative Infinity.
+#define TEST14 INFINITY
+#define TEST15 -INFINITY
+#define TEST16 NAN

--- a/test/header_parser_tests/macros_test.dart
+++ b/test/header_parser_tests/macros_test.dart
@@ -27,6 +27,8 @@ ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
     - 'test/header_parser_tests/macros.h'
+  ${strings.includeDirectives}:
+    - '**macros.h'
         ''') as yaml.YamlMap),
       );
     });
@@ -84,6 +86,18 @@ ${strings.headers}:
       expect(actual.getBindingAsString('TEST13'),
           expected.getBindingAsString('TEST13'));
     });
+    test('TEST14', () {
+      expect(actual.getBindingAsString('TEST14'),
+          expected.getBindingAsString('TEST14'));
+    });
+    test('TEST15', () {
+      expect(actual.getBindingAsString('TEST15'),
+          expected.getBindingAsString('TEST15'));
+    });
+    test('TEST16', () {
+      expect(actual.getBindingAsString('TEST16'),
+          expected.getBindingAsString('TEST16'));
+    });
   });
 }
 
@@ -104,6 +118,13 @@ Library expectedLibrary() {
       Constant(
           name: 'TEST12', rawType: 'String', rawValue: r"'hello\n\t\r\v\b'"),
       Constant(name: 'TEST13', rawType: 'String', rawValue: r"'test\\'"),
+      Constant(
+          name: 'TEST14', rawType: 'double', rawValue: strings.doubleInfinity),
+      Constant(
+          name: 'TEST15',
+          rawType: 'double',
+          rawValue: strings.doubleNegativeInfinity),
+      Constant(name: 'TEST16', rawType: 'double', rawValue: strings.doubleNaN),
     ],
   );
 }


### PR DESCRIPTION
Closes #112 
- Handled conversion of macro doubles properly (`double.Infinity`, `double.negativeInfinity` and `double.nan`).
- Updated version and changelog.
- Added tests. 