### PR TITLE
Skip inline functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.0-dev.6
+- Functions marked `inline` are now skipped.
+
 # 2.0.0-dev.5
 - Use `Opaque` for representing empty `Struct`s.
 

--- a/lib/src/header_parser/clang_bindings/clang_bindings.dart
+++ b/lib/src/header_parser/clang_bindings/clang_bindings.dart
@@ -510,6 +510,21 @@ class Clang {
 
   _dart_clang_Cursor_isMacroBuiltin? _clang_Cursor_isMacroBuiltin;
 
+  /// Determine whether a  CXCursor that is a function declaration, is an
+  /// inline declaration.
+  int clang_Cursor_isFunctionInlined(
+    CXCursor C,
+  ) {
+    return (_clang_Cursor_isFunctionInlined ??= _dylib.lookupFunction<
+            _c_clang_Cursor_isFunctionInlined,
+            _dart_clang_Cursor_isFunctionInlined>(
+        'clang_Cursor_isFunctionInlined'))(
+      C,
+    );
+  }
+
+  _dart_clang_Cursor_isFunctionInlined? _clang_Cursor_isFunctionInlined;
+
   /// For pointer types, returns the type of the pointee.
   CXType clang_getPointeeType(
     CXType T,
@@ -2560,6 +2575,14 @@ typedef _c_clang_Cursor_isMacroBuiltin = ffi.Uint32 Function(
 );
 
 typedef _dart_clang_Cursor_isMacroBuiltin = int Function(
+  CXCursor C,
+);
+
+typedef _c_clang_Cursor_isFunctionInlined = ffi.Uint32 Function(
+  CXCursor C,
+);
+
+typedef _dart_clang_Cursor_isFunctionInlined = int Function(
   CXCursor C,
 );
 

--- a/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -35,6 +35,16 @@ Func? parseFunctionDeclaration(clang_types.CXCursor cursor) {
     final rt = _getFunctionReturnType(cursor);
     final parameters = _getParameters(cursor, funcName);
 
+    if (clang.clang_Cursor_isFunctionInlined(cursor) != 0) {
+      _logger.fine(
+          '---- Removed Function, reason: inline function: ${cursor.completeStringRepr()}');
+      _logger.warning(
+          "Skipped Function '$funcName', inline functions are not supported.");
+      return _stack
+          .pop()
+          .func; // Returning null so that [addToBindings] function excludes this.
+    }
+
     if (rt.isIncompleteStruct || _stack.top.incompleteStructParameter) {
       _logger.fine(
           '---- Removed Function, reason: Incomplete struct pass/return by value: ${cursor.completeStringRepr()}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.0.0-dev.5
+version: 2.0.0-dev.6
 homepage: https://github.com/dart-lang/ffigen
 description: Experimental generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/functions.h
+++ b/test/header_parser_tests/functions.h
@@ -16,3 +16,6 @@ void *func4(int8_t **, double, int32_t ***);
 typedef void shortHand(void(b)());
 // Would be treated as `void func5(shortHand *a, void (*b)())`.
 void func5(shortHand a, void(b)());
+
+// Should be skipped as inline functions are not supported.
+static inline void inlineFunc();

--- a/test/header_parser_tests/functions_test.dart
+++ b/test/header_parser_tests/functions_test.dart
@@ -58,6 +58,11 @@ ${strings.headers}:
       expect(actual.getBindingAsString('func5'),
           expected.getBindingAsString('func5'));
     });
+
+    test('Skip inline functions', () {
+      expect(() => actual.getBindingAsString('inlineFunc'),
+          throwsA(TypeMatcher<NotFoundException>()));
+    });
   });
 }
 

--- a/tool/libclang_config.yaml
+++ b/tool/libclang_config.yaml
@@ -101,3 +101,4 @@ functions:
     - clang_Cursor_isAnonymousRecordDecl
     - clang_getCursorUSR
     - clang_getFieldDeclBitWidth
+    - clang_Cursor_isFunctionInlined


### PR DESCRIPTION
Closes #146 
- Inline functions are now skipped, with a warning.
- Added test, updated changelog and version.