### PR TITLE
Use Opaque to represent empty Structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.0-dev.5
+- Use `Opaque` for representing empty `Struct`s.
+
 # 2.0.0-dev.4
 - Add support for parsing and generating globals.
 

--- a/example/c_json/pubspec.yaml
+++ b/example/c_json/pubspec.yaml
@@ -5,7 +5,7 @@
 name: c_json_example
 
 environment:
-  sdk: '>=2.12.0-198.0.dev <3.0.0'
+  sdk: '>=2.12.0-230.0.dev <3.0.0'
 
 dependencies:
   ffi: ^0.2.0-nullsafety.1

--- a/example/libclang-example/generated_bindings.dart
+++ b/example/libclang-example/generated_bindings.dart
@@ -6250,9 +6250,9 @@ class CXStringSet extends ffi.Struct {
   external int Count;
 }
 
-class CXTargetInfoImpl extends ffi.Struct {}
+class CXTargetInfoImpl extends ffi.Opaque {}
 
-class CXTranslationUnitImpl extends ffi.Struct {}
+class CXTranslationUnitImpl extends ffi.Opaque {}
 
 /// Provides the contents of a file that has not yet been saved to disk.
 ///
@@ -6636,7 +6636,7 @@ class CXPlatformAvailability extends ffi.Struct {
   external CXString Message;
 }
 
-class CXCursorSetImpl extends ffi.Struct {}
+class CXCursorSetImpl extends ffi.Opaque {}
 
 /// Describes the kind of type
 abstract class CXTypeKind {

--- a/example/libclang-example/pubspec.yaml
+++ b/example/libclang-example/pubspec.yaml
@@ -5,7 +5,7 @@
 name: libclang_example
 
 environment:
-  sdk: '>=2.12.0-198.0.dev <3.0.0'
+  sdk: '>=2.12.0-230.0.dev <3.0.0'
 
 dev_dependencies:
   ffigen:

--- a/example/simple/pubspec.yaml
+++ b/example/simple/pubspec.yaml
@@ -5,7 +5,7 @@
 name: simple_example
 
 environment:
-  sdk: '>=2.12.0-198.0.dev <3.0.0'
+  sdk: '>=2.12.0-230.0.dev <3.0.0'
 
 dev_dependencies:
   ffigen:

--- a/lib/src/code_generator/global.dart
+++ b/lib/src/code_generator/global.dart
@@ -73,9 +73,6 @@ class Global extends LookUpBinding {
       }
     } else {
       s.write('$dartType get $globalVarName => $pointerName.value;\n\n');
-    }
-
-    if (type.broadType != BroadType.Struct) {
       s.write(
           'set $globalVarName($dartType value) => $pointerName.value = value;\n\n');
     }

