### PR TITLE
Ignore name of typedef struct pointer declaration, recursively create directories for output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.3
+- Fixed issue where
+
 # 2.0.2
 - Fixed illegal use of `const` in name, crash due to unnamed inline structs and
 structs having `Opaque` members.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.0.3
-- Fixed issue where
+- Ignore typedef to struct pointer when possible.
+- Recursively create directories for output file.
 
 # 2.0.2
 - Fixed illegal use of `const` in name, crash due to unnamed inline structs and

--- a/lib/src/code_generator/library.dart
+++ b/lib/src/code_generator/library.dart
@@ -87,6 +87,7 @@ class Library {
   ///
   /// If format is true(default), 'dartfmt -w $PATH' will be called to format the generated file.
   void generateFile(File file, {bool format = true}) {
+    if (!file.existsSync()) file.createSync(recursive: true);
     file.writeAsStringSync(generate());
     if (format) {
       _dartFmt(file.path);

--- a/lib/src/header_parser/sub_parsers/typedefdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/typedefdecl_parser.dart
@@ -17,9 +17,25 @@ final _logger = Logger('ffigen.header_parser.typedefdecl_parser');
 
 /// Holds temporary information regarding a typedef referenced [Binding]
 /// while parsing.
+///
+/// Note:
+/// - Pointer to Typedefs structs are skipped if the struct is seen.
+/// - If there are multiple typedefs for a declaration (struct/enum), the last
+/// seen name is used.
+/// - Typerefs are completely ignored.
+///
+/// Libclang marks them as following -
+/// ```C
+/// typedef struct A{
+///   int a
+/// } B, *pB; // Typedef(s).
+///
+/// typedef A D; // Typeref.
+/// ```
 class _ParsedTypedef {
   Binding? binding;
   String? typedefName;
+  bool typedefToPointer = false;
   _ParsedTypedef();
 }
 
@@ -28,6 +44,12 @@ final _stack = Stack<_ParsedTypedef>();
 /// Parses a typedef declaration.
 Binding? parseTypedefDeclaration(clang_types.CXCursor cursor) {
   _stack.push(_ParsedTypedef());
+
+  /// Check if typedef declaration is to a pointer.
+  _stack.top.typedefToPointer =
+      (clang.clang_getTypedefDeclUnderlyingType(cursor).kind ==
+          clang_types.CXTypeKind.CXType_Pointer);
+
   // Name of typedef.
   _stack.top.typedefName = cursor.spelling();
   final resultCode = clang.clang_visitChildren(
@@ -54,8 +76,15 @@ int _typedefdeclarationCursorVisitor(clang_types.CXCursor cursor,
 
     switch (clang.clang_getCursorKind(cursor)) {
       case clang_types.CXCursorKind.CXCursor_StructDecl:
-        _stack.top.binding =
-            parseStructDeclaration(cursor, name: _stack.top.typedefName);
+        if (_stack.top.typedefToPointer &&
+            bindingsIndex.isSeenStruct(cursor.usr())) {
+          // Skip a typedef pointer if struct is seen.
+          _stack.top.binding = bindingsIndex.getSeenStruct(cursor.usr());
+        } else {
+          // This will update the name of struct if already seen.
+          _stack.top.binding =
+              parseStructDeclaration(cursor, name: _stack.top.typedefName);
+        }
         break;
       case clang_types.CXCursorKind.CXCursor_EnumDecl:
         _stack.top.binding =

--- a/lib/src/header_parser/sub_parsers/typedefdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/typedefdecl_parser.dart
@@ -18,7 +18,7 @@ final _logger = Logger('ffigen.header_parser.typedefdecl_parser');
 /// Holds temporary information regarding a typedef referenced [Binding]
 /// while parsing.
 ///
-/// Note:
+/// Notes:
 /// - Pointer to Typedefs structs are skipped if the struct is seen.
 /// - If there are multiple typedefs for a declaration (struct/enum), the last
 /// seen name is used.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.0.2
+version: 2.0.3
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/header_parser_tests/typedef.h
+++ b/test/header_parser_tests/typedef.h
@@ -40,13 +40,13 @@ void func2(NTyperef1 *);
 
 typedef enum
 {
-    a=0
+    a = 0
 } AnonymousEnumInTypedef;
 
 // Name from global namespace is used.
 typedef enum _NamedEnumInTypedef
 {
-    b=0
+    b = 0
 } NamedEnumInTypedef;
 
 // Should be treated as IntPtr when used.
@@ -54,3 +54,8 @@ typedef char specified_type_as_IntPtr;
 typedef specified_type_as_IntPtr nesting_a_specified_type;
 
 void func3(specified_type_as_IntPtr, nesting_a_specified_type b);
+
+// Struct3 is used. `pStruct2` and `pStruct3` are ignored.
+typedef struct
+{
+} Struct2, Struct3, *pStruct2, *pStruct3;

--- a/test/header_parser_tests/typedef_test.dart
+++ b/test/header_parser_tests/typedef_test.dart
@@ -122,6 +122,7 @@ Library expectedLibrary() {
           ),
         ],
       ),
+      Struc(name: 'Struct3'),
     ],
   );
 }


### PR DESCRIPTION
Closes #157, Closes #171
- Do not use the name of typedef to pointer for a struct (157)
- Recursively create folders for output (171)
- Update version and changelog.

---
### Note
For #157 -
Pointer to Typedefs are only ignored are If typedef declaration is directly parsed. So, if a user excludes the struct somehow (say a header file was skipped) the name is not ignored. 

E.g -
```C
typedef Struct {
} S, *pS; // Suppose this struct was excluded by the user in config.

void func(pS p); // But this function uses that struct.
```

In this case, the name of the generated struct will be `pS` (and not `S`), since the struct was not parsed directly (excluded by user but needed for the function).

For such cases, however, the user can always choose to `rename` the struct using config.