### PR TITLE
Fixed missing typedefs nested under return type of another typedef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-- dev
+- stable
 # Only building master means that we don't run two builds for each pull request.
 dart_task:
 - test: --platform vm
@@ -26,6 +26,6 @@ before_script:
 
 matrix:
   include:
-  - dart: dev
+  - dart: stable
     script: ./tool/travis.sh
     name: Collect and report coverage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.6
+- Fixed missing typedefs nested in another typedef's return types.
+
 # 1.0.5
 - Fixed issues with generating macros of type `double.Infinity` and `double.NaN`.
 

--- a/lib/src/code_generator/typedef.dart
+++ b/lib/src/code_generator/typedef.dart
@@ -47,6 +47,10 @@ class Typedef {
         dep.addAll(base.nativeFunc.getDependencies());
       }
     }
+    final returnTypeBase = returnType.getBaseType();
+    if (returnTypeBase.broadType == BroadType.NativeFunction) {
+      dep.addAll(returnTypeBase.nativeFunc.getDependencies());
+    }
     dep.add(this);
     return dep;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 1.0.5
+version: 1.0.6
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/native_func_typedef.h
+++ b/test/header_parser_tests/native_func_typedef.h
@@ -11,3 +11,7 @@ void func(void (*unnamed1)(void (*unnamed2)()));
 
 // This will be removed because 'long double' is unsupported.
 void funcNestedUnimplemented(void (*unnamed1)(void (*unnamed2)(long double)));
+
+typedef void (*insideReturnType)();
+typedef insideReturnType (*withTypedefReturnType)();
+void funcWithNativeFunc(withTypedefReturnType named);

--- a/test/header_parser_tests/native_func_typedef_test.dart
+++ b/test/header_parser_tests/native_func_typedef_test.dart
@@ -66,6 +66,16 @@ _func ??= _dylib.lookupFunction<_c_func,_dart_func>('func');
 }
 _dart_func _func;
 
+void funcWithNativeFunc(
+  ffi.Pointer<ffi.NativeFunction<withTypedefReturnType>> named,
+) {
+_funcWithNativeFunc ??= _dylib.lookupFunction<_c_funcWithNativeFunc,_dart_funcWithNativeFunc>('funcWithNativeFunc');
+  return _funcWithNativeFunc(
+    named,
+  );
+}
+_dart_funcWithNativeFunc _funcWithNativeFunc;
+
 }
 
 class struc extends ffi.Struct{
@@ -86,6 +96,20 @@ typedef _c_func = ffi.Void Function(
 
 typedef _dart_func = void Function(
   ffi.Pointer<ffi.NativeFunction<_typedefC_4>> unnamed1,
+);
+
+typedef _typedefC_5 = ffi.Void Function(
+);
+
+typedef withTypedefReturnType = ffi.Pointer<ffi.NativeFunction<_typedefC_5>> Function(
+);
+
+typedef _c_funcWithNativeFunc = ffi.Void Function(
+  ffi.Pointer<ffi.NativeFunction<withTypedefReturnType>> named,
+);
+
+typedef _dart_funcWithNativeFunc = void Function(
+  ffi.Pointer<ffi.NativeFunction<withTypedefReturnType>> named,
 );
 
 typedef _typedefC_1 = ffi.Void Function(


### PR DESCRIPTION
closes #115 
- Fixed missing typedefs nested under return type of another typedef
- Added test
- Updated changelog and version