### PR TITLE
Bump version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1
+- Switch to preview release of `package:quiver`.
+
 # 2.0.0
 - Upgraded all dependencies. `package:ffigen` now runs with sound null safety.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
 
 dependencies:
   ffi: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,18 +3,18 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   ffi: ^1.0.0
   yaml: ^3.0.0
   path: ^1.8.0
-  quiver: ^3.0.0-nullsafety.3
+  quiver: ^3.0.0
   args: ^2.0.0
   logging: ^1.0.0
   cli_util: ^0.3.0


### PR DESCRIPTION
- Updated `package:quiver`'s version 
---
@dcharkes 
Looking at `package:quiver`'s [pubspec.yaml](https://github.com/google/quiver-dart/blob/a837ed13026cdeec95d4d935f3fe95fd55556183/pubspec.yaml#L9) I have updated the sdk constraints to `sdk: '>=2.12.0-0 <3.0.0'`.