--- a/lib/src/code_generator/global.dart
+++ b/lib/src/code_generator/global.dart
@@ -61,11 +61,20 @@ class Global extends LookUpBinding {
     final pointerName = w.wrapperLevelUniqueNamer.makeUnique('_$globalVarName');
     final dartType = type.getDartType(w);
     final cType = type.getCType(w);
-    final refOrValue = type.broadType == BroadType.Struct ? 'ref' : 'value';
 
     s.write(
-        "late final ${w.ffiLibraryPrefix}.Pointer<$dartType> $pointerName = ${w.dylibIdentifier}.lookup<$cType>('$originalName');\n\n");
-    s.write('$dartType get $globalVarName => $pointerName.$refOrValue;\n\n');
+        "late final ${w.ffiLibraryPrefix}.Pointer<$cType> $pointerName = ${w.dylibIdentifier}.lookup<$cType>('$originalName');\n\n");
+    if (type.broadType == BroadType.Struct) {
+      if (type.struc!.isOpaque) {
+        s.write(
+            '${w.ffiLibraryPrefix}.Pointer<$cType> get $globalVarName => $pointerName;\n\n');
+      } else {
+        s.write('$dartType get $globalVarName => $pointerName.ref;\n\n');
+      }
+    } else {
+      s.write('$dartType get $globalVarName => $pointerName.value;\n\n');
+    }
+
     if (type.broadType != BroadType.Struct) {
       s.write(
           'set $globalVarName($dartType value) => $pointerName.value = value;\n\n');

--- a/lib/src/code_generator/struc.dart
+++ b/lib/src/code_generator/struc.dart
@@ -42,6 +42,8 @@ class Struc extends NoLookUpBinding {
 
   List<Member> members;
 
+  bool get isOpaque => members.isEmpty;
+
   Struc({
     String? usr,
     String? originalName,
@@ -102,7 +104,7 @@ class Struc extends NoLookUpBinding {
 
     // Write class declaration.
     s.write(
-        'class $enclosingClassName extends ${w.ffiLibraryPrefix}.Struct{\n');
+        'class $enclosingClassName extends ${w.ffiLibraryPrefix}.${isOpaque ? 'Opaque' : 'Struct'}{\n');
     for (final m in members) {
       final memberName = localUniqueNamer.makeUnique(m.name);
       if (m.type.broadType == BroadType.ConstantArray) {

--- a/lib/src/header_parser/clang_bindings/clang_bindings.dart
+++ b/lib/src/header_parser/clang_bindings/clang_bindings.dart
@@ -920,7 +920,7 @@ class CXString extends ffi.Struct {
   external int private_flags;
 }
 
-class CXTranslationUnitImpl extends ffi.Struct {}
+class CXTranslationUnitImpl extends ffi.Opaque {}
 
 /// Provides the contents of a file that has not yet been saved to disk.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,12 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.0.0-dev.4
+version: 2.0.0-dev.5
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 
 environment:
-  sdk: '>=2.12.0-198.0.dev <3.0.0'
+  sdk: '>=2.12.0-230.0.dev <3.0.0'
 
 dependencies:
   ffi: ^0.2.0-nullsafety.1

--- a/test/code_generator_test.dart
+++ b/test/code_generator_test.dart
@@ -236,7 +236,7 @@ import 'dart:ffi' as ffi;
 
 /// Just a test struct
 /// heres another line
-class NoMember extends ffi.Struct{
+class NoMember extends ffi.Opaque{
 }
 
 class WithPrimitiveMember extends ffi.Struct{
@@ -388,6 +388,8 @@ typedef _dart_someFunc = ffi.Pointer<SomeStruc> Function(
       final struc_some = Struc(
         name: 'Some',
       );
+      final emptyGlobalStruc = Struc(name: 'EmptyStruct');
+
       final library = Library(
         name: 'Bindings',
         bindings: [
@@ -414,6 +416,8 @@ typedef _dart_someFunc = ffi.Pointer<SomeStruc> Function(
               ),
             ),
           ),
+          emptyGlobalStruc,
+          Global(name: 'globalStruct', type: Type.struct(emptyGlobalStruc)),
         ],
       );
 
@@ -436,7 +440,7 @@ final ffi.DynamicLibrary _dylib;
 /// The symbols are looked up in [dynamicLibrary].
 Bindings(ffi.DynamicLibrary dynamicLibrary): _dylib = dynamicLibrary;
 
-late final ffi.Pointer<int> _test1 = _dylib.lookup<ffi.Int32>('test1');
+late final ffi.Pointer<ffi.Int32> _test1 = _dylib.lookup<ffi.Int32>('test1');
 
 int get test1 => _test1.value;
 
@@ -454,9 +458,16 @@ ffi.Pointer<Some> get test5 => _test5.value;
 
 set test5(ffi.Pointer<Some> value) => _test5.value = value;
 
+late final ffi.Pointer<EmptyStruct> _globalStruct = _dylib.lookup<EmptyStruct>('globalStruct');
+
+ffi.Pointer<EmptyStruct> get globalStruct => _globalStruct;
+
 }
 
-class Some extends ffi.Struct{
+class Some extends ffi.Opaque{
+}
+
+class EmptyStruct extends ffi.Opaque{
 }
 
 ''');
@@ -708,7 +719,7 @@ default:
 }
 }
 }
-class ArrayHelperPrefixCollisionTest extends ffi.Struct{
+class ArrayHelperPrefixCollisionTest extends ffi.Opaque{
 }
 
 abstract class _c_Test {

--- a/test/header_parser_tests/globals.h
+++ b/test/header_parser_tests/globals.h
@@ -13,3 +13,9 @@ long double *pointerToLongDouble;
 
 // This should be ignored
 int GlobalIgnore;
+
+struct EmptyStruct
+{
+};
+
+struct EmptyStruct globalStruct;

--- a/test/header_parser_tests/globals_test.dart
+++ b/test/header_parser_tests/globals_test.dart
@@ -31,6 +31,8 @@ ${strings.headers}:
 ${strings.globals}:
   ${strings.exclude}:
     - GlobalIgnore
+# Needed for stdbool.h in MacOS
+${strings.compilerOpts}: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/ -Wno-nullability-completeness'
         ''') as yaml.YamlMap),
       );
     });
@@ -60,6 +62,7 @@ ${strings.globals}:
 }
 
 Library expectedLibrary() {
+  final globalStruc = Struc(name: 'EmptyStruct');
   return Library(
     name: 'Bindings',
     bindings: [
@@ -68,6 +71,8 @@ Library expectedLibrary() {
       Global(
           type: Type.pointer(Type.nativeType(SupportedNativeType.Int32)),
           name: 'aGlobalPointer'),
+      globalStruc,
+      Global(name: 'globalStruct', type: Type.struct(globalStruc)),
     ],
   );
 }

--- a/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -5045,13 +5045,13 @@ class CXStringSet extends ffi.Struct {
   external int Count;
 }
 
-class CXVirtualFileOverlayImpl extends ffi.Struct {}
+class CXVirtualFileOverlayImpl extends ffi.Opaque {}
 
-class CXModuleMapDescriptorImpl extends ffi.Struct {}
+class CXModuleMapDescriptorImpl extends ffi.Opaque {}
 
-class CXTargetInfoImpl extends ffi.Struct {}
+class CXTargetInfoImpl extends ffi.Opaque {}
 
-class CXTranslationUnitImpl extends ffi.Struct {}
+class CXTranslationUnitImpl extends ffi.Opaque {}
 
 /// Provides the contents of a file that has not yet been saved to disk.
 class CXUnsavedFile extends ffi.Struct {
@@ -6333,7 +6333,7 @@ abstract class CXTLSKind {
   static const int CXTLS_Static = 2;
 }
 
-class CXCursorSetImpl extends ffi.Struct {}
+class CXCursorSetImpl extends ffi.Opaque {}
 
 /// Describes the kind of type
 abstract class CXTypeKind {

--- a/test/large_integration_tests/_expected_sqlite_bindings.dart
+++ b/test/large_integration_tests/_expected_sqlite_bindings.dart
@@ -8984,9 +8984,9 @@ class SQLite {
   _dart_sqlite3_rtree_query_callback? _sqlite3_rtree_query_callback;
 }
 
-class sqlite3 extends ffi.Struct {}
+class sqlite3 extends ffi.Opaque {}
 
-class sqlite3_file extends ffi.Struct {}
+class sqlite3_file extends ffi.Opaque {}
 
 class sqlite3_io_methods extends ffi.Struct {
   @ffi.Int32()
@@ -9031,19 +9031,19 @@ class sqlite3_io_methods extends ffi.Struct {
   external ffi.Pointer<ffi.NativeFunction<_typedefC_19>> xUnfetch;
 }
 
-class sqlite3_mutex extends ffi.Struct {}
+class sqlite3_mutex extends ffi.Opaque {}
 
-class sqlite3_api_routines extends ffi.Struct {}
+class sqlite3_api_routines extends ffi.Opaque {}
 
-class sqlite3_vfs extends ffi.Struct {}
+class sqlite3_vfs extends ffi.Opaque {}
 
-class sqlite3_mem_methods extends ffi.Struct {}
+class sqlite3_mem_methods extends ffi.Opaque {}
 
-class sqlite3_stmt extends ffi.Struct {}
+class sqlite3_stmt extends ffi.Opaque {}
 
-class sqlite3_value extends ffi.Struct {}
+class sqlite3_value extends ffi.Opaque {}
 
-class sqlite3_context extends ffi.Struct {}
+class sqlite3_context extends ffi.Opaque {}
 
 /// CAPI3REF: Virtual Table Instance Object
 /// KEYWORDS: sqlite3_vtab
@@ -9061,7 +9061,7 @@ class sqlite3_context extends ffi.Struct {}
 /// prior to assigning a new string to zErrMsg.  ^After the error message
 /// is delivered up to the client application, the string will be automatically
 /// freed by sqlite3_free() and the zErrMsg field will be zeroed.
-class sqlite3_vtab extends ffi.Struct {}
+class sqlite3_vtab extends ffi.Opaque {}
 
 /// CAPI3REF: Virtual Table Indexing Information
 /// KEYWORDS: sqlite3_index_info
@@ -9163,7 +9163,7 @@ class sqlite3_vtab extends ffi.Struct {}
 /// It may therefore only be used if
 /// sqlite3_libversion_number() returns a value greater than or equal to
 /// 3009000.
-class sqlite3_index_info extends ffi.Struct {}
+class sqlite3_index_info extends ffi.Opaque {}
 
 /// CAPI3REF: Virtual Table Cursor Object
 /// KEYWORDS: sqlite3_vtab_cursor {virtual table cursor}
@@ -9180,7 +9180,7 @@ class sqlite3_index_info extends ffi.Struct {}
 ///
 /// This superclass exists in order to define fields of the cursor that
 /// are common to all implementations.
-class sqlite3_vtab_cursor extends ffi.Struct {}
+class sqlite3_vtab_cursor extends ffi.Opaque {}
 
 /// CAPI3REF: Virtual Table Object
 /// KEYWORDS: sqlite3_module {virtual table module}
@@ -9196,23 +9196,23 @@ class sqlite3_vtab_cursor extends ffi.Struct {}
 /// module or until the [database connection] closes.  The content
 /// of this structure must not change while it is registered with
 /// any database connection.
-class sqlite3_module extends ffi.Struct {}
+class sqlite3_module extends ffi.Opaque {}
 
-class sqlite3_blob extends ffi.Struct {}
+class sqlite3_blob extends ffi.Opaque {}
 
-class sqlite3_mutex_methods extends ffi.Struct {}
+class sqlite3_mutex_methods extends ffi.Opaque {}
 
-class sqlite3_str extends ffi.Struct {}
+class sqlite3_str extends ffi.Opaque {}
 
-class sqlite3_pcache extends ffi.Struct {}
+class sqlite3_pcache extends ffi.Opaque {}
 
-class sqlite3_pcache_page extends ffi.Struct {}
+class sqlite3_pcache_page extends ffi.Opaque {}
 
-class sqlite3_pcache_methods2 extends ffi.Struct {}
+class sqlite3_pcache_methods2 extends ffi.Opaque {}
 
-class sqlite3_pcache_methods extends ffi.Struct {}
+class sqlite3_pcache_methods extends ffi.Opaque {}
 
-class sqlite3_backup extends ffi.Struct {}
+class sqlite3_backup extends ffi.Opaque {}
 
 /// CAPI3REF: Database Snapshot
 /// KEYWORDS: {snapshot} {sqlite3_snapshot}
@@ -9610,7 +9610,7 @@ class ArrayHelper_sqlite3_snapshot_hidden_level0 {
 
 /// A pointer to a structure of the following type is passed as the first
 /// argument to callbacks registered using rtree_geometry_callback().
-class sqlite3_rtree_geometry extends ffi.Struct {}
+class sqlite3_rtree_geometry extends ffi.Opaque {}
 
 /// A pointer to a structure of the following type is passed as the
 /// argument to scored geometry callback registered using
@@ -9619,7 +9619,7 @@ class sqlite3_rtree_geometry extends ffi.Struct {}
 /// Note that the first 5 fields of this structure are identical to
 /// sqlite3_rtree_geometry.  This structure is a subclass of
 /// sqlite3_rtree_geometry.
-class sqlite3_rtree_query_info extends ffi.Struct {}
+class sqlite3_rtree_query_info extends ffi.Opaque {}
 
 /// EXTENSION API FUNCTIONS
 ///
@@ -9830,17 +9830,17 @@ class sqlite3_rtree_query_info extends ffi.Struct {}
 ///
 /// xPhraseNextColumn()
 /// See xPhraseFirstColumn above.
-class Fts5ExtensionApi extends ffi.Struct {}
+class Fts5ExtensionApi extends ffi.Opaque {}
 
-class Fts5Context extends ffi.Struct {}
+class Fts5Context extends ffi.Opaque {}
 
-class Fts5PhraseIter extends ffi.Struct {}
+class Fts5PhraseIter extends ffi.Opaque {}
 
-class Fts5Tokenizer extends ffi.Struct {}
+class Fts5Tokenizer extends ffi.Opaque {}
 
-class fts5_tokenizer extends ffi.Struct {}
+class fts5_tokenizer extends ffi.Opaque {}
 
-class fts5_api extends ffi.Struct {}
+class fts5_api extends ffi.Opaque {}
 
 const String SQLITE_VERSION = '3.32.3';
 


### PR DESCRIPTION
Closes #140 
- Use `Opaque` for representing empty `Struct`s.
- Updated tests, version, changelog
- Fixed Globals, updated Global to directly use `Pointer<EmptyStruct>` instead of `emptyStruct.ref` for getters of `Opaque` types.

---

@dcharkes All the empty structs will now be generated as `Opaque`, this also includes all those structs which we are unable to generate in dart:ffi, which had all their members removed. Is this the correct behavior? or should we handle those structs in some different way.