### PR TITLE
Added support for Dart_Handle to be generated as Handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.0
+- Added support for `Dart_Handle` from `dart_api.h`.
+
 # 1.1.0
 - `typedef-map` can now be used to map a typedef name to a native type directly.
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,19 @@ dart-bool: true
 ```
   </td>
   </tr>
-   <tr>
+  <tr>
+    <td>use-dart-handle</td>
+    <td>Should map `Dart_Handle` to `Handle`.<br>
+    <b>Default: true</b>
+    </td>
+    <td>
+
+```yaml
+use-dart-handle: true
+```
+  </td>
+  </tr>
+  <tr>
     <td>preamble</td>
     <td>Raw header of the file, pasted as-it-is.</td>
     <td>

--- a/lib/src/code_generator/type.dart
+++ b/lib/src/code_generator/type.dart
@@ -39,6 +39,9 @@ enum BroadType {
   Struct,
   NativeFunction,
 
+  /// Represents a Dart_Handle.
+  Handle,
+
   /// Stores its element type in NativeType as only those are supported.
   ConstantArray,
   IncompleteArray,
@@ -130,6 +133,9 @@ class Type {
     return Type._(
         broadType: BroadType.Unimplemented, unimplementedReason: reason);
   }
+  factory Type.handle() {
+    return Type._(broadType: BroadType.Handle);
+  }
 
   /// Get base type for any type.
   ///
@@ -176,6 +182,8 @@ class Type {
         return '${w.ffiLibraryPrefix}.Pointer<${child.getCType(w)}>';
       case BroadType.Boolean: // Booleans are treated as uint8.
         return '${w.ffiLibraryPrefix}.${_primitives[SupportedNativeType.Uint8].c}';
+      case BroadType.Handle:
+        return '${w.ffiLibraryPrefix}.Handle';
       default:
         throw Exception('cType unknown');
     }
@@ -199,6 +207,8 @@ class Type {
         return '${w.ffiLibraryPrefix}.Pointer<${child.getCType(w)}>';
       case BroadType.Boolean: // Booleans are treated as uint8.
         return _primitives[SupportedNativeType.Uint8].dart;
+      case BroadType.Handle:
+        return 'Object';
       default:
         throw Exception('dart type unknown for ${broadType.toString()}');
     }

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -92,7 +92,7 @@ class Config {
   String _preamble;
   Config._();
 
-  /// If typedef of supported types(int8_t) should be directly used.
+  /// If `Dart_Handle` should be mapped with Handle/Object.
   bool get useDartHandle => _useDartHandle;
   bool _useDartHandle;
 

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -92,6 +92,10 @@ class Config {
   String _preamble;
   Config._();
 
+  /// If typedef of supported types(int8_t) should be directly used.
+  bool get useDartHandle => _useDartHandle;
+  bool _useDartHandle;
+
   /// Create config from Yaml map.
   factory Config.fromYaml(YamlMap map) {
     final configspecs = Config._();
@@ -292,6 +296,13 @@ class Config {
         validator: nonEmptyStringValidator,
         extractor: stringExtractor,
         extractedResult: (dynamic result) => _preamble = result as String,
+      ),
+      strings.useDartHandle: Specification<bool>(
+        requirement: Requirement.no,
+        validator: booleanValidator,
+        extractor: booleanExtractor,
+        defaultValue: () => true,
+        extractedResult: (dynamic result) => _useDartHandle = result as bool,
       ),
     };
   }

--- a/lib/src/header_parser/sub_parsers/structdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/structdecl_parser.dart
@@ -22,6 +22,7 @@ class _ParsedStruc {
   bool flexibleArrayMember = false;
   bool arrayMember = false;
   bool bitFieldMember = false;
+  bool dartHandleMember = false;
   _ParsedStruc();
 }
 
@@ -115,6 +116,12 @@ void _setStructMembers(Pointer<clang_types.CXCursor> cursor) {
     _logger.warning(
         'Removed All Struct Members from ${_stack.top.struc.name}(${_stack.top.struc.originalName}), Bit Field members not supported.');
     return _stack.top.struc.members.clear();
+  } else if (_stack.top.dartHandleMember) {
+    _logger.fine(
+        '---- Removed Struct members, reason: Dart_Handle member. ${cursor.completeStringRepr()}');
+    _logger.warning(
+        'Removed All Struct Members from ${_stack.top.struc.name}(${_stack.top.struc.originalName}), Dart_Handle member not supported.');
+    return _stack.top.struc.members.clear();
   }
 }
 
@@ -146,6 +153,8 @@ int _structMembersVisitor(Pointer<clang_types.CXCursor> cursor,
       } else if (clang.clang_getFieldDeclBitWidth_wrap(cursor) != -1) {
         // TODO(84): Struct with bitfields are not suppoorted.
         _stack.top.bitFieldMember = true;
+      } else if (mt.broadType == BroadType.Handle) {
+        _stack.top.dartHandleMember = true;
       }
 
       if (mt.getBaseType().broadType == BroadType.Unimplemented) {

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -6,6 +6,7 @@
 import 'dart:ffi';
 
 import 'package:ffigen/src/code_generator.dart';
+import 'package:ffigen/src/strings.dart' as strings;
 import 'package:logging/logging.dart';
 
 import '../clang_bindings/clang_bindings.dart' as clang_types;
@@ -28,6 +29,13 @@ Type getCodeGenType(Pointer<clang_types.CXType> cxtype, {String parentName}) {
       final pt = clang.clang_getPointeeType_wrap(cxtype);
       final s = getCodeGenType(pt, parentName: parentName);
       pt.dispose();
+
+      // Handle Pointer to Dart_Handle as Handle.
+      if (config.useDartHandle &&
+          s.broadType == BroadType.Struct &&
+          s.struc.usr == strings.dartHandleUsr) {
+        return Type.handle();
+      }
       return Type.pointer(s);
     case clang_types.CXTypeKind.CXType_Typedef:
       final spelling = cxtype.spelling();
@@ -116,8 +124,11 @@ Type _extractfromRecord(Pointer<clang_types.CXType> cxtype, String parentName) {
         final struc = parseStructDeclaration(cursor,
             name: structName, ignoreFilter: true);
         type = Type.struct(struc);
-        // Add to bindings.
-        addToBindings(struc);
+
+        // Add to bindings if it's not DartHandle.
+        if (!(config.useDartHandle && structUsr == strings.dartHandleUsr)) {
+          addToBindings(struc);
+        }
       }
 
       cxtype.dispose();

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -30,7 +30,7 @@ Type getCodeGenType(Pointer<clang_types.CXType> cxtype, {String parentName}) {
       final s = getCodeGenType(pt, parentName: parentName);
       pt.dispose();
 
-      // Handle Pointer to Dart_Handle as Handle.
+      // Replace Pointer<_Dart_Handle> with Handle.
       if (config.useDartHandle &&
           s.broadType == BroadType.Struct &&
           s.struc.usr == strings.dartHandleUsr) {
@@ -125,7 +125,7 @@ Type _extractfromRecord(Pointer<clang_types.CXType> cxtype, String parentName) {
             name: structName, ignoreFilter: true);
         type = Type.struct(struc);
 
-        // Add to bindings if it's not DartHandle.
+        // Add to bindings if it's not Dart_Handle.
         if (!(config.useDartHandle && structUsr == strings.dartHandleUsr)) {
           addToBindings(struc);
         }

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -101,19 +101,20 @@ const useSupportedTypedefs = 'use-supported-typedefs';
 const warnWhenRemoving = 'warn-when-removing';
 const arrayWorkaround = 'array-workaround';
 const dartBool = 'dart-bool';
+const useDartHandle = 'use-dart-handle';
 
 const comments = 'comments';
-// Sub-fields of comments
+// Sub-fields of comments.
 const style = 'style';
 const length = 'length';
 
-// Sub-fields of style
+// Sub-fields of style.
 const doxygen = 'doxygen';
 const any = 'any';
-// Sub-fields of length
+// Sub-fields of length.
 const brief = 'brief';
 const full = 'full';
-// Cmd line comment option
+// Cmd line comment option.
 const fparseAllComments = '-fparse-all-comments';
 
 // Library input.
@@ -126,7 +127,10 @@ const libclang_dylib_linux = 'libwrapped_clang.so';
 const libclang_dylib_macos = 'libwrapped_clang.dylib';
 const libclang_dylib_windows = 'wrapped_clang.dll';
 
-// Writen doubles
+// Writen doubles.
 const doubleInfinity = 'double.infinity';
 const doubleNegativeInfinity = 'double.negativeInfinity';
 const doubleNaN = 'double.nan';
+
+/// USR for struct `_Dart_Handle`.
+const dartHandleUsr = 'c:@S@_Dart_Handle';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/dart_handle.h
+++ b/test/header_parser_tests/dart_handle.h
@@ -8,6 +8,9 @@ void func1(Dart_Handle);
 Dart_Handle func2();
 Dart_Handle **func3(Dart_Handle *);
 
+typedef void (*typedef1)(Dart_Handle);
+void func4(typedef1);
+
 // Dart_Handle isn't supported directly, so all members are removed.
 struct struc1
 {

--- a/test/header_parser_tests/dart_handle.h
+++ b/test/header_parser_tests/dart_handle.h
@@ -1,0 +1,9 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include <dart_api.h>
+
+void func1(Dart_Handle);
+Dart_Handle func2();
+Dart_Handle **func3(Dart_Handle *);

--- a/test/header_parser_tests/dart_handle.h
+++ b/test/header_parser_tests/dart_handle.h
@@ -7,3 +7,16 @@
 void func1(Dart_Handle);
 Dart_Handle func2();
 Dart_Handle **func3(Dart_Handle *);
+
+// Dart_Handle isn't supported directly, so all members are removed.
+struct struc1
+{
+    Dart_Handle h;
+    int a;
+};
+
+// Pointer<Handle> works.
+struct struc2
+{
+    Dart_Handle *h;
+};

--- a/test/header_parser_tests/dart_handle_test.dart
+++ b/test/header_parser_tests/dart_handle_test.dart
@@ -51,6 +51,14 @@ ${strings.headers}:
       expect(actual.getBindingAsString('func3'),
           expected.getBindingAsString('func3'));
     });
+    test('struc1', () {
+      expect(actual.getBindingAsString('struc1'),
+          expected.getBindingAsString('struc1'));
+    });
+    test('struc2', () {
+      expect(actual.getBindingAsString('struc2'),
+          expected.getBindingAsString('struc2'));
+    });
   });
 }
 
@@ -78,6 +86,14 @@ Library expectedLibrary() {
           Parameter(
             type: Type.pointer(Type.handle()),
           ),
+        ],
+      ),
+      // struc1 should have no members.
+      Struc(name: 'struc1'),
+      Struc(
+        name: 'struc2',
+        members: [
+          Member(name: 'h', type: Type.pointer(Type.handle())),
         ],
       ),
     ],

--- a/test/header_parser_tests/dart_handle_test.dart
+++ b/test/header_parser_tests/dart_handle_test.dart
@@ -51,6 +51,10 @@ ${strings.headers}:
       expect(actual.getBindingAsString('func3'),
           expected.getBindingAsString('func3'));
     });
+    test('func4', () {
+      expect(actual.getBindingAsString('func4'),
+          expected.getBindingAsString('func4'));
+    });
     test('struc1', () {
       expect(actual.getBindingAsString('struc1'),
           expected.getBindingAsString('struc1'));
@@ -63,6 +67,12 @@ ${strings.headers}:
 }
 
 Library expectedLibrary() {
+  final namedTypedef = Typedef(
+    name: 'typedef1',
+    typedefType: TypedefType.C,
+    returnType: Type.nativeType(SupportedNativeType.Void),
+    parameters: [Parameter(type: Type.handle())],
+  );
   return Library(
     name: 'NativeLibrary',
     bindings: [
@@ -85,6 +95,15 @@ Library expectedLibrary() {
         parameters: [
           Parameter(
             type: Type.pointer(Type.handle()),
+          ),
+        ],
+      ),
+      Func(
+        name: 'func4',
+        returnType: Type.nativeType(SupportedNativeType.Void),
+        parameters: [
+          Parameter(
+            type: Type.pointer(Type.nativeFunc(namedTypedef)),
           ),
         ],
       ),

--- a/test/header_parser_tests/dart_handle_test.dart
+++ b/test/header_parser_tests/dart_handle_test.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:cli_util/cli_util.dart';
+import 'package:path/path.dart' as path;
+import 'package:ffigen/src/code_generator.dart';
+import 'package:ffigen/src/header_parser.dart' as parser;
+import 'package:ffigen/src/config_provider.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart' as yaml;
+import 'package:ffigen/src/strings.dart' as strings;
+
+import '../test_utils.dart';
+
+Library actual, expected;
+
+void main() {
+  group('dart_handle_test', () {
+    setUpAll(() {
+      logWarnings();
+      expected = expectedLibrary();
+      actual = parser.parse(
+        Config.fromYaml(yaml.loadYaml('''
+${strings.name}: 'NativeLibrary'
+${strings.description}: 'Dart_Handle Test'
+${strings.output}: 'unused'
+${strings.compilerOpts}: '-I${path.join(getSdkPath(), "include")} -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/'
+
+${strings.headers}:
+  ${strings.entryPoints}:
+    - 'test/header_parser_tests/dart_handle.h'
+  ${strings.includeDirectives}:
+    - '**dart_handle.h'
+        ''') as yaml.YamlMap),
+      );
+    });
+    test('Total bindings count', () {
+      expect(actual.bindings.length, expected.bindings.length);
+    });
+
+    test('func1', () {
+      expect(actual.getBindingAsString('func1'),
+          expected.getBindingAsString('func1'));
+    });
+    test('func2', () {
+      expect(actual.getBindingAsString('func2'),
+          expected.getBindingAsString('func2'));
+    });
+    test('func3', () {
+      expect(actual.getBindingAsString('func3'),
+          expected.getBindingAsString('func3'));
+    });
+  });
+}
+
+Library expectedLibrary() {
+  return Library(
+    name: 'NativeLibrary',
+    bindings: [
+      Func(
+        name: 'func1',
+        returnType: Type.nativeType(
+          SupportedNativeType.Void,
+        ),
+        parameters: [
+          Parameter(type: Type.handle()),
+        ],
+      ),
+      Func(
+        name: 'func2',
+        returnType: Type.handle(),
+      ),
+      Func(
+        name: 'func3',
+        returnType: Type.pointer(Type.pointer(Type.handle())),
+        parameters: [
+          Parameter(
+            type: Type.pointer(Type.handle()),
+          ),
+        ],
+      ),
+    ],
+  );
+}

--- a/test/native_test/config.yaml
+++ b/test/native_test/config.yaml
@@ -18,4 +18,4 @@ headers:
 array-workaround: true
 
 # Needed for stdbool.h in MacOS
-compiler-opts: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/'
+compiler-opts: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/ -Wno-nullability-completeness'


### PR DESCRIPTION
Closes #120 
- Dart_Handle is now mapped directly to Handle/Object.
- Added config option `use-dart-handle` to enable(default) or disable generating Handles.
- Updated readme, version and changelog.

---

I am comparing the USR for the underlying struct to determine if it's `Dart_Handle`.
```dart
const dartHandleUsr = 'c:@S@_Dart_Handle';
```

This **can** be confused with a user-defined Struct named `_Dart_Handle`. So in case, the user has a struct called `_Dart_handle` they can disable Handle generation using `use-dart-handle: false`.

Also, I am hoping the name of the underlying struct (`_Dart_Handle` as defined in `dart_api.h`) won't change or this feature will break.
```c
typedef struct _Dart_Handle* Dart_Handle;
```

If a struct has `Dart_Handle`, all its members will be removed. However using `Dart_Handle*` will work and be generated as `Pointer<Handle>`.
```c
// Dart_Handle isn't supported directly, so all members are removed.
struct struc1
{
    Dart_Handle h;
    int a;
};

// Pointer<Handle> works.
struct struc2
{
    Dart_Handle *h;
};
```
### Sample I/O

```C
Dart_Handle func(Dart_Handle **a);
```

```dart
class NativeLibrary {
  /// Holds the Dynamic library.
  final ffi.DynamicLibrary _dylib;

  /// The symbols are looked up in [dynamicLibrary].
  NativeLibrary(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;

  Object func(
    ffi.Pointer<ffi.Pointer<ffi.Handle>> a,
  ) {
    _func ??= _dylib.lookupFunction<_c_func, _dart_func>('func');
    return _func(
      a,
    );
  }

  _dart_func _func;
}

typedef _c_func = ffi.Handle Function(
  ffi.Pointer<ffi.Pointer<ffi.Handle>> a,
);

typedef _dart_func = Object Function(
  ffi.Pointer<ffi.Pointer<ffi.Handle>> a,
);
```