### PR TITLE
Support for Dynamic linking

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.12.0-259.9.beta] # TODO(127): Revert to stable.
+        sdk: [2.12.0]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0
         with:
-          sdk: 2.12.0-259.9.beta # TODO(127): Revert to stable.
+          sdk: 2.12.0
       - name: Install dependencies
         run: dart pub get
       - name: Install libclang-10-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.4
+- Support for dynamic linking, use `NativeLibrary.fromLookup()` constructor.
+
 # 2.0.3
 - Ignore typedef to struct pointer when possible.
 - Recursively create directories for output file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 2.0.4
-- Support for dynamic linking, use `NativeLibrary.fromLookup()` constructor.
+# 2.1.0
+- Added a new named constructor `NativeLibrary.fromLookup()` to support dynamic linking.
+- Updated dart SDK constraints to latest stable version `2.12.0`.
 
 # 2.0.3
 - Ignore typedef to struct pointer when possible.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,3 +15,4 @@ linter:
     - prefer_final_fields
     - prefer_final_locals
     - prefer_final_in_for_each
+    - unnecessary_brace_in_string_interps

--- a/example/c_json/cjson_generated_bindings.dart
+++ b/example/c_json/cjson_generated_bindings.dart
@@ -25,16 +25,23 @@ import 'dart:ffi' as ffi;
 
 /// Holds bindings to cJSON.
 class CJson {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  CJson(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  CJson(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  CJson.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   ffi.Pointer<ffi.Int8> cJSON_Version() {
     return (_cJSON_Version ??=
-        _dylib.lookupFunction<_c_cJSON_Version, _dart_cJSON_Version>(
-            'cJSON_Version'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_Version>>('cJSON_Version')
+            .asFunction<_dart_cJSON_Version>())();
   }
 
   _dart_cJSON_Version? _cJSON_Version;
@@ -43,8 +50,8 @@ class CJson {
     ffi.Pointer<cJSON_Hooks> hooks,
   ) {
     return (_cJSON_InitHooks ??=
-        _dylib.lookupFunction<_c_cJSON_InitHooks, _dart_cJSON_InitHooks>(
-            'cJSON_InitHooks'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_InitHooks>>('cJSON_InitHooks')
+            .asFunction<_dart_cJSON_InitHooks>())(
       hooks,
     );
   }
@@ -54,8 +61,9 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_Parse(
     ffi.Pointer<ffi.Int8> value,
   ) {
-    return (_cJSON_Parse ??= _dylib
-        .lookupFunction<_c_cJSON_Parse, _dart_cJSON_Parse>('cJSON_Parse'))(
+    return (_cJSON_Parse ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Parse>>('cJSON_Parse')
+            .asFunction<_dart_cJSON_Parse>())(
       value,
     );
   }
@@ -67,9 +75,10 @@ class CJson {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> return_parse_end,
     int require_null_terminated,
   ) {
-    return (_cJSON_ParseWithOpts ??= _dylib.lookupFunction<
-        _c_cJSON_ParseWithOpts,
-        _dart_cJSON_ParseWithOpts>('cJSON_ParseWithOpts'))(
+    return (_cJSON_ParseWithOpts ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ParseWithOpts>>(
+                'cJSON_ParseWithOpts')
+            .asFunction<_dart_cJSON_ParseWithOpts>())(
       value,
       return_parse_end,
       require_null_terminated,
@@ -81,8 +90,9 @@ class CJson {
   ffi.Pointer<ffi.Int8> cJSON_Print(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_Print ??= _dylib
-        .lookupFunction<_c_cJSON_Print, _dart_cJSON_Print>('cJSON_Print'))(
+    return (_cJSON_Print ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Print>>('cJSON_Print')
+            .asFunction<_dart_cJSON_Print>())(
       item,
     );
   }
@@ -92,9 +102,10 @@ class CJson {
   ffi.Pointer<ffi.Int8> cJSON_PrintUnformatted(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_PrintUnformatted ??= _dylib.lookupFunction<
-        _c_cJSON_PrintUnformatted,
-        _dart_cJSON_PrintUnformatted>('cJSON_PrintUnformatted'))(
+    return (_cJSON_PrintUnformatted ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_PrintUnformatted>>(
+                'cJSON_PrintUnformatted')
+            .asFunction<_dart_cJSON_PrintUnformatted>())(
       item,
     );
   }
@@ -106,9 +117,10 @@ class CJson {
     int prebuffer,
     int fmt,
   ) {
-    return (_cJSON_PrintBuffered ??= _dylib.lookupFunction<
-        _c_cJSON_PrintBuffered,
-        _dart_cJSON_PrintBuffered>('cJSON_PrintBuffered'))(
+    return (_cJSON_PrintBuffered ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_PrintBuffered>>(
+                'cJSON_PrintBuffered')
+            .asFunction<_dart_cJSON_PrintBuffered>())(
       item,
       prebuffer,
       fmt,
@@ -123,9 +135,10 @@ class CJson {
     int length,
     int format,
   ) {
-    return (_cJSON_PrintPreallocated ??= _dylib.lookupFunction<
-        _c_cJSON_PrintPreallocated,
-        _dart_cJSON_PrintPreallocated>('cJSON_PrintPreallocated'))(
+    return (_cJSON_PrintPreallocated ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_PrintPreallocated>>(
+                'cJSON_PrintPreallocated')
+            .asFunction<_dart_cJSON_PrintPreallocated>())(
       item,
       buffer,
       length,
@@ -138,8 +151,9 @@ class CJson {
   void cJSON_Delete(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_Delete ??= _dylib
-        .lookupFunction<_c_cJSON_Delete, _dart_cJSON_Delete>('cJSON_Delete'))(
+    return (_cJSON_Delete ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Delete>>('cJSON_Delete')
+            .asFunction<_dart_cJSON_Delete>())(
       item,
     );
   }
@@ -150,8 +164,8 @@ class CJson {
     ffi.Pointer<cJSON> array,
   ) {
     return (_cJSON_GetArraySize ??=
-        _dylib.lookupFunction<_c_cJSON_GetArraySize, _dart_cJSON_GetArraySize>(
-            'cJSON_GetArraySize'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_GetArraySize>>('cJSON_GetArraySize')
+            .asFunction<_dart_cJSON_GetArraySize>())(
       array,
     );
   }
@@ -163,8 +177,8 @@ class CJson {
     int index,
   ) {
     return (_cJSON_GetArrayItem ??=
-        _dylib.lookupFunction<_c_cJSON_GetArrayItem, _dart_cJSON_GetArrayItem>(
-            'cJSON_GetArrayItem'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_GetArrayItem>>('cJSON_GetArrayItem')
+            .asFunction<_dart_cJSON_GetArrayItem>())(
       array,
       index,
     );
@@ -176,9 +190,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_GetObjectItem ??= _dylib.lookupFunction<
-        _c_cJSON_GetObjectItem,
-        _dart_cJSON_GetObjectItem>('cJSON_GetObjectItem'))(
+    return (_cJSON_GetObjectItem ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_GetObjectItem>>(
+                'cJSON_GetObjectItem')
+            .asFunction<_dart_cJSON_GetObjectItem>())(
       object,
       string,
     );
@@ -190,10 +205,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_GetObjectItemCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_GetObjectItemCaseSensitive,
-            _dart_cJSON_GetObjectItemCaseSensitive>(
-        'cJSON_GetObjectItemCaseSensitive'))(
+    return (_cJSON_GetObjectItemCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_GetObjectItemCaseSensitive>>(
+                'cJSON_GetObjectItemCaseSensitive')
+            .asFunction<_dart_cJSON_GetObjectItemCaseSensitive>())(
       object,
       string,
     );
@@ -205,9 +220,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_HasObjectItem ??= _dylib.lookupFunction<
-        _c_cJSON_HasObjectItem,
-        _dart_cJSON_HasObjectItem>('cJSON_HasObjectItem'))(
+    return (_cJSON_HasObjectItem ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_HasObjectItem>>(
+                'cJSON_HasObjectItem')
+            .asFunction<_dart_cJSON_HasObjectItem>())(
       object,
       string,
     );
@@ -217,8 +233,8 @@ class CJson {
 
   ffi.Pointer<ffi.Int8> cJSON_GetErrorPtr() {
     return (_cJSON_GetErrorPtr ??=
-        _dylib.lookupFunction<_c_cJSON_GetErrorPtr, _dart_cJSON_GetErrorPtr>(
-            'cJSON_GetErrorPtr'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_GetErrorPtr>>('cJSON_GetErrorPtr')
+            .asFunction<_dart_cJSON_GetErrorPtr>())();
   }
 
   _dart_cJSON_GetErrorPtr? _cJSON_GetErrorPtr;
@@ -226,9 +242,10 @@ class CJson {
   ffi.Pointer<ffi.Int8> cJSON_GetStringValue(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_GetStringValue ??= _dylib.lookupFunction<
-        _c_cJSON_GetStringValue,
-        _dart_cJSON_GetStringValue>('cJSON_GetStringValue'))(
+    return (_cJSON_GetStringValue ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_GetStringValue>>(
+                'cJSON_GetStringValue')
+            .asFunction<_dart_cJSON_GetStringValue>())(
       item,
     );
   }
@@ -239,8 +256,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsInvalid ??=
-        _dylib.lookupFunction<_c_cJSON_IsInvalid, _dart_cJSON_IsInvalid>(
-            'cJSON_IsInvalid'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsInvalid>>('cJSON_IsInvalid')
+            .asFunction<_dart_cJSON_IsInvalid>())(
       item,
     );
   }
@@ -251,8 +268,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsFalse ??=
-        _dylib.lookupFunction<_c_cJSON_IsFalse, _dart_cJSON_IsFalse>(
-            'cJSON_IsFalse'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsFalse>>('cJSON_IsFalse')
+            .asFunction<_dart_cJSON_IsFalse>())(
       item,
     );
   }
@@ -262,8 +279,9 @@ class CJson {
   int cJSON_IsTrue(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsTrue ??= _dylib
-        .lookupFunction<_c_cJSON_IsTrue, _dart_cJSON_IsTrue>('cJSON_IsTrue'))(
+    return (_cJSON_IsTrue ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsTrue>>('cJSON_IsTrue')
+            .asFunction<_dart_cJSON_IsTrue>())(
       item,
     );
   }
@@ -273,8 +291,9 @@ class CJson {
   int cJSON_IsBool(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsBool ??= _dylib
-        .lookupFunction<_c_cJSON_IsBool, _dart_cJSON_IsBool>('cJSON_IsBool'))(
+    return (_cJSON_IsBool ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsBool>>('cJSON_IsBool')
+            .asFunction<_dart_cJSON_IsBool>())(
       item,
     );
   }
@@ -284,8 +303,9 @@ class CJson {
   int cJSON_IsNull(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsNull ??= _dylib
-        .lookupFunction<_c_cJSON_IsNull, _dart_cJSON_IsNull>('cJSON_IsNull'))(
+    return (_cJSON_IsNull ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsNull>>('cJSON_IsNull')
+            .asFunction<_dart_cJSON_IsNull>())(
       item,
     );
   }
@@ -296,8 +316,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsNumber ??=
-        _dylib.lookupFunction<_c_cJSON_IsNumber, _dart_cJSON_IsNumber>(
-            'cJSON_IsNumber'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsNumber>>('cJSON_IsNumber')
+            .asFunction<_dart_cJSON_IsNumber>())(
       item,
     );
   }
@@ -308,8 +328,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsString ??=
-        _dylib.lookupFunction<_c_cJSON_IsString, _dart_cJSON_IsString>(
-            'cJSON_IsString'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsString>>('cJSON_IsString')
+            .asFunction<_dart_cJSON_IsString>())(
       item,
     );
   }
@@ -320,8 +340,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsArray ??=
-        _dylib.lookupFunction<_c_cJSON_IsArray, _dart_cJSON_IsArray>(
-            'cJSON_IsArray'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsArray>>('cJSON_IsArray')
+            .asFunction<_dart_cJSON_IsArray>())(
       item,
     );
   }
@@ -332,8 +352,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsObject ??=
-        _dylib.lookupFunction<_c_cJSON_IsObject, _dart_cJSON_IsObject>(
-            'cJSON_IsObject'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsObject>>('cJSON_IsObject')
+            .asFunction<_dart_cJSON_IsObject>())(
       item,
     );
   }
@@ -343,8 +363,9 @@ class CJson {
   int cJSON_IsRaw(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsRaw ??= _dylib
-        .lookupFunction<_c_cJSON_IsRaw, _dart_cJSON_IsRaw>('cJSON_IsRaw'))(
+    return (_cJSON_IsRaw ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsRaw>>('cJSON_IsRaw')
+            .asFunction<_dart_cJSON_IsRaw>())(
       item,
     );
   }
@@ -353,24 +374,24 @@ class CJson {
 
   ffi.Pointer<cJSON> cJSON_CreateNull() {
     return (_cJSON_CreateNull ??=
-        _dylib.lookupFunction<_c_cJSON_CreateNull, _dart_cJSON_CreateNull>(
-            'cJSON_CreateNull'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateNull>>('cJSON_CreateNull')
+            .asFunction<_dart_cJSON_CreateNull>())();
   }
 
   _dart_cJSON_CreateNull? _cJSON_CreateNull;
 
   ffi.Pointer<cJSON> cJSON_CreateTrue() {
     return (_cJSON_CreateTrue ??=
-        _dylib.lookupFunction<_c_cJSON_CreateTrue, _dart_cJSON_CreateTrue>(
-            'cJSON_CreateTrue'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateTrue>>('cJSON_CreateTrue')
+            .asFunction<_dart_cJSON_CreateTrue>())();
   }
 
   _dart_cJSON_CreateTrue? _cJSON_CreateTrue;
 
   ffi.Pointer<cJSON> cJSON_CreateFalse() {
     return (_cJSON_CreateFalse ??=
-        _dylib.lookupFunction<_c_cJSON_CreateFalse, _dart_cJSON_CreateFalse>(
-            'cJSON_CreateFalse'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateFalse>>('cJSON_CreateFalse')
+            .asFunction<_dart_cJSON_CreateFalse>())();
   }
 
   _dart_cJSON_CreateFalse? _cJSON_CreateFalse;
@@ -379,8 +400,8 @@ class CJson {
     int boolean,
   ) {
     return (_cJSON_CreateBool ??=
-        _dylib.lookupFunction<_c_cJSON_CreateBool, _dart_cJSON_CreateBool>(
-            'cJSON_CreateBool'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateBool>>('cJSON_CreateBool')
+            .asFunction<_dart_cJSON_CreateBool>())(
       boolean,
     );
   }
@@ -391,8 +412,8 @@ class CJson {
     double num,
   ) {
     return (_cJSON_CreateNumber ??=
-        _dylib.lookupFunction<_c_cJSON_CreateNumber, _dart_cJSON_CreateNumber>(
-            'cJSON_CreateNumber'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateNumber>>('cJSON_CreateNumber')
+            .asFunction<_dart_cJSON_CreateNumber>())(
       num,
     );
   }
@@ -403,8 +424,8 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
   ) {
     return (_cJSON_CreateString ??=
-        _dylib.lookupFunction<_c_cJSON_CreateString, _dart_cJSON_CreateString>(
-            'cJSON_CreateString'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateString>>('cJSON_CreateString')
+            .asFunction<_dart_cJSON_CreateString>())(
       string,
     );
   }
@@ -415,8 +436,8 @@ class CJson {
     ffi.Pointer<ffi.Int8> raw,
   ) {
     return (_cJSON_CreateRaw ??=
-        _dylib.lookupFunction<_c_cJSON_CreateRaw, _dart_cJSON_CreateRaw>(
-            'cJSON_CreateRaw'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateRaw>>('cJSON_CreateRaw')
+            .asFunction<_dart_cJSON_CreateRaw>())(
       raw,
     );
   }
@@ -425,16 +446,16 @@ class CJson {
 
   ffi.Pointer<cJSON> cJSON_CreateArray() {
     return (_cJSON_CreateArray ??=
-        _dylib.lookupFunction<_c_cJSON_CreateArray, _dart_cJSON_CreateArray>(
-            'cJSON_CreateArray'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateArray>>('cJSON_CreateArray')
+            .asFunction<_dart_cJSON_CreateArray>())();
   }
 
   _dart_cJSON_CreateArray? _cJSON_CreateArray;
 
   ffi.Pointer<cJSON> cJSON_CreateObject() {
     return (_cJSON_CreateObject ??=
-        _dylib.lookupFunction<_c_cJSON_CreateObject, _dart_cJSON_CreateObject>(
-            'cJSON_CreateObject'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateObject>>('cJSON_CreateObject')
+            .asFunction<_dart_cJSON_CreateObject>())();
   }
 
   _dart_cJSON_CreateObject? _cJSON_CreateObject;
@@ -442,9 +463,10 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_CreateStringReference(
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_CreateStringReference ??= _dylib.lookupFunction<
-        _c_cJSON_CreateStringReference,
-        _dart_cJSON_CreateStringReference>('cJSON_CreateStringReference'))(
+    return (_cJSON_CreateStringReference ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateStringReference>>(
+                'cJSON_CreateStringReference')
+            .asFunction<_dart_cJSON_CreateStringReference>())(
       string,
     );
   }
@@ -454,9 +476,10 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_CreateObjectReference(
     ffi.Pointer<cJSON> child,
   ) {
-    return (_cJSON_CreateObjectReference ??= _dylib.lookupFunction<
-        _c_cJSON_CreateObjectReference,
-        _dart_cJSON_CreateObjectReference>('cJSON_CreateObjectReference'))(
+    return (_cJSON_CreateObjectReference ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateObjectReference>>(
+                'cJSON_CreateObjectReference')
+            .asFunction<_dart_cJSON_CreateObjectReference>())(
       child,
     );
   }
@@ -466,9 +489,10 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_CreateArrayReference(
     ffi.Pointer<cJSON> child,
   ) {
-    return (_cJSON_CreateArrayReference ??= _dylib.lookupFunction<
-        _c_cJSON_CreateArrayReference,
-        _dart_cJSON_CreateArrayReference>('cJSON_CreateArrayReference'))(
+    return (_cJSON_CreateArrayReference ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateArrayReference>>(
+                'cJSON_CreateArrayReference')
+            .asFunction<_dart_cJSON_CreateArrayReference>())(
       child,
     );
   }
@@ -479,9 +503,10 @@ class CJson {
     ffi.Pointer<ffi.Int32> numbers,
     int count,
   ) {
-    return (_cJSON_CreateIntArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateIntArray,
-        _dart_cJSON_CreateIntArray>('cJSON_CreateIntArray'))(
+    return (_cJSON_CreateIntArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateIntArray>>(
+                'cJSON_CreateIntArray')
+            .asFunction<_dart_cJSON_CreateIntArray>())(
       numbers,
       count,
     );
@@ -493,9 +518,10 @@ class CJson {
     ffi.Pointer<ffi.Float> numbers,
     int count,
   ) {
-    return (_cJSON_CreateFloatArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateFloatArray,
-        _dart_cJSON_CreateFloatArray>('cJSON_CreateFloatArray'))(
+    return (_cJSON_CreateFloatArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateFloatArray>>(
+                'cJSON_CreateFloatArray')
+            .asFunction<_dart_cJSON_CreateFloatArray>())(
       numbers,
       count,
     );
@@ -507,9 +533,10 @@ class CJson {
     ffi.Pointer<ffi.Double> numbers,
     int count,
   ) {
-    return (_cJSON_CreateDoubleArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateDoubleArray,
-        _dart_cJSON_CreateDoubleArray>('cJSON_CreateDoubleArray'))(
+    return (_cJSON_CreateDoubleArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateDoubleArray>>(
+                'cJSON_CreateDoubleArray')
+            .asFunction<_dart_cJSON_CreateDoubleArray>())(
       numbers,
       count,
     );
@@ -521,9 +548,10 @@ class CJson {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> strings,
     int count,
   ) {
-    return (_cJSON_CreateStringArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateStringArray,
-        _dart_cJSON_CreateStringArray>('cJSON_CreateStringArray'))(
+    return (_cJSON_CreateStringArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateStringArray>>(
+                'cJSON_CreateStringArray')
+            .asFunction<_dart_cJSON_CreateStringArray>())(
       strings,
       count,
     );
@@ -535,9 +563,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemToArray ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemToArray,
-        _dart_cJSON_AddItemToArray>('cJSON_AddItemToArray'))(
+    return (_cJSON_AddItemToArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemToArray>>(
+                'cJSON_AddItemToArray')
+            .asFunction<_dart_cJSON_AddItemToArray>())(
       array,
       item,
     );
@@ -550,9 +579,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemToObject,
-        _dart_cJSON_AddItemToObject>('cJSON_AddItemToObject'))(
+    return (_cJSON_AddItemToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemToObject>>(
+                'cJSON_AddItemToObject')
+            .asFunction<_dart_cJSON_AddItemToObject>())(
       object,
       string,
       item,
@@ -566,9 +596,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemToObjectCS ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemToObjectCS,
-        _dart_cJSON_AddItemToObjectCS>('cJSON_AddItemToObjectCS'))(
+    return (_cJSON_AddItemToObjectCS ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemToObjectCS>>(
+                'cJSON_AddItemToObjectCS')
+            .asFunction<_dart_cJSON_AddItemToObjectCS>())(
       object,
       string,
       item,
@@ -581,9 +612,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemReferenceToArray ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemReferenceToArray,
-        _dart_cJSON_AddItemReferenceToArray>('cJSON_AddItemReferenceToArray'))(
+    return (_cJSON_AddItemReferenceToArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemReferenceToArray>>(
+                'cJSON_AddItemReferenceToArray')
+            .asFunction<_dart_cJSON_AddItemReferenceToArray>())(
       array,
       item,
     );
@@ -596,10 +628,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemReferenceToObject ??= _dylib.lookupFunction<
-            _c_cJSON_AddItemReferenceToObject,
-            _dart_cJSON_AddItemReferenceToObject>(
-        'cJSON_AddItemReferenceToObject'))(
+    return (_cJSON_AddItemReferenceToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemReferenceToObject>>(
+                'cJSON_AddItemReferenceToObject')
+            .asFunction<_dart_cJSON_AddItemReferenceToObject>())(
       object,
       string,
       item,
@@ -612,9 +644,10 @@ class CJson {
     ffi.Pointer<cJSON> parent,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_DetachItemViaPointer ??= _dylib.lookupFunction<
-        _c_cJSON_DetachItemViaPointer,
-        _dart_cJSON_DetachItemViaPointer>('cJSON_DetachItemViaPointer'))(
+    return (_cJSON_DetachItemViaPointer ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemViaPointer>>(
+                'cJSON_DetachItemViaPointer')
+            .asFunction<_dart_cJSON_DetachItemViaPointer>())(
       parent,
       item,
     );
@@ -626,9 +659,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     int which,
   ) {
-    return (_cJSON_DetachItemFromArray ??= _dylib.lookupFunction<
-        _c_cJSON_DetachItemFromArray,
-        _dart_cJSON_DetachItemFromArray>('cJSON_DetachItemFromArray'))(
+    return (_cJSON_DetachItemFromArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemFromArray>>(
+                'cJSON_DetachItemFromArray')
+            .asFunction<_dart_cJSON_DetachItemFromArray>())(
       array,
       which,
     );
@@ -640,9 +674,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     int which,
   ) {
-    return (_cJSON_DeleteItemFromArray ??= _dylib.lookupFunction<
-        _c_cJSON_DeleteItemFromArray,
-        _dart_cJSON_DeleteItemFromArray>('cJSON_DeleteItemFromArray'))(
+    return (_cJSON_DeleteItemFromArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DeleteItemFromArray>>(
+                'cJSON_DeleteItemFromArray')
+            .asFunction<_dart_cJSON_DeleteItemFromArray>())(
       array,
       which,
     );
@@ -654,9 +689,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DetachItemFromObject ??= _dylib.lookupFunction<
-        _c_cJSON_DetachItemFromObject,
-        _dart_cJSON_DetachItemFromObject>('cJSON_DetachItemFromObject'))(
+    return (_cJSON_DetachItemFromObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemFromObject>>(
+                'cJSON_DetachItemFromObject')
+            .asFunction<_dart_cJSON_DetachItemFromObject>())(
       object,
       string,
     );
@@ -668,10 +704,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DetachItemFromObjectCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_DetachItemFromObjectCaseSensitive,
-            _dart_cJSON_DetachItemFromObjectCaseSensitive>(
-        'cJSON_DetachItemFromObjectCaseSensitive'))(
+    return (_cJSON_DetachItemFromObjectCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemFromObjectCaseSensitive>>(
+                'cJSON_DetachItemFromObjectCaseSensitive')
+            .asFunction<_dart_cJSON_DetachItemFromObjectCaseSensitive>())(
       object,
       string,
     );
@@ -684,9 +720,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DeleteItemFromObject ??= _dylib.lookupFunction<
-        _c_cJSON_DeleteItemFromObject,
-        _dart_cJSON_DeleteItemFromObject>('cJSON_DeleteItemFromObject'))(
+    return (_cJSON_DeleteItemFromObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DeleteItemFromObject>>(
+                'cJSON_DeleteItemFromObject')
+            .asFunction<_dart_cJSON_DeleteItemFromObject>())(
       object,
       string,
     );
@@ -698,10 +735,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DeleteItemFromObjectCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_DeleteItemFromObjectCaseSensitive,
-            _dart_cJSON_DeleteItemFromObjectCaseSensitive>(
-        'cJSON_DeleteItemFromObjectCaseSensitive'))(
+    return (_cJSON_DeleteItemFromObjectCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DeleteItemFromObjectCaseSensitive>>(
+                'cJSON_DeleteItemFromObjectCaseSensitive')
+            .asFunction<_dart_cJSON_DeleteItemFromObjectCaseSensitive>())(
       object,
       string,
     );
@@ -715,9 +752,10 @@ class CJson {
     int which,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_InsertItemInArray ??= _dylib.lookupFunction<
-        _c_cJSON_InsertItemInArray,
-        _dart_cJSON_InsertItemInArray>('cJSON_InsertItemInArray'))(
+    return (_cJSON_InsertItemInArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_InsertItemInArray>>(
+                'cJSON_InsertItemInArray')
+            .asFunction<_dart_cJSON_InsertItemInArray>())(
       array,
       which,
       newitem,
@@ -731,9 +769,10 @@ class CJson {
     ffi.Pointer<cJSON> item,
     ffi.Pointer<cJSON> replacement,
   ) {
-    return (_cJSON_ReplaceItemViaPointer ??= _dylib.lookupFunction<
-        _c_cJSON_ReplaceItemViaPointer,
-        _dart_cJSON_ReplaceItemViaPointer>('cJSON_ReplaceItemViaPointer'))(
+    return (_cJSON_ReplaceItemViaPointer ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemViaPointer>>(
+                'cJSON_ReplaceItemViaPointer')
+            .asFunction<_dart_cJSON_ReplaceItemViaPointer>())(
       parent,
       item,
       replacement,
@@ -747,9 +786,10 @@ class CJson {
     int which,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_ReplaceItemInArray ??= _dylib.lookupFunction<
-        _c_cJSON_ReplaceItemInArray,
-        _dart_cJSON_ReplaceItemInArray>('cJSON_ReplaceItemInArray'))(
+    return (_cJSON_ReplaceItemInArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemInArray>>(
+                'cJSON_ReplaceItemInArray')
+            .asFunction<_dart_cJSON_ReplaceItemInArray>())(
       array,
       which,
       newitem,
@@ -763,9 +803,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_ReplaceItemInObject ??= _dylib.lookupFunction<
-        _c_cJSON_ReplaceItemInObject,
-        _dart_cJSON_ReplaceItemInObject>('cJSON_ReplaceItemInObject'))(
+    return (_cJSON_ReplaceItemInObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemInObject>>(
+                'cJSON_ReplaceItemInObject')
+            .asFunction<_dart_cJSON_ReplaceItemInObject>())(
       object,
       string,
       newitem,
@@ -779,10 +820,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_ReplaceItemInObjectCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_ReplaceItemInObjectCaseSensitive,
-            _dart_cJSON_ReplaceItemInObjectCaseSensitive>(
-        'cJSON_ReplaceItemInObjectCaseSensitive'))(
+    return (_cJSON_ReplaceItemInObjectCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemInObjectCaseSensitive>>(
+                'cJSON_ReplaceItemInObjectCaseSensitive')
+            .asFunction<_dart_cJSON_ReplaceItemInObjectCaseSensitive>())(
       object,
       string,
       newitem,
@@ -797,8 +838,8 @@ class CJson {
     int recurse,
   ) {
     return (_cJSON_Duplicate ??=
-        _dylib.lookupFunction<_c_cJSON_Duplicate, _dart_cJSON_Duplicate>(
-            'cJSON_Duplicate'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_Duplicate>>('cJSON_Duplicate')
+            .asFunction<_dart_cJSON_Duplicate>())(
       item,
       recurse,
     );
@@ -812,8 +853,8 @@ class CJson {
     int case_sensitive,
   ) {
     return (_cJSON_Compare ??=
-        _dylib.lookupFunction<_c_cJSON_Compare, _dart_cJSON_Compare>(
-            'cJSON_Compare'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_Compare>>('cJSON_Compare')
+            .asFunction<_dart_cJSON_Compare>())(
       a,
       b,
       case_sensitive,
@@ -825,8 +866,9 @@ class CJson {
   void cJSON_Minify(
     ffi.Pointer<ffi.Int8> json,
   ) {
-    return (_cJSON_Minify ??= _dylib
-        .lookupFunction<_c_cJSON_Minify, _dart_cJSON_Minify>('cJSON_Minify'))(
+    return (_cJSON_Minify ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Minify>>('cJSON_Minify')
+            .asFunction<_dart_cJSON_Minify>())(
       json,
     );
   }
@@ -837,9 +879,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddNullToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddNullToObject,
-        _dart_cJSON_AddNullToObject>('cJSON_AddNullToObject'))(
+    return (_cJSON_AddNullToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddNullToObject>>(
+                'cJSON_AddNullToObject')
+            .asFunction<_dart_cJSON_AddNullToObject>())(
       object,
       name,
     );
@@ -851,9 +894,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddTrueToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddTrueToObject,
-        _dart_cJSON_AddTrueToObject>('cJSON_AddTrueToObject'))(
+    return (_cJSON_AddTrueToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddTrueToObject>>(
+                'cJSON_AddTrueToObject')
+            .asFunction<_dart_cJSON_AddTrueToObject>())(
       object,
       name,
     );
@@ -865,9 +909,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddFalseToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddFalseToObject,
-        _dart_cJSON_AddFalseToObject>('cJSON_AddFalseToObject'))(
+    return (_cJSON_AddFalseToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddFalseToObject>>(
+                'cJSON_AddFalseToObject')
+            .asFunction<_dart_cJSON_AddFalseToObject>())(
       object,
       name,
     );
@@ -880,9 +925,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     int boolean,
   ) {
-    return (_cJSON_AddBoolToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddBoolToObject,
-        _dart_cJSON_AddBoolToObject>('cJSON_AddBoolToObject'))(
+    return (_cJSON_AddBoolToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddBoolToObject>>(
+                'cJSON_AddBoolToObject')
+            .asFunction<_dart_cJSON_AddBoolToObject>())(
       object,
       name,
       boolean,
@@ -896,9 +942,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     double number,
   ) {
-    return (_cJSON_AddNumberToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddNumberToObject,
-        _dart_cJSON_AddNumberToObject>('cJSON_AddNumberToObject'))(
+    return (_cJSON_AddNumberToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddNumberToObject>>(
+                'cJSON_AddNumberToObject')
+            .asFunction<_dart_cJSON_AddNumberToObject>())(
       object,
       name,
       number,
@@ -912,9 +959,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_AddStringToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddStringToObject,
-        _dart_cJSON_AddStringToObject>('cJSON_AddStringToObject'))(
+    return (_cJSON_AddStringToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddStringToObject>>(
+                'cJSON_AddStringToObject')
+            .asFunction<_dart_cJSON_AddStringToObject>())(
       object,
       name,
       string,
@@ -928,9 +976,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     ffi.Pointer<ffi.Int8> raw,
   ) {
-    return (_cJSON_AddRawToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddRawToObject,
-        _dart_cJSON_AddRawToObject>('cJSON_AddRawToObject'))(
+    return (_cJSON_AddRawToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddRawToObject>>(
+                'cJSON_AddRawToObject')
+            .asFunction<_dart_cJSON_AddRawToObject>())(
       object,
       name,
       raw,
@@ -943,9 +992,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddObjectToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddObjectToObject,
-        _dart_cJSON_AddObjectToObject>('cJSON_AddObjectToObject'))(
+    return (_cJSON_AddObjectToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddObjectToObject>>(
+                'cJSON_AddObjectToObject')
+            .asFunction<_dart_cJSON_AddObjectToObject>())(
       object,
       name,
     );
@@ -957,9 +1007,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddArrayToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddArrayToObject,
-        _dart_cJSON_AddArrayToObject>('cJSON_AddArrayToObject'))(
+    return (_cJSON_AddArrayToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddArrayToObject>>(
+                'cJSON_AddArrayToObject')
+            .asFunction<_dart_cJSON_AddArrayToObject>())(
       object,
       name,
     );
@@ -971,9 +1022,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     double number,
   ) {
-    return (_cJSON_SetNumberHelper ??= _dylib.lookupFunction<
-        _c_cJSON_SetNumberHelper,
-        _dart_cJSON_SetNumberHelper>('cJSON_SetNumberHelper'))(
+    return (_cJSON_SetNumberHelper ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_SetNumberHelper>>(
+                'cJSON_SetNumberHelper')
+            .asFunction<_dart_cJSON_SetNumberHelper>())(
       object,
       number,
     );
@@ -984,8 +1036,9 @@ class CJson {
   ffi.Pointer<ffi.Void> cJSON_malloc(
     int size,
   ) {
-    return (_cJSON_malloc ??= _dylib
-        .lookupFunction<_c_cJSON_malloc, _dart_cJSON_malloc>('cJSON_malloc'))(
+    return (_cJSON_malloc ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_malloc>>('cJSON_malloc')
+            .asFunction<_dart_cJSON_malloc>())(
       size,
     );
   }
@@ -996,7 +1049,8 @@ class CJson {
     ffi.Pointer<ffi.Void> object,
   ) {
     return (_cJSON_free ??=
-        _dylib.lookupFunction<_c_cJSON_free, _dart_cJSON_free>('cJSON_free'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_free>>('cJSON_free')
+            .asFunction<_dart_cJSON_free>())(
       object,
     );
   }

--- a/example/c_json/pubspec.yaml
+++ b/example/c_json/pubspec.yaml
@@ -5,7 +5,7 @@
 name: c_json_example
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   ffi: ^1.0.0

--- a/example/libclang-example/generated_bindings.dart
+++ b/example/libclang-example/generated_bindings.dart
@@ -10,19 +10,26 @@ import 'dart:ffi' as ffi;
 
 /// Holds bindings to LibClang.
 class LibClang {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  LibClang(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  LibClang(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  LibClang.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   /// Retrieve the character data associated with the given string.
   ffi.Pointer<ffi.Int8> clang_getCString(
     CXString string,
   ) {
     return (_clang_getCString ??=
-        _dylib.lookupFunction<_c_clang_getCString, _dart_clang_getCString>(
-            'clang_getCString'))(
+        _lookup<ffi.NativeFunction<_c_clang_getCString>>('clang_getCString')
+            .asFunction<_dart_clang_getCString>())(
       string,
     );
   }
@@ -33,9 +40,10 @@ class LibClang {
   void clang_disposeString(
     CXString string,
   ) {
-    return (_clang_disposeString ??= _dylib.lookupFunction<
-        _c_clang_disposeString,
-        _dart_clang_disposeString>('clang_disposeString'))(
+    return (_clang_disposeString ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeString>>(
+                'clang_disposeString')
+            .asFunction<_dart_clang_disposeString>())(
       string,
     );
   }
@@ -46,9 +54,10 @@ class LibClang {
   void clang_disposeStringSet(
     ffi.Pointer<CXStringSet> set_1,
   ) {
-    return (_clang_disposeStringSet ??= _dylib.lookupFunction<
-        _c_clang_disposeStringSet,
-        _dart_clang_disposeStringSet>('clang_disposeStringSet'))(
+    return (_clang_disposeStringSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeStringSet>>(
+                'clang_disposeStringSet')
+            .asFunction<_dart_clang_disposeStringSet>())(
       set_1,
     );
   }
@@ -98,8 +107,8 @@ class LibClang {
     int displayDiagnostics,
   ) {
     return (_clang_createIndex ??=
-        _dylib.lookupFunction<_c_clang_createIndex, _dart_clang_createIndex>(
-            'clang_createIndex'))(
+        _lookup<ffi.NativeFunction<_c_clang_createIndex>>('clang_createIndex')
+            .asFunction<_dart_clang_createIndex>())(
       excludeDeclarationsFromPCH,
       displayDiagnostics,
     );
@@ -115,8 +124,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> index,
   ) {
     return (_clang_disposeIndex ??=
-        _dylib.lookupFunction<_c_clang_disposeIndex, _dart_clang_disposeIndex>(
-            'clang_disposeIndex'))(
+        _lookup<ffi.NativeFunction<_c_clang_disposeIndex>>('clang_disposeIndex')
+            .asFunction<_dart_clang_disposeIndex>())(
       index,
     );
   }
@@ -138,10 +147,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> arg0,
     int options,
   ) {
-    return (_clang_CXIndex_setGlobalOptions ??= _dylib.lookupFunction<
-            _c_clang_CXIndex_setGlobalOptions,
-            _dart_clang_CXIndex_setGlobalOptions>(
-        'clang_CXIndex_setGlobalOptions'))(
+    return (_clang_CXIndex_setGlobalOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXIndex_setGlobalOptions>>(
+                'clang_CXIndex_setGlobalOptions')
+            .asFunction<_dart_clang_CXIndex_setGlobalOptions>())(
       arg0,
       options,
     );
@@ -156,10 +165,10 @@ class LibClang {
   int clang_CXIndex_getGlobalOptions(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_CXIndex_getGlobalOptions ??= _dylib.lookupFunction<
-            _c_clang_CXIndex_getGlobalOptions,
-            _dart_clang_CXIndex_getGlobalOptions>(
-        'clang_CXIndex_getGlobalOptions'))(
+    return (_clang_CXIndex_getGlobalOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXIndex_getGlobalOptions>>(
+                'clang_CXIndex_getGlobalOptions')
+            .asFunction<_dart_clang_CXIndex_getGlobalOptions>())(
       arg0,
     );
   }
@@ -175,10 +184,11 @@ class LibClang {
     ffi.Pointer<ffi.Void> arg0,
     ffi.Pointer<ffi.Int8> Path,
   ) {
-    return (_clang_CXIndex_setInvocationEmissionPathOption ??=
-        _dylib.lookupFunction<_c_clang_CXIndex_setInvocationEmissionPathOption,
-                _dart_clang_CXIndex_setInvocationEmissionPathOption>(
-            'clang_CXIndex_setInvocationEmissionPathOption'))(
+    return (_clang_CXIndex_setInvocationEmissionPathOption ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_CXIndex_setInvocationEmissionPathOption>>(
+            'clang_CXIndex_setInvocationEmissionPathOption')
+        .asFunction<_dart_clang_CXIndex_setInvocationEmissionPathOption>())(
       arg0,
       Path,
     );
@@ -192,8 +202,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> SFile,
   ) {
     return (_clang_getFileName ??=
-        _dylib.lookupFunction<_c_clang_getFileName, _dart_clang_getFileName>(
-            'clang_getFileName'))(
+        _lookup<ffi.NativeFunction<_c_clang_getFileName>>('clang_getFileName')
+            .asFunction<_dart_clang_getFileName>())(
       SFile,
     );
   }
@@ -205,8 +215,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> SFile,
   ) {
     return (_clang_getFileTime ??=
-        _dylib.lookupFunction<_c_clang_getFileTime, _dart_clang_getFileTime>(
-            'clang_getFileTime'))(
+        _lookup<ffi.NativeFunction<_c_clang_getFileTime>>('clang_getFileTime')
+            .asFunction<_dart_clang_getFileTime>())(
       SFile,
     );
   }
@@ -223,9 +233,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     ffi.Pointer<CXFileUniqueID> outID,
   ) {
-    return (_clang_getFileUniqueID ??= _dylib.lookupFunction<
-        _c_clang_getFileUniqueID,
-        _dart_clang_getFileUniqueID>('clang_getFileUniqueID'))(
+    return (_clang_getFileUniqueID ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFileUniqueID>>(
+                'clang_getFileUniqueID')
+            .asFunction<_dart_clang_getFileUniqueID>())(
       file,
       outID,
     );
@@ -240,10 +251,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> tu,
     ffi.Pointer<ffi.Void> file,
   ) {
-    return (_clang_isFileMultipleIncludeGuarded ??= _dylib.lookupFunction<
-            _c_clang_isFileMultipleIncludeGuarded,
-            _dart_clang_isFileMultipleIncludeGuarded>(
-        'clang_isFileMultipleIncludeGuarded'))(
+    return (_clang_isFileMultipleIncludeGuarded ??=
+        _lookup<ffi.NativeFunction<_c_clang_isFileMultipleIncludeGuarded>>(
+                'clang_isFileMultipleIncludeGuarded')
+            .asFunction<_dart_clang_isFileMultipleIncludeGuarded>())(
       tu,
       file,
     );
@@ -264,8 +275,8 @@ class LibClang {
     ffi.Pointer<ffi.Int8> file_name,
   ) {
     return (_clang_getFile ??=
-        _dylib.lookupFunction<_c_clang_getFile, _dart_clang_getFile>(
-            'clang_getFile'))(
+        _lookup<ffi.NativeFunction<_c_clang_getFile>>('clang_getFile')
+            .asFunction<_dart_clang_getFile>())(
       tu,
       file_name,
     );
@@ -288,9 +299,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     ffi.Pointer<ffi.Uint64> size,
   ) {
-    return (_clang_getFileContents ??= _dylib.lookupFunction<
-        _c_clang_getFileContents,
-        _dart_clang_getFileContents>('clang_getFileContents'))(
+    return (_clang_getFileContents ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFileContents>>(
+                'clang_getFileContents')
+            .asFunction<_dart_clang_getFileContents>())(
       tu,
       file,
       size,
@@ -306,8 +318,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> file2,
   ) {
     return (_clang_File_isEqual ??=
-        _dylib.lookupFunction<_c_clang_File_isEqual, _dart_clang_File_isEqual>(
-            'clang_File_isEqual'))(
+        _lookup<ffi.NativeFunction<_c_clang_File_isEqual>>('clang_File_isEqual')
+            .asFunction<_dart_clang_File_isEqual>())(
       file1,
       file2,
     );
@@ -321,9 +333,10 @@ class LibClang {
   CXString clang_File_tryGetRealPathName(
     ffi.Pointer<ffi.Void> file,
   ) {
-    return (_clang_File_tryGetRealPathName ??= _dylib.lookupFunction<
-        _c_clang_File_tryGetRealPathName,
-        _dart_clang_File_tryGetRealPathName>('clang_File_tryGetRealPathName'))(
+    return (_clang_File_tryGetRealPathName ??=
+        _lookup<ffi.NativeFunction<_c_clang_File_tryGetRealPathName>>(
+                'clang_File_tryGetRealPathName')
+            .asFunction<_dart_clang_File_tryGetRealPathName>())(
       file,
     );
   }
@@ -332,9 +345,10 @@ class LibClang {
 
   /// Retrieve a NULL (invalid) source location.
   CXSourceLocation clang_getNullLocation() {
-    return (_clang_getNullLocation ??= _dylib.lookupFunction<
-        _c_clang_getNullLocation,
-        _dart_clang_getNullLocation>('clang_getNullLocation'))();
+    return (_clang_getNullLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNullLocation>>(
+                'clang_getNullLocation')
+            .asFunction<_dart_clang_getNullLocation>())();
   }
 
   _dart_clang_getNullLocation? _clang_getNullLocation;
@@ -349,9 +363,10 @@ class LibClang {
     CXSourceLocation loc1,
     CXSourceLocation loc2,
   ) {
-    return (_clang_equalLocations ??= _dylib.lookupFunction<
-        _c_clang_equalLocations,
-        _dart_clang_equalLocations>('clang_equalLocations'))(
+    return (_clang_equalLocations ??=
+        _lookup<ffi.NativeFunction<_c_clang_equalLocations>>(
+                'clang_equalLocations')
+            .asFunction<_dart_clang_equalLocations>())(
       loc1,
       loc2,
     );
@@ -368,8 +383,8 @@ class LibClang {
     int column,
   ) {
     return (_clang_getLocation ??=
-        _dylib.lookupFunction<_c_clang_getLocation, _dart_clang_getLocation>(
-            'clang_getLocation'))(
+        _lookup<ffi.NativeFunction<_c_clang_getLocation>>('clang_getLocation')
+            .asFunction<_dart_clang_getLocation>())(
       tu,
       file,
       line,
@@ -386,9 +401,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     int offset,
   ) {
-    return (_clang_getLocationForOffset ??= _dylib.lookupFunction<
-        _c_clang_getLocationForOffset,
-        _dart_clang_getLocationForOffset>('clang_getLocationForOffset'))(
+    return (_clang_getLocationForOffset ??=
+        _lookup<ffi.NativeFunction<_c_clang_getLocationForOffset>>(
+                'clang_getLocationForOffset')
+            .asFunction<_dart_clang_getLocationForOffset>())(
       tu,
       file,
       offset,
@@ -401,10 +417,10 @@ class LibClang {
   int clang_Location_isInSystemHeader(
     CXSourceLocation location,
   ) {
-    return (_clang_Location_isInSystemHeader ??= _dylib.lookupFunction<
-            _c_clang_Location_isInSystemHeader,
-            _dart_clang_Location_isInSystemHeader>(
-        'clang_Location_isInSystemHeader'))(
+    return (_clang_Location_isInSystemHeader ??=
+        _lookup<ffi.NativeFunction<_c_clang_Location_isInSystemHeader>>(
+                'clang_Location_isInSystemHeader')
+            .asFunction<_dart_clang_Location_isInSystemHeader>())(
       location,
     );
   }
@@ -416,9 +432,10 @@ class LibClang {
   int clang_Location_isFromMainFile(
     CXSourceLocation location,
   ) {
-    return (_clang_Location_isFromMainFile ??= _dylib.lookupFunction<
-        _c_clang_Location_isFromMainFile,
-        _dart_clang_Location_isFromMainFile>('clang_Location_isFromMainFile'))(
+    return (_clang_Location_isFromMainFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_Location_isFromMainFile>>(
+                'clang_Location_isFromMainFile')
+            .asFunction<_dart_clang_Location_isFromMainFile>())(
       location,
     );
   }
@@ -428,8 +445,8 @@ class LibClang {
   /// Retrieve a NULL (invalid) source range.
   CXSourceRange clang_getNullRange() {
     return (_clang_getNullRange ??=
-        _dylib.lookupFunction<_c_clang_getNullRange, _dart_clang_getNullRange>(
-            'clang_getNullRange'))();
+        _lookup<ffi.NativeFunction<_c_clang_getNullRange>>('clang_getNullRange')
+            .asFunction<_dart_clang_getNullRange>())();
   }
 
   _dart_clang_getNullRange? _clang_getNullRange;
@@ -441,8 +458,8 @@ class LibClang {
     CXSourceLocation end,
   ) {
     return (_clang_getRange ??=
-        _dylib.lookupFunction<_c_clang_getRange, _dart_clang_getRange>(
-            'clang_getRange'))(
+        _lookup<ffi.NativeFunction<_c_clang_getRange>>('clang_getRange')
+            .asFunction<_dart_clang_getRange>())(
       begin,
       end,
     );
@@ -458,8 +475,8 @@ class LibClang {
     CXSourceRange range2,
   ) {
     return (_clang_equalRanges ??=
-        _dylib.lookupFunction<_c_clang_equalRanges, _dart_clang_equalRanges>(
-            'clang_equalRanges'))(
+        _lookup<ffi.NativeFunction<_c_clang_equalRanges>>('clang_equalRanges')
+            .asFunction<_dart_clang_equalRanges>())(
       range1,
       range2,
     );
@@ -472,8 +489,8 @@ class LibClang {
     CXSourceRange range,
   ) {
     return (_clang_Range_isNull ??=
-        _dylib.lookupFunction<_c_clang_Range_isNull, _dart_clang_Range_isNull>(
-            'clang_Range_isNull'))(
+        _lookup<ffi.NativeFunction<_c_clang_Range_isNull>>('clang_Range_isNull')
+            .asFunction<_dart_clang_Range_isNull>())(
       range,
     );
   }
@@ -507,9 +524,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getExpansionLocation ??= _dylib.lookupFunction<
-        _c_clang_getExpansionLocation,
-        _dart_clang_getExpansionLocation>('clang_getExpansionLocation'))(
+    return (_clang_getExpansionLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getExpansionLocation>>(
+                'clang_getExpansionLocation')
+            .asFunction<_dart_clang_getExpansionLocation>())(
       location,
       file,
       line,
@@ -564,9 +582,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> line,
     ffi.Pointer<ffi.Uint32> column,
   ) {
-    return (_clang_getPresumedLocation ??= _dylib.lookupFunction<
-        _c_clang_getPresumedLocation,
-        _dart_clang_getPresumedLocation>('clang_getPresumedLocation'))(
+    return (_clang_getPresumedLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getPresumedLocation>>(
+                'clang_getPresumedLocation')
+            .asFunction<_dart_clang_getPresumedLocation>())(
       location,
       filename,
       line,
@@ -589,10 +608,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getInstantiationLocation ??= _dylib.lookupFunction<
-            _c_clang_getInstantiationLocation,
-            _dart_clang_getInstantiationLocation>(
-        'clang_getInstantiationLocation'))(
+    return (_clang_getInstantiationLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getInstantiationLocation>>(
+                'clang_getInstantiationLocation')
+            .asFunction<_dart_clang_getInstantiationLocation>())(
       location,
       file,
       line,
@@ -630,9 +649,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getSpellingLocation ??= _dylib.lookupFunction<
-        _c_clang_getSpellingLocation,
-        _dart_clang_getSpellingLocation>('clang_getSpellingLocation'))(
+    return (_clang_getSpellingLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getSpellingLocation>>(
+                'clang_getSpellingLocation')
+            .asFunction<_dart_clang_getSpellingLocation>())(
       location,
       file,
       line,
@@ -671,9 +691,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getFileLocation ??= _dylib.lookupFunction<
-        _c_clang_getFileLocation,
-        _dart_clang_getFileLocation>('clang_getFileLocation'))(
+    return (_clang_getFileLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFileLocation>>(
+                'clang_getFileLocation')
+            .asFunction<_dart_clang_getFileLocation>())(
       location,
       file,
       line,
@@ -689,9 +710,10 @@ class LibClang {
   CXSourceLocation clang_getRangeStart(
     CXSourceRange range,
   ) {
-    return (_clang_getRangeStart ??= _dylib.lookupFunction<
-        _c_clang_getRangeStart,
-        _dart_clang_getRangeStart>('clang_getRangeStart'))(
+    return (_clang_getRangeStart ??=
+        _lookup<ffi.NativeFunction<_c_clang_getRangeStart>>(
+                'clang_getRangeStart')
+            .asFunction<_dart_clang_getRangeStart>())(
       range,
     );
   }
@@ -704,8 +726,8 @@ class LibClang {
     CXSourceRange range,
   ) {
     return (_clang_getRangeEnd ??=
-        _dylib.lookupFunction<_c_clang_getRangeEnd, _dart_clang_getRangeEnd>(
-            'clang_getRangeEnd'))(
+        _lookup<ffi.NativeFunction<_c_clang_getRangeEnd>>('clang_getRangeEnd')
+            .asFunction<_dart_clang_getRangeEnd>())(
       range,
     );
   }
@@ -720,9 +742,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> tu,
     ffi.Pointer<ffi.Void> file,
   ) {
-    return (_clang_getSkippedRanges ??= _dylib.lookupFunction<
-        _c_clang_getSkippedRanges,
-        _dart_clang_getSkippedRanges>('clang_getSkippedRanges'))(
+    return (_clang_getSkippedRanges ??=
+        _lookup<ffi.NativeFunction<_c_clang_getSkippedRanges>>(
+                'clang_getSkippedRanges')
+            .asFunction<_dart_clang_getSkippedRanges>())(
       tu,
       file,
     );
@@ -738,9 +761,10 @@ class LibClang {
   ffi.Pointer<CXSourceRangeList> clang_getAllSkippedRanges(
     ffi.Pointer<CXTranslationUnitImpl> tu,
   ) {
-    return (_clang_getAllSkippedRanges ??= _dylib.lookupFunction<
-        _c_clang_getAllSkippedRanges,
-        _dart_clang_getAllSkippedRanges>('clang_getAllSkippedRanges'))(
+    return (_clang_getAllSkippedRanges ??=
+        _lookup<ffi.NativeFunction<_c_clang_getAllSkippedRanges>>(
+                'clang_getAllSkippedRanges')
+            .asFunction<_dart_clang_getAllSkippedRanges>())(
       tu,
     );
   }
@@ -751,9 +775,10 @@ class LibClang {
   void clang_disposeSourceRangeList(
     ffi.Pointer<CXSourceRangeList> ranges,
   ) {
-    return (_clang_disposeSourceRangeList ??= _dylib.lookupFunction<
-        _c_clang_disposeSourceRangeList,
-        _dart_clang_disposeSourceRangeList>('clang_disposeSourceRangeList'))(
+    return (_clang_disposeSourceRangeList ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeSourceRangeList>>(
+                'clang_disposeSourceRangeList')
+            .asFunction<_dart_clang_disposeSourceRangeList>())(
       ranges,
     );
   }
@@ -764,9 +789,10 @@ class LibClang {
   int clang_getNumDiagnosticsInSet(
     ffi.Pointer<ffi.Void> Diags,
   ) {
-    return (_clang_getNumDiagnosticsInSet ??= _dylib.lookupFunction<
-        _c_clang_getNumDiagnosticsInSet,
-        _dart_clang_getNumDiagnosticsInSet>('clang_getNumDiagnosticsInSet'))(
+    return (_clang_getNumDiagnosticsInSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumDiagnosticsInSet>>(
+                'clang_getNumDiagnosticsInSet')
+            .asFunction<_dart_clang_getNumDiagnosticsInSet>())(
       Diags,
     );
   }
@@ -784,9 +810,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diags,
     int Index,
   ) {
-    return (_clang_getDiagnosticInSet ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticInSet,
-        _dart_clang_getDiagnosticInSet>('clang_getDiagnosticInSet'))(
+    return (_clang_getDiagnosticInSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticInSet>>(
+                'clang_getDiagnosticInSet')
+            .asFunction<_dart_clang_getDiagnosticInSet>())(
       Diags,
       Index,
     );
@@ -810,9 +837,10 @@ class LibClang {
     ffi.Pointer<ffi.Int32> error,
     ffi.Pointer<CXString> errorString,
   ) {
-    return (_clang_loadDiagnostics ??= _dylib.lookupFunction<
-        _c_clang_loadDiagnostics,
-        _dart_clang_loadDiagnostics>('clang_loadDiagnostics'))(
+    return (_clang_loadDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_loadDiagnostics>>(
+                'clang_loadDiagnostics')
+            .asFunction<_dart_clang_loadDiagnostics>())(
       file,
       error,
       errorString,
@@ -825,9 +853,10 @@ class LibClang {
   void clang_disposeDiagnosticSet(
     ffi.Pointer<ffi.Void> Diags,
   ) {
-    return (_clang_disposeDiagnosticSet ??= _dylib.lookupFunction<
-        _c_clang_disposeDiagnosticSet,
-        _dart_clang_disposeDiagnosticSet>('clang_disposeDiagnosticSet'))(
+    return (_clang_disposeDiagnosticSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeDiagnosticSet>>(
+                'clang_disposeDiagnosticSet')
+            .asFunction<_dart_clang_disposeDiagnosticSet>())(
       Diags,
     );
   }
@@ -841,9 +870,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getChildDiagnostics(
     ffi.Pointer<ffi.Void> D,
   ) {
-    return (_clang_getChildDiagnostics ??= _dylib.lookupFunction<
-        _c_clang_getChildDiagnostics,
-        _dart_clang_getChildDiagnostics>('clang_getChildDiagnostics'))(
+    return (_clang_getChildDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_getChildDiagnostics>>(
+                'clang_getChildDiagnostics')
+            .asFunction<_dart_clang_getChildDiagnostics>())(
       D,
     );
   }
@@ -855,9 +885,10 @@ class LibClang {
   int clang_getNumDiagnostics(
     ffi.Pointer<CXTranslationUnitImpl> Unit,
   ) {
-    return (_clang_getNumDiagnostics ??= _dylib.lookupFunction<
-        _c_clang_getNumDiagnostics,
-        _dart_clang_getNumDiagnostics>('clang_getNumDiagnostics'))(
+    return (_clang_getNumDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumDiagnostics>>(
+                'clang_getNumDiagnostics')
+            .asFunction<_dart_clang_getNumDiagnostics>())(
       Unit,
     );
   }
@@ -875,9 +906,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> Unit,
     int Index,
   ) {
-    return (_clang_getDiagnostic ??= _dylib.lookupFunction<
-        _c_clang_getDiagnostic,
-        _dart_clang_getDiagnostic>('clang_getDiagnostic'))(
+    return (_clang_getDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnostic>>(
+                'clang_getDiagnostic')
+            .asFunction<_dart_clang_getDiagnostic>())(
       Unit,
       Index,
     );
@@ -892,9 +924,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getDiagnosticSetFromTU(
     ffi.Pointer<CXTranslationUnitImpl> Unit,
   ) {
-    return (_clang_getDiagnosticSetFromTU ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticSetFromTU,
-        _dart_clang_getDiagnosticSetFromTU>('clang_getDiagnosticSetFromTU'))(
+    return (_clang_getDiagnosticSetFromTU ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticSetFromTU>>(
+                'clang_getDiagnosticSetFromTU')
+            .asFunction<_dart_clang_getDiagnosticSetFromTU>())(
       Unit,
     );
   }
@@ -905,9 +938,10 @@ class LibClang {
   void clang_disposeDiagnostic(
     ffi.Pointer<ffi.Void> Diagnostic,
   ) {
-    return (_clang_disposeDiagnostic ??= _dylib.lookupFunction<
-        _c_clang_disposeDiagnostic,
-        _dart_clang_disposeDiagnostic>('clang_disposeDiagnostic'))(
+    return (_clang_disposeDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeDiagnostic>>(
+                'clang_disposeDiagnostic')
+            .asFunction<_dart_clang_disposeDiagnostic>())(
       Diagnostic,
     );
   }
@@ -931,9 +965,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diagnostic,
     int Options,
   ) {
-    return (_clang_formatDiagnostic ??= _dylib.lookupFunction<
-        _c_clang_formatDiagnostic,
-        _dart_clang_formatDiagnostic>('clang_formatDiagnostic'))(
+    return (_clang_formatDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_formatDiagnostic>>(
+                'clang_formatDiagnostic')
+            .asFunction<_dart_clang_formatDiagnostic>())(
       Diagnostic,
       Options,
     );
@@ -947,10 +982,10 @@ class LibClang {
   /// \returns A set of display options suitable for use with \c
   /// clang_formatDiagnostic().
   int clang_defaultDiagnosticDisplayOptions() {
-    return (_clang_defaultDiagnosticDisplayOptions ??= _dylib.lookupFunction<
-            _c_clang_defaultDiagnosticDisplayOptions,
-            _dart_clang_defaultDiagnosticDisplayOptions>(
-        'clang_defaultDiagnosticDisplayOptions'))();
+    return (_clang_defaultDiagnosticDisplayOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultDiagnosticDisplayOptions>>(
+                'clang_defaultDiagnosticDisplayOptions')
+            .asFunction<_dart_clang_defaultDiagnosticDisplayOptions>())();
   }
 
   _dart_clang_defaultDiagnosticDisplayOptions?
@@ -960,9 +995,10 @@ class LibClang {
   int clang_getDiagnosticSeverity(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticSeverity ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticSeverity,
-        _dart_clang_getDiagnosticSeverity>('clang_getDiagnosticSeverity'))(
+    return (_clang_getDiagnosticSeverity ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticSeverity>>(
+                'clang_getDiagnosticSeverity')
+            .asFunction<_dart_clang_getDiagnosticSeverity>())(
       arg0,
     );
   }
@@ -976,9 +1012,10 @@ class LibClang {
   CXSourceLocation clang_getDiagnosticLocation(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticLocation ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticLocation,
-        _dart_clang_getDiagnosticLocation>('clang_getDiagnosticLocation'))(
+    return (_clang_getDiagnosticLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticLocation>>(
+                'clang_getDiagnosticLocation')
+            .asFunction<_dart_clang_getDiagnosticLocation>())(
       arg0,
     );
   }
@@ -989,9 +1026,10 @@ class LibClang {
   CXString clang_getDiagnosticSpelling(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticSpelling ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticSpelling,
-        _dart_clang_getDiagnosticSpelling>('clang_getDiagnosticSpelling'))(
+    return (_clang_getDiagnosticSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticSpelling>>(
+                'clang_getDiagnosticSpelling')
+            .asFunction<_dart_clang_getDiagnosticSpelling>())(
       arg0,
     );
   }
@@ -1012,9 +1050,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diag,
     ffi.Pointer<CXString> Disable,
   ) {
-    return (_clang_getDiagnosticOption ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticOption,
-        _dart_clang_getDiagnosticOption>('clang_getDiagnosticOption'))(
+    return (_clang_getDiagnosticOption ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticOption>>(
+                'clang_getDiagnosticOption')
+            .asFunction<_dart_clang_getDiagnosticOption>())(
       Diag,
       Disable,
     );
@@ -1033,9 +1072,10 @@ class LibClang {
   int clang_getDiagnosticCategory(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticCategory ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticCategory,
-        _dart_clang_getDiagnosticCategory>('clang_getDiagnosticCategory'))(
+    return (_clang_getDiagnosticCategory ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticCategory>>(
+                'clang_getDiagnosticCategory')
+            .asFunction<_dart_clang_getDiagnosticCategory>())(
       arg0,
     );
   }
@@ -1053,10 +1093,10 @@ class LibClang {
   CXString clang_getDiagnosticCategoryName(
     int Category,
   ) {
-    return (_clang_getDiagnosticCategoryName ??= _dylib.lookupFunction<
-            _c_clang_getDiagnosticCategoryName,
-            _dart_clang_getDiagnosticCategoryName>(
-        'clang_getDiagnosticCategoryName'))(
+    return (_clang_getDiagnosticCategoryName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticCategoryName>>(
+                'clang_getDiagnosticCategoryName')
+            .asFunction<_dart_clang_getDiagnosticCategoryName>())(
       Category,
     );
   }
@@ -1069,10 +1109,10 @@ class LibClang {
   CXString clang_getDiagnosticCategoryText(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticCategoryText ??= _dylib.lookupFunction<
-            _c_clang_getDiagnosticCategoryText,
-            _dart_clang_getDiagnosticCategoryText>(
-        'clang_getDiagnosticCategoryText'))(
+    return (_clang_getDiagnosticCategoryText ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticCategoryText>>(
+                'clang_getDiagnosticCategoryText')
+            .asFunction<_dart_clang_getDiagnosticCategoryText>())(
       arg0,
     );
   }
@@ -1084,9 +1124,10 @@ class LibClang {
   int clang_getDiagnosticNumRanges(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticNumRanges ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticNumRanges,
-        _dart_clang_getDiagnosticNumRanges>('clang_getDiagnosticNumRanges'))(
+    return (_clang_getDiagnosticNumRanges ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticNumRanges>>(
+                'clang_getDiagnosticNumRanges')
+            .asFunction<_dart_clang_getDiagnosticNumRanges>())(
       arg0,
     );
   }
@@ -1108,9 +1149,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diagnostic,
     int Range,
   ) {
-    return (_clang_getDiagnosticRange ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticRange,
-        _dart_clang_getDiagnosticRange>('clang_getDiagnosticRange'))(
+    return (_clang_getDiagnosticRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticRange>>(
+                'clang_getDiagnosticRange')
+            .asFunction<_dart_clang_getDiagnosticRange>())(
       Diagnostic,
       Range,
     );
@@ -1123,9 +1165,10 @@ class LibClang {
   int clang_getDiagnosticNumFixIts(
     ffi.Pointer<ffi.Void> Diagnostic,
   ) {
-    return (_clang_getDiagnosticNumFixIts ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticNumFixIts,
-        _dart_clang_getDiagnosticNumFixIts>('clang_getDiagnosticNumFixIts'))(
+    return (_clang_getDiagnosticNumFixIts ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticNumFixIts>>(
+                'clang_getDiagnosticNumFixIts')
+            .asFunction<_dart_clang_getDiagnosticNumFixIts>())(
       Diagnostic,
     );
   }
@@ -1160,9 +1203,10 @@ class LibClang {
     int FixIt,
     ffi.Pointer<CXSourceRange> ReplacementRange,
   ) {
-    return (_clang_getDiagnosticFixIt ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticFixIt,
-        _dart_clang_getDiagnosticFixIt>('clang_getDiagnosticFixIt'))(
+    return (_clang_getDiagnosticFixIt ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticFixIt>>(
+                'clang_getDiagnosticFixIt')
+            .asFunction<_dart_clang_getDiagnosticFixIt>())(
       Diagnostic,
       FixIt,
       ReplacementRange,
@@ -1175,10 +1219,10 @@ class LibClang {
   CXString clang_getTranslationUnitSpelling(
     ffi.Pointer<CXTranslationUnitImpl> CTUnit,
   ) {
-    return (_clang_getTranslationUnitSpelling ??= _dylib.lookupFunction<
-            _c_clang_getTranslationUnitSpelling,
-            _dart_clang_getTranslationUnitSpelling>(
-        'clang_getTranslationUnitSpelling'))(
+    return (_clang_getTranslationUnitSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTranslationUnitSpelling>>(
+                'clang_getTranslationUnitSpelling')
+            .asFunction<_dart_clang_getTranslationUnitSpelling>())(
       CTUnit,
     );
   }
@@ -1231,10 +1275,11 @@ class LibClang {
     int num_unsaved_files,
     ffi.Pointer<CXUnsavedFile> unsaved_files,
   ) {
-    return (_clang_createTranslationUnitFromSourceFile ??=
-        _dylib.lookupFunction<_c_clang_createTranslationUnitFromSourceFile,
-                _dart_clang_createTranslationUnitFromSourceFile>(
-            'clang_createTranslationUnitFromSourceFile'))(
+    return (_clang_createTranslationUnitFromSourceFile ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_createTranslationUnitFromSourceFile>>(
+            'clang_createTranslationUnitFromSourceFile')
+        .asFunction<_dart_clang_createTranslationUnitFromSourceFile>())(
       CIdx,
       source_filename,
       num_clang_command_line_args,
@@ -1255,9 +1300,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> CIdx,
     ffi.Pointer<ffi.Int8> ast_filename,
   ) {
-    return (_clang_createTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_createTranslationUnit,
-        _dart_clang_createTranslationUnit>('clang_createTranslationUnit'))(
+    return (_clang_createTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_createTranslationUnit>>(
+                'clang_createTranslationUnit')
+            .asFunction<_dart_clang_createTranslationUnit>())(
       CIdx,
       ast_filename,
     );
@@ -1276,9 +1322,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> ast_filename,
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
   ) {
-    return (_clang_createTranslationUnit2 ??= _dylib.lookupFunction<
-        _c_clang_createTranslationUnit2,
-        _dart_clang_createTranslationUnit2>('clang_createTranslationUnit2'))(
+    return (_clang_createTranslationUnit2 ??=
+        _lookup<ffi.NativeFunction<_c_clang_createTranslationUnit2>>(
+                'clang_createTranslationUnit2')
+            .asFunction<_dart_clang_createTranslationUnit2>())(
       CIdx,
       ast_filename,
       out_TU,
@@ -1298,10 +1345,11 @@ class LibClang {
   /// preamble) geared toward improving the performance of these routines. The
   /// set of optimizations enabled may change from one version to the next.
   int clang_defaultEditingTranslationUnitOptions() {
-    return (_clang_defaultEditingTranslationUnitOptions ??=
-        _dylib.lookupFunction<_c_clang_defaultEditingTranslationUnitOptions,
-                _dart_clang_defaultEditingTranslationUnitOptions>(
-            'clang_defaultEditingTranslationUnitOptions'))();
+    return (_clang_defaultEditingTranslationUnitOptions ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_defaultEditingTranslationUnitOptions>>(
+            'clang_defaultEditingTranslationUnitOptions')
+        .asFunction<_dart_clang_defaultEditingTranslationUnitOptions>())();
   }
 
   _dart_clang_defaultEditingTranslationUnitOptions?
@@ -1320,9 +1368,10 @@ class LibClang {
     int num_unsaved_files,
     int options,
   ) {
-    return (_clang_parseTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_parseTranslationUnit,
-        _dart_clang_parseTranslationUnit>('clang_parseTranslationUnit'))(
+    return (_clang_parseTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_parseTranslationUnit>>(
+                'clang_parseTranslationUnit')
+            .asFunction<_dart_clang_parseTranslationUnit>())(
       CIdx,
       source_filename,
       command_line_args,
@@ -1387,9 +1436,10 @@ class LibClang {
     int options,
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
   ) {
-    return (_clang_parseTranslationUnit2 ??= _dylib.lookupFunction<
-        _c_clang_parseTranslationUnit2,
-        _dart_clang_parseTranslationUnit2>('clang_parseTranslationUnit2'))(
+    return (_clang_parseTranslationUnit2 ??=
+        _lookup<ffi.NativeFunction<_c_clang_parseTranslationUnit2>>(
+                'clang_parseTranslationUnit2')
+            .asFunction<_dart_clang_parseTranslationUnit2>())(
       CIdx,
       source_filename,
       command_line_args,
@@ -1416,10 +1466,10 @@ class LibClang {
     int options,
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
   ) {
-    return (_clang_parseTranslationUnit2FullArgv ??= _dylib.lookupFunction<
-            _c_clang_parseTranslationUnit2FullArgv,
-            _dart_clang_parseTranslationUnit2FullArgv>(
-        'clang_parseTranslationUnit2FullArgv'))(
+    return (_clang_parseTranslationUnit2FullArgv ??=
+        _lookup<ffi.NativeFunction<_c_clang_parseTranslationUnit2FullArgv>>(
+                'clang_parseTranslationUnit2FullArgv')
+            .asFunction<_dart_clang_parseTranslationUnit2FullArgv>())(
       CIdx,
       source_filename,
       command_line_args,
@@ -1444,9 +1494,10 @@ class LibClang {
   int clang_defaultSaveOptions(
     ffi.Pointer<CXTranslationUnitImpl> TU,
   ) {
-    return (_clang_defaultSaveOptions ??= _dylib.lookupFunction<
-        _c_clang_defaultSaveOptions,
-        _dart_clang_defaultSaveOptions>('clang_defaultSaveOptions'))(
+    return (_clang_defaultSaveOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultSaveOptions>>(
+                'clang_defaultSaveOptions')
+            .asFunction<_dart_clang_defaultSaveOptions>())(
       TU,
     );
   }
@@ -1479,9 +1530,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> FileName,
     int options,
   ) {
-    return (_clang_saveTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_saveTranslationUnit,
-        _dart_clang_saveTranslationUnit>('clang_saveTranslationUnit'))(
+    return (_clang_saveTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_saveTranslationUnit>>(
+                'clang_saveTranslationUnit')
+            .asFunction<_dart_clang_saveTranslationUnit>())(
       TU,
       FileName,
       options,
@@ -1498,9 +1550,10 @@ class LibClang {
   int clang_suspendTranslationUnit(
     ffi.Pointer<CXTranslationUnitImpl> arg0,
   ) {
-    return (_clang_suspendTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_suspendTranslationUnit,
-        _dart_clang_suspendTranslationUnit>('clang_suspendTranslationUnit'))(
+    return (_clang_suspendTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_suspendTranslationUnit>>(
+                'clang_suspendTranslationUnit')
+            .asFunction<_dart_clang_suspendTranslationUnit>())(
       arg0,
     );
   }
@@ -1511,9 +1564,10 @@ class LibClang {
   void clang_disposeTranslationUnit(
     ffi.Pointer<CXTranslationUnitImpl> arg0,
   ) {
-    return (_clang_disposeTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_disposeTranslationUnit,
-        _dart_clang_disposeTranslationUnit>('clang_disposeTranslationUnit'))(
+    return (_clang_disposeTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeTranslationUnit>>(
+                'clang_disposeTranslationUnit')
+            .asFunction<_dart_clang_disposeTranslationUnit>())(
       arg0,
     );
   }
@@ -1531,9 +1585,10 @@ class LibClang {
   int clang_defaultReparseOptions(
     ffi.Pointer<CXTranslationUnitImpl> TU,
   ) {
-    return (_clang_defaultReparseOptions ??= _dylib.lookupFunction<
-        _c_clang_defaultReparseOptions,
-        _dart_clang_defaultReparseOptions>('clang_defaultReparseOptions'))(
+    return (_clang_defaultReparseOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultReparseOptions>>(
+                'clang_defaultReparseOptions')
+            .asFunction<_dart_clang_defaultReparseOptions>())(
       TU,
     );
   }
@@ -1583,9 +1638,10 @@ class LibClang {
     ffi.Pointer<CXUnsavedFile> unsaved_files,
     int options,
   ) {
-    return (_clang_reparseTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_reparseTranslationUnit,
-        _dart_clang_reparseTranslationUnit>('clang_reparseTranslationUnit'))(
+    return (_clang_reparseTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_reparseTranslationUnit>>(
+                'clang_reparseTranslationUnit')
+            .asFunction<_dart_clang_reparseTranslationUnit>())(
       TU,
       num_unsaved_files,
       unsaved_files,
@@ -1600,9 +1656,10 @@ class LibClang {
   ffi.Pointer<ffi.Int8> clang_getTUResourceUsageName(
     int kind,
   ) {
-    return (_clang_getTUResourceUsageName ??= _dylib.lookupFunction<
-        _c_clang_getTUResourceUsageName,
-        _dart_clang_getTUResourceUsageName>('clang_getTUResourceUsageName'))(
+    return (_clang_getTUResourceUsageName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTUResourceUsageName>>(
+                'clang_getTUResourceUsageName')
+            .asFunction<_dart_clang_getTUResourceUsageName>())(
       kind,
     );
   }
@@ -1614,9 +1671,10 @@ class LibClang {
   CXTUResourceUsage clang_getCXTUResourceUsage(
     ffi.Pointer<CXTranslationUnitImpl> TU,
   ) {
-    return (_clang_getCXTUResourceUsage ??= _dylib.lookupFunction<
-        _c_clang_getCXTUResourceUsage,
-        _dart_clang_getCXTUResourceUsage>('clang_getCXTUResourceUsage'))(
+    return (_clang_getCXTUResourceUsage ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCXTUResourceUsage>>(
+                'clang_getCXTUResourceUsage')
+            .asFunction<_dart_clang_getCXTUResourceUsage>())(
       TU,
     );
   }
@@ -1626,10 +1684,10 @@ class LibClang {
   void clang_disposeCXTUResourceUsage(
     CXTUResourceUsage usage,
   ) {
-    return (_clang_disposeCXTUResourceUsage ??= _dylib.lookupFunction<
-            _c_clang_disposeCXTUResourceUsage,
-            _dart_clang_disposeCXTUResourceUsage>(
-        'clang_disposeCXTUResourceUsage'))(
+    return (_clang_disposeCXTUResourceUsage ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCXTUResourceUsage>>(
+                'clang_disposeCXTUResourceUsage')
+            .asFunction<_dart_clang_disposeCXTUResourceUsage>())(
       usage,
     );
   }
@@ -1642,10 +1700,10 @@ class LibClang {
   ffi.Pointer<CXTargetInfoImpl> clang_getTranslationUnitTargetInfo(
     ffi.Pointer<CXTranslationUnitImpl> CTUnit,
   ) {
-    return (_clang_getTranslationUnitTargetInfo ??= _dylib.lookupFunction<
-            _c_clang_getTranslationUnitTargetInfo,
-            _dart_clang_getTranslationUnitTargetInfo>(
-        'clang_getTranslationUnitTargetInfo'))(
+    return (_clang_getTranslationUnitTargetInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTranslationUnitTargetInfo>>(
+                'clang_getTranslationUnitTargetInfo')
+            .asFunction<_dart_clang_getTranslationUnitTargetInfo>())(
       CTUnit,
     );
   }
@@ -1656,9 +1714,10 @@ class LibClang {
   void clang_TargetInfo_dispose(
     ffi.Pointer<CXTargetInfoImpl> Info,
   ) {
-    return (_clang_TargetInfo_dispose ??= _dylib.lookupFunction<
-        _c_clang_TargetInfo_dispose,
-        _dart_clang_TargetInfo_dispose>('clang_TargetInfo_dispose'))(
+    return (_clang_TargetInfo_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_TargetInfo_dispose>>(
+                'clang_TargetInfo_dispose')
+            .asFunction<_dart_clang_TargetInfo_dispose>())(
       Info,
     );
   }
@@ -1671,9 +1730,10 @@ class LibClang {
   CXString clang_TargetInfo_getTriple(
     ffi.Pointer<CXTargetInfoImpl> Info,
   ) {
-    return (_clang_TargetInfo_getTriple ??= _dylib.lookupFunction<
-        _c_clang_TargetInfo_getTriple,
-        _dart_clang_TargetInfo_getTriple>('clang_TargetInfo_getTriple'))(
+    return (_clang_TargetInfo_getTriple ??=
+        _lookup<ffi.NativeFunction<_c_clang_TargetInfo_getTriple>>(
+                'clang_TargetInfo_getTriple')
+            .asFunction<_dart_clang_TargetInfo_getTriple>())(
       Info,
     );
   }
@@ -1686,10 +1746,10 @@ class LibClang {
   int clang_TargetInfo_getPointerWidth(
     ffi.Pointer<CXTargetInfoImpl> Info,
   ) {
-    return (_clang_TargetInfo_getPointerWidth ??= _dylib.lookupFunction<
-            _c_clang_TargetInfo_getPointerWidth,
-            _dart_clang_TargetInfo_getPointerWidth>(
-        'clang_TargetInfo_getPointerWidth'))(
+    return (_clang_TargetInfo_getPointerWidth ??=
+        _lookup<ffi.NativeFunction<_c_clang_TargetInfo_getPointerWidth>>(
+                'clang_TargetInfo_getPointerWidth')
+            .asFunction<_dart_clang_TargetInfo_getPointerWidth>())(
       Info,
     );
   }
@@ -1698,9 +1758,10 @@ class LibClang {
 
   /// Retrieve the NULL cursor, which represents no entity.
   CXCursor clang_getNullCursor() {
-    return (_clang_getNullCursor ??= _dylib.lookupFunction<
-        _c_clang_getNullCursor,
-        _dart_clang_getNullCursor>('clang_getNullCursor'))();
+    return (_clang_getNullCursor ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNullCursor>>(
+                'clang_getNullCursor')
+            .asFunction<_dart_clang_getNullCursor>())();
   }
 
   _dart_clang_getNullCursor? _clang_getNullCursor;
@@ -1712,10 +1773,10 @@ class LibClang {
   CXCursor clang_getTranslationUnitCursor(
     ffi.Pointer<CXTranslationUnitImpl> arg0,
   ) {
-    return (_clang_getTranslationUnitCursor ??= _dylib.lookupFunction<
-            _c_clang_getTranslationUnitCursor,
-            _dart_clang_getTranslationUnitCursor>(
-        'clang_getTranslationUnitCursor'))(
+    return (_clang_getTranslationUnitCursor ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTranslationUnitCursor>>(
+                'clang_getTranslationUnitCursor')
+            .asFunction<_dart_clang_getTranslationUnitCursor>())(
       arg0,
     );
   }
@@ -1728,8 +1789,8 @@ class LibClang {
     CXCursor arg1,
   ) {
     return (_clang_equalCursors ??=
-        _dylib.lookupFunction<_c_clang_equalCursors, _dart_clang_equalCursors>(
-            'clang_equalCursors'))(
+        _lookup<ffi.NativeFunction<_c_clang_equalCursors>>('clang_equalCursors')
+            .asFunction<_dart_clang_equalCursors>())(
       arg0,
       arg1,
     );
@@ -1741,9 +1802,10 @@ class LibClang {
   int clang_Cursor_isNull(
     CXCursor cursor,
   ) {
-    return (_clang_Cursor_isNull ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isNull,
-        _dart_clang_Cursor_isNull>('clang_Cursor_isNull'))(
+    return (_clang_Cursor_isNull ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isNull>>(
+                'clang_Cursor_isNull')
+            .asFunction<_dart_clang_Cursor_isNull>())(
       cursor,
     );
   }
@@ -1755,8 +1817,8 @@ class LibClang {
     CXCursor arg0,
   ) {
     return (_clang_hashCursor ??=
-        _dylib.lookupFunction<_c_clang_hashCursor, _dart_clang_hashCursor>(
-            'clang_hashCursor'))(
+        _lookup<ffi.NativeFunction<_c_clang_hashCursor>>('clang_hashCursor')
+            .asFunction<_dart_clang_hashCursor>())(
       arg0,
     );
   }
@@ -1767,9 +1829,10 @@ class LibClang {
   int clang_getCursorKind(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorKind ??= _dylib.lookupFunction<
-        _c_clang_getCursorKind,
-        _dart_clang_getCursorKind>('clang_getCursorKind'))(
+    return (_clang_getCursorKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorKind>>(
+                'clang_getCursorKind')
+            .asFunction<_dart_clang_getCursorKind>())(
       arg0,
     );
   }
@@ -1780,9 +1843,10 @@ class LibClang {
   int clang_isDeclaration(
     int arg0,
   ) {
-    return (_clang_isDeclaration ??= _dylib.lookupFunction<
-        _c_clang_isDeclaration,
-        _dart_clang_isDeclaration>('clang_isDeclaration'))(
+    return (_clang_isDeclaration ??=
+        _lookup<ffi.NativeFunction<_c_clang_isDeclaration>>(
+                'clang_isDeclaration')
+            .asFunction<_dart_clang_isDeclaration>())(
       arg0,
     );
   }
@@ -1798,9 +1862,10 @@ class LibClang {
   int clang_isInvalidDeclaration(
     CXCursor arg0,
   ) {
-    return (_clang_isInvalidDeclaration ??= _dylib.lookupFunction<
-        _c_clang_isInvalidDeclaration,
-        _dart_clang_isInvalidDeclaration>('clang_isInvalidDeclaration'))(
+    return (_clang_isInvalidDeclaration ??=
+        _lookup<ffi.NativeFunction<_c_clang_isInvalidDeclaration>>(
+                'clang_isInvalidDeclaration')
+            .asFunction<_dart_clang_isInvalidDeclaration>())(
       arg0,
     );
   }
@@ -1817,8 +1882,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isReference ??=
-        _dylib.lookupFunction<_c_clang_isReference, _dart_clang_isReference>(
-            'clang_isReference'))(
+        _lookup<ffi.NativeFunction<_c_clang_isReference>>('clang_isReference')
+            .asFunction<_dart_clang_isReference>())(
       arg0,
     );
   }
@@ -1830,8 +1895,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isExpression ??=
-        _dylib.lookupFunction<_c_clang_isExpression, _dart_clang_isExpression>(
-            'clang_isExpression'))(
+        _lookup<ffi.NativeFunction<_c_clang_isExpression>>('clang_isExpression')
+            .asFunction<_dart_clang_isExpression>())(
       arg0,
     );
   }
@@ -1843,8 +1908,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isStatement ??=
-        _dylib.lookupFunction<_c_clang_isStatement, _dart_clang_isStatement>(
-            'clang_isStatement'))(
+        _lookup<ffi.NativeFunction<_c_clang_isStatement>>('clang_isStatement')
+            .asFunction<_dart_clang_isStatement>())(
       arg0,
     );
   }
@@ -1856,8 +1921,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isAttribute ??=
-        _dylib.lookupFunction<_c_clang_isAttribute, _dart_clang_isAttribute>(
-            'clang_isAttribute'))(
+        _lookup<ffi.NativeFunction<_c_clang_isAttribute>>('clang_isAttribute')
+            .asFunction<_dart_clang_isAttribute>())(
       arg0,
     );
   }
@@ -1868,9 +1933,10 @@ class LibClang {
   int clang_Cursor_hasAttrs(
     CXCursor C,
   ) {
-    return (_clang_Cursor_hasAttrs ??= _dylib.lookupFunction<
-        _c_clang_Cursor_hasAttrs,
-        _dart_clang_Cursor_hasAttrs>('clang_Cursor_hasAttrs'))(
+    return (_clang_Cursor_hasAttrs ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_hasAttrs>>(
+                'clang_Cursor_hasAttrs')
+            .asFunction<_dart_clang_Cursor_hasAttrs>())(
       C,
     );
   }
@@ -1883,8 +1949,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isInvalid ??=
-        _dylib.lookupFunction<_c_clang_isInvalid, _dart_clang_isInvalid>(
-            'clang_isInvalid'))(
+        _lookup<ffi.NativeFunction<_c_clang_isInvalid>>('clang_isInvalid')
+            .asFunction<_dart_clang_isInvalid>())(
       arg0,
     );
   }
@@ -1896,9 +1962,10 @@ class LibClang {
   int clang_isTranslationUnit(
     int arg0,
   ) {
-    return (_clang_isTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_isTranslationUnit,
-        _dart_clang_isTranslationUnit>('clang_isTranslationUnit'))(
+    return (_clang_isTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_isTranslationUnit>>(
+                'clang_isTranslationUnit')
+            .asFunction<_dart_clang_isTranslationUnit>())(
       arg0,
     );
   }
@@ -1910,9 +1977,10 @@ class LibClang {
   int clang_isPreprocessing(
     int arg0,
   ) {
-    return (_clang_isPreprocessing ??= _dylib.lookupFunction<
-        _c_clang_isPreprocessing,
-        _dart_clang_isPreprocessing>('clang_isPreprocessing'))(
+    return (_clang_isPreprocessing ??=
+        _lookup<ffi.NativeFunction<_c_clang_isPreprocessing>>(
+                'clang_isPreprocessing')
+            .asFunction<_dart_clang_isPreprocessing>())(
       arg0,
     );
   }
@@ -1925,8 +1993,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isUnexposed ??=
-        _dylib.lookupFunction<_c_clang_isUnexposed, _dart_clang_isUnexposed>(
-            'clang_isUnexposed'))(
+        _lookup<ffi.NativeFunction<_c_clang_isUnexposed>>('clang_isUnexposed')
+            .asFunction<_dart_clang_isUnexposed>())(
       arg0,
     );
   }
@@ -1937,9 +2005,10 @@ class LibClang {
   int clang_getCursorLinkage(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorLinkage ??= _dylib.lookupFunction<
-        _c_clang_getCursorLinkage,
-        _dart_clang_getCursorLinkage>('clang_getCursorLinkage'))(
+    return (_clang_getCursorLinkage ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLinkage>>(
+                'clang_getCursorLinkage')
+            .asFunction<_dart_clang_getCursorLinkage>())(
       cursor,
     );
   }
@@ -1958,9 +2027,10 @@ class LibClang {
   int clang_getCursorVisibility(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorVisibility ??= _dylib.lookupFunction<
-        _c_clang_getCursorVisibility,
-        _dart_clang_getCursorVisibility>('clang_getCursorVisibility'))(
+    return (_clang_getCursorVisibility ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorVisibility>>(
+                'clang_getCursorVisibility')
+            .asFunction<_dart_clang_getCursorVisibility>())(
       cursor,
     );
   }
@@ -1976,9 +2046,10 @@ class LibClang {
   int clang_getCursorAvailability(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorAvailability ??= _dylib.lookupFunction<
-        _c_clang_getCursorAvailability,
-        _dart_clang_getCursorAvailability>('clang_getCursorAvailability'))(
+    return (_clang_getCursorAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorAvailability>>(
+                'clang_getCursorAvailability')
+            .asFunction<_dart_clang_getCursorAvailability>())(
       cursor,
     );
   }
@@ -2028,10 +2099,10 @@ class LibClang {
     ffi.Pointer<CXPlatformAvailability> availability,
     int availability_size,
   ) {
-    return (_clang_getCursorPlatformAvailability ??= _dylib.lookupFunction<
-            _c_clang_getCursorPlatformAvailability,
-            _dart_clang_getCursorPlatformAvailability>(
-        'clang_getCursorPlatformAvailability'))(
+    return (_clang_getCursorPlatformAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorPlatformAvailability>>(
+                'clang_getCursorPlatformAvailability')
+            .asFunction<_dart_clang_getCursorPlatformAvailability>())(
       cursor,
       always_deprecated,
       deprecated_message,
@@ -2049,10 +2120,10 @@ class LibClang {
   void clang_disposeCXPlatformAvailability(
     ffi.Pointer<CXPlatformAvailability> availability,
   ) {
-    return (_clang_disposeCXPlatformAvailability ??= _dylib.lookupFunction<
-            _c_clang_disposeCXPlatformAvailability,
-            _dart_clang_disposeCXPlatformAvailability>(
-        'clang_disposeCXPlatformAvailability'))(
+    return (_clang_disposeCXPlatformAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCXPlatformAvailability>>(
+                'clang_disposeCXPlatformAvailability')
+            .asFunction<_dart_clang_disposeCXPlatformAvailability>())(
       availability,
     );
   }
@@ -2064,9 +2135,10 @@ class LibClang {
   int clang_getCursorLanguage(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorLanguage ??= _dylib.lookupFunction<
-        _c_clang_getCursorLanguage,
-        _dart_clang_getCursorLanguage>('clang_getCursorLanguage'))(
+    return (_clang_getCursorLanguage ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLanguage>>(
+                'clang_getCursorLanguage')
+            .asFunction<_dart_clang_getCursorLanguage>())(
       cursor,
     );
   }
@@ -2078,9 +2150,10 @@ class LibClang {
   int clang_getCursorTLSKind(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorTLSKind ??= _dylib.lookupFunction<
-        _c_clang_getCursorTLSKind,
-        _dart_clang_getCursorTLSKind>('clang_getCursorTLSKind'))(
+    return (_clang_getCursorTLSKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorTLSKind>>(
+                'clang_getCursorTLSKind')
+            .asFunction<_dart_clang_getCursorTLSKind>())(
       cursor,
     );
   }
@@ -2091,10 +2164,10 @@ class LibClang {
   ffi.Pointer<CXTranslationUnitImpl> clang_Cursor_getTranslationUnit(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getTranslationUnit ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTranslationUnit,
-            _dart_clang_Cursor_getTranslationUnit>(
-        'clang_Cursor_getTranslationUnit'))(
+    return (_clang_Cursor_getTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTranslationUnit>>(
+                'clang_Cursor_getTranslationUnit')
+            .asFunction<_dart_clang_Cursor_getTranslationUnit>())(
       arg0,
     );
   }
@@ -2103,9 +2176,10 @@ class LibClang {
 
   /// Creates an empty CXCursorSet.
   ffi.Pointer<CXCursorSetImpl> clang_createCXCursorSet() {
-    return (_clang_createCXCursorSet ??= _dylib.lookupFunction<
-        _c_clang_createCXCursorSet,
-        _dart_clang_createCXCursorSet>('clang_createCXCursorSet'))();
+    return (_clang_createCXCursorSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_createCXCursorSet>>(
+                'clang_createCXCursorSet')
+            .asFunction<_dart_clang_createCXCursorSet>())();
   }
 
   _dart_clang_createCXCursorSet? _clang_createCXCursorSet;
@@ -2114,9 +2188,10 @@ class LibClang {
   void clang_disposeCXCursorSet(
     ffi.Pointer<CXCursorSetImpl> cset,
   ) {
-    return (_clang_disposeCXCursorSet ??= _dylib.lookupFunction<
-        _c_clang_disposeCXCursorSet,
-        _dart_clang_disposeCXCursorSet>('clang_disposeCXCursorSet'))(
+    return (_clang_disposeCXCursorSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCXCursorSet>>(
+                'clang_disposeCXCursorSet')
+            .asFunction<_dart_clang_disposeCXCursorSet>())(
       cset,
     );
   }
@@ -2130,9 +2205,10 @@ class LibClang {
     ffi.Pointer<CXCursorSetImpl> cset,
     CXCursor cursor,
   ) {
-    return (_clang_CXCursorSet_contains ??= _dylib.lookupFunction<
-        _c_clang_CXCursorSet_contains,
-        _dart_clang_CXCursorSet_contains>('clang_CXCursorSet_contains'))(
+    return (_clang_CXCursorSet_contains ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXCursorSet_contains>>(
+                'clang_CXCursorSet_contains')
+            .asFunction<_dart_clang_CXCursorSet_contains>())(
       cset,
       cursor,
     );
@@ -2147,9 +2223,10 @@ class LibClang {
     ffi.Pointer<CXCursorSetImpl> cset,
     CXCursor cursor,
   ) {
-    return (_clang_CXCursorSet_insert ??= _dylib.lookupFunction<
-        _c_clang_CXCursorSet_insert,
-        _dart_clang_CXCursorSet_insert>('clang_CXCursorSet_insert'))(
+    return (_clang_CXCursorSet_insert ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXCursorSet_insert>>(
+                'clang_CXCursorSet_insert')
+            .asFunction<_dart_clang_CXCursorSet_insert>())(
       cset,
       cursor,
     );
@@ -2191,9 +2268,10 @@ class LibClang {
   CXCursor clang_getCursorSemanticParent(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorSemanticParent ??= _dylib.lookupFunction<
-        _c_clang_getCursorSemanticParent,
-        _dart_clang_getCursorSemanticParent>('clang_getCursorSemanticParent'))(
+    return (_clang_getCursorSemanticParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorSemanticParent>>(
+                'clang_getCursorSemanticParent')
+            .asFunction<_dart_clang_getCursorSemanticParent>())(
       cursor,
     );
   }
@@ -2235,9 +2313,10 @@ class LibClang {
   CXCursor clang_getCursorLexicalParent(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorLexicalParent ??= _dylib.lookupFunction<
-        _c_clang_getCursorLexicalParent,
-        _dart_clang_getCursorLexicalParent>('clang_getCursorLexicalParent'))(
+    return (_clang_getCursorLexicalParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLexicalParent>>(
+                'clang_getCursorLexicalParent')
+            .asFunction<_dart_clang_getCursorLexicalParent>())(
       cursor,
     );
   }
@@ -2290,9 +2369,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<CXCursor>> overridden,
     ffi.Pointer<ffi.Uint32> num_overridden,
   ) {
-    return (_clang_getOverriddenCursors ??= _dylib.lookupFunction<
-        _c_clang_getOverriddenCursors,
-        _dart_clang_getOverriddenCursors>('clang_getOverriddenCursors'))(
+    return (_clang_getOverriddenCursors ??=
+        _lookup<ffi.NativeFunction<_c_clang_getOverriddenCursors>>(
+                'clang_getOverriddenCursors')
+            .asFunction<_dart_clang_getOverriddenCursors>())(
       cursor,
       overridden,
       num_overridden,
@@ -2306,10 +2386,10 @@ class LibClang {
   void clang_disposeOverriddenCursors(
     ffi.Pointer<CXCursor> overridden,
   ) {
-    return (_clang_disposeOverriddenCursors ??= _dylib.lookupFunction<
-            _c_clang_disposeOverriddenCursors,
-            _dart_clang_disposeOverriddenCursors>(
-        'clang_disposeOverriddenCursors'))(
+    return (_clang_disposeOverriddenCursors ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeOverriddenCursors>>(
+                'clang_disposeOverriddenCursors')
+            .asFunction<_dart_clang_disposeOverriddenCursors>())(
       overridden,
     );
   }
@@ -2321,9 +2401,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getIncludedFile(
     CXCursor cursor,
   ) {
-    return (_clang_getIncludedFile ??= _dylib.lookupFunction<
-        _c_clang_getIncludedFile,
-        _dart_clang_getIncludedFile>('clang_getIncludedFile'))(
+    return (_clang_getIncludedFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_getIncludedFile>>(
+                'clang_getIncludedFile')
+            .asFunction<_dart_clang_getIncludedFile>())(
       cursor,
     );
   }
@@ -2348,8 +2429,8 @@ class LibClang {
     CXSourceLocation arg1,
   ) {
     return (_clang_getCursor ??=
-        _dylib.lookupFunction<_c_clang_getCursor, _dart_clang_getCursor>(
-            'clang_getCursor'))(
+        _lookup<ffi.NativeFunction<_c_clang_getCursor>>('clang_getCursor')
+            .asFunction<_dart_clang_getCursor>())(
       arg0,
       arg1,
     );
@@ -2368,9 +2449,10 @@ class LibClang {
   CXSourceLocation clang_getCursorLocation(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorLocation ??= _dylib.lookupFunction<
-        _c_clang_getCursorLocation,
-        _dart_clang_getCursorLocation>('clang_getCursorLocation'))(
+    return (_clang_getCursorLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLocation>>(
+                'clang_getCursorLocation')
+            .asFunction<_dart_clang_getCursorLocation>())(
       arg0,
     );
   }
@@ -2389,9 +2471,10 @@ class LibClang {
   CXSourceRange clang_getCursorExtent(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorExtent ??= _dylib.lookupFunction<
-        _c_clang_getCursorExtent,
-        _dart_clang_getCursorExtent>('clang_getCursorExtent'))(
+    return (_clang_getCursorExtent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorExtent>>(
+                'clang_getCursorExtent')
+            .asFunction<_dart_clang_getCursorExtent>())(
       arg0,
     );
   }
@@ -2402,9 +2485,10 @@ class LibClang {
   CXType clang_getCursorType(
     CXCursor C,
   ) {
-    return (_clang_getCursorType ??= _dylib.lookupFunction<
-        _c_clang_getCursorType,
-        _dart_clang_getCursorType>('clang_getCursorType'))(
+    return (_clang_getCursorType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorType>>(
+                'clang_getCursorType')
+            .asFunction<_dart_clang_getCursorType>())(
       C,
     );
   }
@@ -2418,9 +2502,10 @@ class LibClang {
   CXString clang_getTypeSpelling(
     CXType CT,
   ) {
-    return (_clang_getTypeSpelling ??= _dylib.lookupFunction<
-        _c_clang_getTypeSpelling,
-        _dart_clang_getTypeSpelling>('clang_getTypeSpelling'))(
+    return (_clang_getTypeSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypeSpelling>>(
+                'clang_getTypeSpelling')
+            .asFunction<_dart_clang_getTypeSpelling>())(
       CT,
     );
   }
@@ -2434,10 +2519,10 @@ class LibClang {
   CXType clang_getTypedefDeclUnderlyingType(
     CXCursor C,
   ) {
-    return (_clang_getTypedefDeclUnderlyingType ??= _dylib.lookupFunction<
-            _c_clang_getTypedefDeclUnderlyingType,
-            _dart_clang_getTypedefDeclUnderlyingType>(
-        'clang_getTypedefDeclUnderlyingType'))(
+    return (_clang_getTypedefDeclUnderlyingType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypedefDeclUnderlyingType>>(
+                'clang_getTypedefDeclUnderlyingType')
+            .asFunction<_dart_clang_getTypedefDeclUnderlyingType>())(
       C,
     );
   }
@@ -2451,9 +2536,10 @@ class LibClang {
   CXType clang_getEnumDeclIntegerType(
     CXCursor C,
   ) {
-    return (_clang_getEnumDeclIntegerType ??= _dylib.lookupFunction<
-        _c_clang_getEnumDeclIntegerType,
-        _dart_clang_getEnumDeclIntegerType>('clang_getEnumDeclIntegerType'))(
+    return (_clang_getEnumDeclIntegerType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getEnumDeclIntegerType>>(
+                'clang_getEnumDeclIntegerType')
+            .asFunction<_dart_clang_getEnumDeclIntegerType>())(
       C,
     );
   }
@@ -2469,10 +2555,10 @@ class LibClang {
   int clang_getEnumConstantDeclValue(
     CXCursor C,
   ) {
-    return (_clang_getEnumConstantDeclValue ??= _dylib.lookupFunction<
-            _c_clang_getEnumConstantDeclValue,
-            _dart_clang_getEnumConstantDeclValue>(
-        'clang_getEnumConstantDeclValue'))(
+    return (_clang_getEnumConstantDeclValue ??=
+        _lookup<ffi.NativeFunction<_c_clang_getEnumConstantDeclValue>>(
+                'clang_getEnumConstantDeclValue')
+            .asFunction<_dart_clang_getEnumConstantDeclValue>())(
       C,
     );
   }
@@ -2488,10 +2574,10 @@ class LibClang {
   int clang_getEnumConstantDeclUnsignedValue(
     CXCursor C,
   ) {
-    return (_clang_getEnumConstantDeclUnsignedValue ??= _dylib.lookupFunction<
-            _c_clang_getEnumConstantDeclUnsignedValue,
-            _dart_clang_getEnumConstantDeclUnsignedValue>(
-        'clang_getEnumConstantDeclUnsignedValue'))(
+    return (_clang_getEnumConstantDeclUnsignedValue ??=
+        _lookup<ffi.NativeFunction<_c_clang_getEnumConstantDeclUnsignedValue>>(
+                'clang_getEnumConstantDeclUnsignedValue')
+            .asFunction<_dart_clang_getEnumConstantDeclUnsignedValue>())(
       C,
     );
   }
@@ -2505,9 +2591,10 @@ class LibClang {
   int clang_getFieldDeclBitWidth(
     CXCursor C,
   ) {
-    return (_clang_getFieldDeclBitWidth ??= _dylib.lookupFunction<
-        _c_clang_getFieldDeclBitWidth,
-        _dart_clang_getFieldDeclBitWidth>('clang_getFieldDeclBitWidth'))(
+    return (_clang_getFieldDeclBitWidth ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFieldDeclBitWidth>>(
+                'clang_getFieldDeclBitWidth')
+            .asFunction<_dart_clang_getFieldDeclBitWidth>())(
       C,
     );
   }
@@ -2522,9 +2609,10 @@ class LibClang {
   int clang_Cursor_getNumArguments(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getNumArguments ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getNumArguments,
-        _dart_clang_Cursor_getNumArguments>('clang_Cursor_getNumArguments'))(
+    return (_clang_Cursor_getNumArguments ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getNumArguments>>(
+                'clang_Cursor_getNumArguments')
+            .asFunction<_dart_clang_Cursor_getNumArguments>())(
       C,
     );
   }
@@ -2540,9 +2628,10 @@ class LibClang {
     CXCursor C,
     int i,
   ) {
-    return (_clang_Cursor_getArgument ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getArgument,
-        _dart_clang_Cursor_getArgument>('clang_Cursor_getArgument'))(
+    return (_clang_Cursor_getArgument ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getArgument>>(
+                'clang_Cursor_getArgument')
+            .asFunction<_dart_clang_Cursor_getArgument>())(
       C,
       i,
     );
@@ -2567,10 +2656,10 @@ class LibClang {
   int clang_Cursor_getNumTemplateArguments(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getNumTemplateArguments ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getNumTemplateArguments,
-            _dart_clang_Cursor_getNumTemplateArguments>(
-        'clang_Cursor_getNumTemplateArguments'))(
+    return (_clang_Cursor_getNumTemplateArguments ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getNumTemplateArguments>>(
+                'clang_Cursor_getNumTemplateArguments')
+            .asFunction<_dart_clang_Cursor_getNumTemplateArguments>())(
       C,
     );
   }
@@ -2596,10 +2685,10 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentKind ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTemplateArgumentKind,
-            _dart_clang_Cursor_getTemplateArgumentKind>(
-        'clang_Cursor_getTemplateArgumentKind'))(
+    return (_clang_Cursor_getTemplateArgumentKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTemplateArgumentKind>>(
+                'clang_Cursor_getTemplateArgumentKind')
+            .asFunction<_dart_clang_Cursor_getTemplateArgumentKind>())(
       C,
       I,
     );
@@ -2628,10 +2717,10 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentType ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTemplateArgumentType,
-            _dart_clang_Cursor_getTemplateArgumentType>(
-        'clang_Cursor_getTemplateArgumentType'))(
+    return (_clang_Cursor_getTemplateArgumentType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTemplateArgumentType>>(
+                'clang_Cursor_getTemplateArgumentType')
+            .asFunction<_dart_clang_Cursor_getTemplateArgumentType>())(
       C,
       I,
     );
@@ -2659,10 +2748,10 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentValue ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTemplateArgumentValue,
-            _dart_clang_Cursor_getTemplateArgumentValue>(
-        'clang_Cursor_getTemplateArgumentValue'))(
+    return (_clang_Cursor_getTemplateArgumentValue ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTemplateArgumentValue>>(
+                'clang_Cursor_getTemplateArgumentValue')
+            .asFunction<_dart_clang_Cursor_getTemplateArgumentValue>())(
       C,
       I,
     );
@@ -2690,10 +2779,11 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentUnsignedValue ??=
-        _dylib.lookupFunction<_c_clang_Cursor_getTemplateArgumentUnsignedValue,
-                _dart_clang_Cursor_getTemplateArgumentUnsignedValue>(
-            'clang_Cursor_getTemplateArgumentUnsignedValue'))(
+    return (_clang_Cursor_getTemplateArgumentUnsignedValue ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_Cursor_getTemplateArgumentUnsignedValue>>(
+            'clang_Cursor_getTemplateArgumentUnsignedValue')
+        .asFunction<_dart_clang_Cursor_getTemplateArgumentUnsignedValue>())(
       C,
       I,
     );
@@ -2711,8 +2801,8 @@ class LibClang {
     CXType B,
   ) {
     return (_clang_equalTypes ??=
-        _dylib.lookupFunction<_c_clang_equalTypes, _dart_clang_equalTypes>(
-            'clang_equalTypes'))(
+        _lookup<ffi.NativeFunction<_c_clang_equalTypes>>('clang_equalTypes')
+            .asFunction<_dart_clang_equalTypes>())(
       A,
       B,
     );
@@ -2729,9 +2819,10 @@ class LibClang {
   CXType clang_getCanonicalType(
     CXType T,
   ) {
-    return (_clang_getCanonicalType ??= _dylib.lookupFunction<
-        _c_clang_getCanonicalType,
-        _dart_clang_getCanonicalType>('clang_getCanonicalType'))(
+    return (_clang_getCanonicalType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCanonicalType>>(
+                'clang_getCanonicalType')
+            .asFunction<_dart_clang_getCanonicalType>())(
       T,
     );
   }
@@ -2744,9 +2835,10 @@ class LibClang {
   int clang_isConstQualifiedType(
     CXType T,
   ) {
-    return (_clang_isConstQualifiedType ??= _dylib.lookupFunction<
-        _c_clang_isConstQualifiedType,
-        _dart_clang_isConstQualifiedType>('clang_isConstQualifiedType'))(
+    return (_clang_isConstQualifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_isConstQualifiedType>>(
+                'clang_isConstQualifiedType')
+            .asFunction<_dart_clang_isConstQualifiedType>())(
       T,
     );
   }
@@ -2758,10 +2850,10 @@ class LibClang {
   int clang_Cursor_isMacroFunctionLike(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isMacroFunctionLike ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isMacroFunctionLike,
-            _dart_clang_Cursor_isMacroFunctionLike>(
-        'clang_Cursor_isMacroFunctionLike'))(
+    return (_clang_Cursor_isMacroFunctionLike ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isMacroFunctionLike>>(
+                'clang_Cursor_isMacroFunctionLike')
+            .asFunction<_dart_clang_Cursor_isMacroFunctionLike>())(
       C,
     );
   }
@@ -2773,9 +2865,10 @@ class LibClang {
   int clang_Cursor_isMacroBuiltin(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isMacroBuiltin ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isMacroBuiltin,
-        _dart_clang_Cursor_isMacroBuiltin>('clang_Cursor_isMacroBuiltin'))(
+    return (_clang_Cursor_isMacroBuiltin ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isMacroBuiltin>>(
+                'clang_Cursor_isMacroBuiltin')
+            .asFunction<_dart_clang_Cursor_isMacroBuiltin>())(
       C,
     );
   }
@@ -2787,10 +2880,10 @@ class LibClang {
   int clang_Cursor_isFunctionInlined(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isFunctionInlined ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isFunctionInlined,
-            _dart_clang_Cursor_isFunctionInlined>(
-        'clang_Cursor_isFunctionInlined'))(
+    return (_clang_Cursor_isFunctionInlined ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isFunctionInlined>>(
+                'clang_Cursor_isFunctionInlined')
+            .asFunction<_dart_clang_Cursor_isFunctionInlined>())(
       C,
     );
   }
@@ -2803,9 +2896,10 @@ class LibClang {
   int clang_isVolatileQualifiedType(
     CXType T,
   ) {
-    return (_clang_isVolatileQualifiedType ??= _dylib.lookupFunction<
-        _c_clang_isVolatileQualifiedType,
-        _dart_clang_isVolatileQualifiedType>('clang_isVolatileQualifiedType'))(
+    return (_clang_isVolatileQualifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_isVolatileQualifiedType>>(
+                'clang_isVolatileQualifiedType')
+            .asFunction<_dart_clang_isVolatileQualifiedType>())(
       T,
     );
   }
@@ -2818,9 +2912,10 @@ class LibClang {
   int clang_isRestrictQualifiedType(
     CXType T,
   ) {
-    return (_clang_isRestrictQualifiedType ??= _dylib.lookupFunction<
-        _c_clang_isRestrictQualifiedType,
-        _dart_clang_isRestrictQualifiedType>('clang_isRestrictQualifiedType'))(
+    return (_clang_isRestrictQualifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_isRestrictQualifiedType>>(
+                'clang_isRestrictQualifiedType')
+            .asFunction<_dart_clang_isRestrictQualifiedType>())(
       T,
     );
   }
@@ -2831,9 +2926,10 @@ class LibClang {
   int clang_getAddressSpace(
     CXType T,
   ) {
-    return (_clang_getAddressSpace ??= _dylib.lookupFunction<
-        _c_clang_getAddressSpace,
-        _dart_clang_getAddressSpace>('clang_getAddressSpace'))(
+    return (_clang_getAddressSpace ??=
+        _lookup<ffi.NativeFunction<_c_clang_getAddressSpace>>(
+                'clang_getAddressSpace')
+            .asFunction<_dart_clang_getAddressSpace>())(
       T,
     );
   }
@@ -2844,9 +2940,10 @@ class LibClang {
   CXString clang_getTypedefName(
     CXType CT,
   ) {
-    return (_clang_getTypedefName ??= _dylib.lookupFunction<
-        _c_clang_getTypedefName,
-        _dart_clang_getTypedefName>('clang_getTypedefName'))(
+    return (_clang_getTypedefName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypedefName>>(
+                'clang_getTypedefName')
+            .asFunction<_dart_clang_getTypedefName>())(
       CT,
     );
   }
@@ -2857,9 +2954,10 @@ class LibClang {
   CXType clang_getPointeeType(
     CXType T,
   ) {
-    return (_clang_getPointeeType ??= _dylib.lookupFunction<
-        _c_clang_getPointeeType,
-        _dart_clang_getPointeeType>('clang_getPointeeType'))(
+    return (_clang_getPointeeType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getPointeeType>>(
+                'clang_getPointeeType')
+            .asFunction<_dart_clang_getPointeeType>())(
       T,
     );
   }
@@ -2870,9 +2968,10 @@ class LibClang {
   CXCursor clang_getTypeDeclaration(
     CXType T,
   ) {
-    return (_clang_getTypeDeclaration ??= _dylib.lookupFunction<
-        _c_clang_getTypeDeclaration,
-        _dart_clang_getTypeDeclaration>('clang_getTypeDeclaration'))(
+    return (_clang_getTypeDeclaration ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypeDeclaration>>(
+                'clang_getTypeDeclaration')
+            .asFunction<_dart_clang_getTypeDeclaration>())(
       T,
     );
   }
@@ -2883,9 +2982,10 @@ class LibClang {
   CXString clang_getDeclObjCTypeEncoding(
     CXCursor C,
   ) {
-    return (_clang_getDeclObjCTypeEncoding ??= _dylib.lookupFunction<
-        _c_clang_getDeclObjCTypeEncoding,
-        _dart_clang_getDeclObjCTypeEncoding>('clang_getDeclObjCTypeEncoding'))(
+    return (_clang_getDeclObjCTypeEncoding ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDeclObjCTypeEncoding>>(
+                'clang_getDeclObjCTypeEncoding')
+            .asFunction<_dart_clang_getDeclObjCTypeEncoding>())(
       C,
     );
   }
@@ -2896,9 +2996,10 @@ class LibClang {
   CXString clang_Type_getObjCEncoding(
     CXType type,
   ) {
-    return (_clang_Type_getObjCEncoding ??= _dylib.lookupFunction<
-        _c_clang_Type_getObjCEncoding,
-        _dart_clang_Type_getObjCEncoding>('clang_Type_getObjCEncoding'))(
+    return (_clang_Type_getObjCEncoding ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCEncoding>>(
+                'clang_Type_getObjCEncoding')
+            .asFunction<_dart_clang_Type_getObjCEncoding>())(
       type,
     );
   }
@@ -2909,9 +3010,10 @@ class LibClang {
   CXString clang_getTypeKindSpelling(
     int K,
   ) {
-    return (_clang_getTypeKindSpelling ??= _dylib.lookupFunction<
-        _c_clang_getTypeKindSpelling,
-        _dart_clang_getTypeKindSpelling>('clang_getTypeKindSpelling'))(
+    return (_clang_getTypeKindSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypeKindSpelling>>(
+                'clang_getTypeKindSpelling')
+            .asFunction<_dart_clang_getTypeKindSpelling>())(
       K,
     );
   }
@@ -2924,10 +3026,10 @@ class LibClang {
   int clang_getFunctionTypeCallingConv(
     CXType T,
   ) {
-    return (_clang_getFunctionTypeCallingConv ??= _dylib.lookupFunction<
-            _c_clang_getFunctionTypeCallingConv,
-            _dart_clang_getFunctionTypeCallingConv>(
-        'clang_getFunctionTypeCallingConv'))(
+    return (_clang_getFunctionTypeCallingConv ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFunctionTypeCallingConv>>(
+                'clang_getFunctionTypeCallingConv')
+            .asFunction<_dart_clang_getFunctionTypeCallingConv>())(
       T,
     );
   }
@@ -2940,9 +3042,10 @@ class LibClang {
   CXType clang_getResultType(
     CXType T,
   ) {
-    return (_clang_getResultType ??= _dylib.lookupFunction<
-        _c_clang_getResultType,
-        _dart_clang_getResultType>('clang_getResultType'))(
+    return (_clang_getResultType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getResultType>>(
+                'clang_getResultType')
+            .asFunction<_dart_clang_getResultType>())(
       T,
     );
   }
@@ -2956,10 +3059,10 @@ class LibClang {
   int clang_getExceptionSpecificationType(
     CXType T,
   ) {
-    return (_clang_getExceptionSpecificationType ??= _dylib.lookupFunction<
-            _c_clang_getExceptionSpecificationType,
-            _dart_clang_getExceptionSpecificationType>(
-        'clang_getExceptionSpecificationType'))(
+    return (_clang_getExceptionSpecificationType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getExceptionSpecificationType>>(
+                'clang_getExceptionSpecificationType')
+            .asFunction<_dart_clang_getExceptionSpecificationType>())(
       T,
     );
   }
@@ -2974,9 +3077,10 @@ class LibClang {
   int clang_getNumArgTypes(
     CXType T,
   ) {
-    return (_clang_getNumArgTypes ??= _dylib.lookupFunction<
-        _c_clang_getNumArgTypes,
-        _dart_clang_getNumArgTypes>('clang_getNumArgTypes'))(
+    return (_clang_getNumArgTypes ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumArgTypes>>(
+                'clang_getNumArgTypes')
+            .asFunction<_dart_clang_getNumArgTypes>())(
       T,
     );
   }
@@ -2992,8 +3096,8 @@ class LibClang {
     int i,
   ) {
     return (_clang_getArgType ??=
-        _dylib.lookupFunction<_c_clang_getArgType, _dart_clang_getArgType>(
-            'clang_getArgType'))(
+        _lookup<ffi.NativeFunction<_c_clang_getArgType>>('clang_getArgType')
+            .asFunction<_dart_clang_getArgType>())(
       T,
       i,
     );
@@ -3007,10 +3111,10 @@ class LibClang {
   CXType clang_Type_getObjCObjectBaseType(
     CXType T,
   ) {
-    return (_clang_Type_getObjCObjectBaseType ??= _dylib.lookupFunction<
-            _c_clang_Type_getObjCObjectBaseType,
-            _dart_clang_Type_getObjCObjectBaseType>(
-        'clang_Type_getObjCObjectBaseType'))(
+    return (_clang_Type_getObjCObjectBaseType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCObjectBaseType>>(
+                'clang_Type_getObjCObjectBaseType')
+            .asFunction<_dart_clang_Type_getObjCObjectBaseType>())(
       T,
     );
   }
@@ -3023,10 +3127,10 @@ class LibClang {
   int clang_Type_getNumObjCProtocolRefs(
     CXType T,
   ) {
-    return (_clang_Type_getNumObjCProtocolRefs ??= _dylib.lookupFunction<
-            _c_clang_Type_getNumObjCProtocolRefs,
-            _dart_clang_Type_getNumObjCProtocolRefs>(
-        'clang_Type_getNumObjCProtocolRefs'))(
+    return (_clang_Type_getNumObjCProtocolRefs ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNumObjCProtocolRefs>>(
+                'clang_Type_getNumObjCProtocolRefs')
+            .asFunction<_dart_clang_Type_getNumObjCProtocolRefs>())(
       T,
     );
   }
@@ -3041,10 +3145,10 @@ class LibClang {
     CXType T,
     int i,
   ) {
-    return (_clang_Type_getObjCProtocolDecl ??= _dylib.lookupFunction<
-            _c_clang_Type_getObjCProtocolDecl,
-            _dart_clang_Type_getObjCProtocolDecl>(
-        'clang_Type_getObjCProtocolDecl'))(
+    return (_clang_Type_getObjCProtocolDecl ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCProtocolDecl>>(
+                'clang_Type_getObjCProtocolDecl')
+            .asFunction<_dart_clang_Type_getObjCProtocolDecl>())(
       T,
       i,
     );
@@ -3058,9 +3162,10 @@ class LibClang {
   int clang_Type_getNumObjCTypeArgs(
     CXType T,
   ) {
-    return (_clang_Type_getNumObjCTypeArgs ??= _dylib.lookupFunction<
-        _c_clang_Type_getNumObjCTypeArgs,
-        _dart_clang_Type_getNumObjCTypeArgs>('clang_Type_getNumObjCTypeArgs'))(
+    return (_clang_Type_getNumObjCTypeArgs ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNumObjCTypeArgs>>(
+                'clang_Type_getNumObjCTypeArgs')
+            .asFunction<_dart_clang_Type_getNumObjCTypeArgs>())(
       T,
     );
   }
@@ -3075,9 +3180,10 @@ class LibClang {
     CXType T,
     int i,
   ) {
-    return (_clang_Type_getObjCTypeArg ??= _dylib.lookupFunction<
-        _c_clang_Type_getObjCTypeArg,
-        _dart_clang_Type_getObjCTypeArg>('clang_Type_getObjCTypeArg'))(
+    return (_clang_Type_getObjCTypeArg ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCTypeArg>>(
+                'clang_Type_getObjCTypeArg')
+            .asFunction<_dart_clang_Type_getObjCTypeArg>())(
       T,
       i,
     );
@@ -3089,9 +3195,10 @@ class LibClang {
   int clang_isFunctionTypeVariadic(
     CXType T,
   ) {
-    return (_clang_isFunctionTypeVariadic ??= _dylib.lookupFunction<
-        _c_clang_isFunctionTypeVariadic,
-        _dart_clang_isFunctionTypeVariadic>('clang_isFunctionTypeVariadic'))(
+    return (_clang_isFunctionTypeVariadic ??=
+        _lookup<ffi.NativeFunction<_c_clang_isFunctionTypeVariadic>>(
+                'clang_isFunctionTypeVariadic')
+            .asFunction<_dart_clang_isFunctionTypeVariadic>())(
       T,
     );
   }
@@ -3104,9 +3211,10 @@ class LibClang {
   CXType clang_getCursorResultType(
     CXCursor C,
   ) {
-    return (_clang_getCursorResultType ??= _dylib.lookupFunction<
-        _c_clang_getCursorResultType,
-        _dart_clang_getCursorResultType>('clang_getCursorResultType'))(
+    return (_clang_getCursorResultType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorResultType>>(
+                'clang_getCursorResultType')
+            .asFunction<_dart_clang_getCursorResultType>())(
       C,
     );
   }
@@ -3120,10 +3228,11 @@ class LibClang {
   int clang_getCursorExceptionSpecificationType(
     CXCursor C,
   ) {
-    return (_clang_getCursorExceptionSpecificationType ??=
-        _dylib.lookupFunction<_c_clang_getCursorExceptionSpecificationType,
-                _dart_clang_getCursorExceptionSpecificationType>(
-            'clang_getCursorExceptionSpecificationType'))(
+    return (_clang_getCursorExceptionSpecificationType ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_getCursorExceptionSpecificationType>>(
+            'clang_getCursorExceptionSpecificationType')
+        .asFunction<_dart_clang_getCursorExceptionSpecificationType>())(
       C,
     );
   }
@@ -3137,8 +3246,8 @@ class LibClang {
     CXType T,
   ) {
     return (_clang_isPODType ??=
-        _dylib.lookupFunction<_c_clang_isPODType, _dart_clang_isPODType>(
-            'clang_isPODType'))(
+        _lookup<ffi.NativeFunction<_c_clang_isPODType>>('clang_isPODType')
+            .asFunction<_dart_clang_isPODType>())(
       T,
     );
   }
@@ -3152,9 +3261,10 @@ class LibClang {
   CXType clang_getElementType(
     CXType T,
   ) {
-    return (_clang_getElementType ??= _dylib.lookupFunction<
-        _c_clang_getElementType,
-        _dart_clang_getElementType>('clang_getElementType'))(
+    return (_clang_getElementType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getElementType>>(
+                'clang_getElementType')
+            .asFunction<_dart_clang_getElementType>())(
       T,
     );
   }
@@ -3168,9 +3278,10 @@ class LibClang {
   int clang_getNumElements(
     CXType T,
   ) {
-    return (_clang_getNumElements ??= _dylib.lookupFunction<
-        _c_clang_getNumElements,
-        _dart_clang_getNumElements>('clang_getNumElements'))(
+    return (_clang_getNumElements ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumElements>>(
+                'clang_getNumElements')
+            .asFunction<_dart_clang_getNumElements>())(
       T,
     );
   }
@@ -3183,9 +3294,10 @@ class LibClang {
   CXType clang_getArrayElementType(
     CXType T,
   ) {
-    return (_clang_getArrayElementType ??= _dylib.lookupFunction<
-        _c_clang_getArrayElementType,
-        _dart_clang_getArrayElementType>('clang_getArrayElementType'))(
+    return (_clang_getArrayElementType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getArrayElementType>>(
+                'clang_getArrayElementType')
+            .asFunction<_dart_clang_getArrayElementType>())(
       T,
     );
   }
@@ -3199,8 +3311,8 @@ class LibClang {
     CXType T,
   ) {
     return (_clang_getArraySize ??=
-        _dylib.lookupFunction<_c_clang_getArraySize, _dart_clang_getArraySize>(
-            'clang_getArraySize'))(
+        _lookup<ffi.NativeFunction<_c_clang_getArraySize>>('clang_getArraySize')
+            .asFunction<_dart_clang_getArraySize>())(
       T,
     );
   }
@@ -3213,9 +3325,10 @@ class LibClang {
   CXType clang_Type_getNamedType(
     CXType T,
   ) {
-    return (_clang_Type_getNamedType ??= _dylib.lookupFunction<
-        _c_clang_Type_getNamedType,
-        _dart_clang_Type_getNamedType>('clang_Type_getNamedType'))(
+    return (_clang_Type_getNamedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNamedType>>(
+                'clang_Type_getNamedType')
+            .asFunction<_dart_clang_Type_getNamedType>())(
       T,
     );
   }
@@ -3231,10 +3344,10 @@ class LibClang {
   int clang_Type_isTransparentTagTypedef(
     CXType T,
   ) {
-    return (_clang_Type_isTransparentTagTypedef ??= _dylib.lookupFunction<
-            _c_clang_Type_isTransparentTagTypedef,
-            _dart_clang_Type_isTransparentTagTypedef>(
-        'clang_Type_isTransparentTagTypedef'))(
+    return (_clang_Type_isTransparentTagTypedef ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_isTransparentTagTypedef>>(
+                'clang_Type_isTransparentTagTypedef')
+            .asFunction<_dart_clang_Type_isTransparentTagTypedef>())(
       T,
     );
   }
@@ -3245,9 +3358,10 @@ class LibClang {
   int clang_Type_getNullability(
     CXType T,
   ) {
-    return (_clang_Type_getNullability ??= _dylib.lookupFunction<
-        _c_clang_Type_getNullability,
-        _dart_clang_Type_getNullability>('clang_Type_getNullability'))(
+    return (_clang_Type_getNullability ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNullability>>(
+                'clang_Type_getNullability')
+            .asFunction<_dart_clang_Type_getNullability>())(
       T,
     );
   }
@@ -3267,9 +3381,10 @@ class LibClang {
   int clang_Type_getAlignOf(
     CXType T,
   ) {
-    return (_clang_Type_getAlignOf ??= _dylib.lookupFunction<
-        _c_clang_Type_getAlignOf,
-        _dart_clang_Type_getAlignOf>('clang_Type_getAlignOf'))(
+    return (_clang_Type_getAlignOf ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getAlignOf>>(
+                'clang_Type_getAlignOf')
+            .asFunction<_dart_clang_Type_getAlignOf>())(
       T,
     );
   }
@@ -3282,9 +3397,10 @@ class LibClang {
   CXType clang_Type_getClassType(
     CXType T,
   ) {
-    return (_clang_Type_getClassType ??= _dylib.lookupFunction<
-        _c_clang_Type_getClassType,
-        _dart_clang_Type_getClassType>('clang_Type_getClassType'))(
+    return (_clang_Type_getClassType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getClassType>>(
+                'clang_Type_getClassType')
+            .asFunction<_dart_clang_Type_getClassType>())(
       T,
     );
   }
@@ -3301,9 +3417,10 @@ class LibClang {
   int clang_Type_getSizeOf(
     CXType T,
   ) {
-    return (_clang_Type_getSizeOf ??= _dylib.lookupFunction<
-        _c_clang_Type_getSizeOf,
-        _dart_clang_Type_getSizeOf>('clang_Type_getSizeOf'))(
+    return (_clang_Type_getSizeOf ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getSizeOf>>(
+                'clang_Type_getSizeOf')
+            .asFunction<_dart_clang_Type_getSizeOf>())(
       T,
     );
   }
@@ -3325,9 +3442,10 @@ class LibClang {
     CXType T,
     ffi.Pointer<ffi.Int8> S,
   ) {
-    return (_clang_Type_getOffsetOf ??= _dylib.lookupFunction<
-        _c_clang_Type_getOffsetOf,
-        _dart_clang_Type_getOffsetOf>('clang_Type_getOffsetOf'))(
+    return (_clang_Type_getOffsetOf ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getOffsetOf>>(
+                'clang_Type_getOffsetOf')
+            .asFunction<_dart_clang_Type_getOffsetOf>())(
       T,
       S,
     );
@@ -3341,9 +3459,10 @@ class LibClang {
   CXType clang_Type_getModifiedType(
     CXType T,
   ) {
-    return (_clang_Type_getModifiedType ??= _dylib.lookupFunction<
-        _c_clang_Type_getModifiedType,
-        _dart_clang_Type_getModifiedType>('clang_Type_getModifiedType'))(
+    return (_clang_Type_getModifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getModifiedType>>(
+                'clang_Type_getModifiedType')
+            .asFunction<_dart_clang_Type_getModifiedType>())(
       T,
     );
   }
@@ -3364,9 +3483,10 @@ class LibClang {
   int clang_Cursor_getOffsetOfField(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getOffsetOfField ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getOffsetOfField,
-        _dart_clang_Cursor_getOffsetOfField>('clang_Cursor_getOffsetOfField'))(
+    return (_clang_Cursor_getOffsetOfField ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getOffsetOfField>>(
+                'clang_Cursor_getOffsetOfField')
+            .asFunction<_dart_clang_Cursor_getOffsetOfField>())(
       C,
     );
   }
@@ -3378,9 +3498,10 @@ class LibClang {
   int clang_Cursor_isAnonymous(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isAnonymous ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isAnonymous,
-        _dart_clang_Cursor_isAnonymous>('clang_Cursor_isAnonymous'))(
+    return (_clang_Cursor_isAnonymous ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isAnonymous>>(
+                'clang_Cursor_isAnonymous')
+            .asFunction<_dart_clang_Cursor_isAnonymous>())(
       C,
     );
   }
@@ -3392,10 +3513,10 @@ class LibClang {
   int clang_Cursor_isAnonymousRecordDecl(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isAnonymousRecordDecl ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isAnonymousRecordDecl,
-            _dart_clang_Cursor_isAnonymousRecordDecl>(
-        'clang_Cursor_isAnonymousRecordDecl'))(
+    return (_clang_Cursor_isAnonymousRecordDecl ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isAnonymousRecordDecl>>(
+                'clang_Cursor_isAnonymousRecordDecl')
+            .asFunction<_dart_clang_Cursor_isAnonymousRecordDecl>())(
       C,
     );
   }
@@ -3407,10 +3528,10 @@ class LibClang {
   int clang_Cursor_isInlineNamespace(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isInlineNamespace ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isInlineNamespace,
-            _dart_clang_Cursor_isInlineNamespace>(
-        'clang_Cursor_isInlineNamespace'))(
+    return (_clang_Cursor_isInlineNamespace ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isInlineNamespace>>(
+                'clang_Cursor_isInlineNamespace')
+            .asFunction<_dart_clang_Cursor_isInlineNamespace>())(
       C,
     );
   }
@@ -3422,10 +3543,10 @@ class LibClang {
   int clang_Type_getNumTemplateArguments(
     CXType T,
   ) {
-    return (_clang_Type_getNumTemplateArguments ??= _dylib.lookupFunction<
-            _c_clang_Type_getNumTemplateArguments,
-            _dart_clang_Type_getNumTemplateArguments>(
-        'clang_Type_getNumTemplateArguments'))(
+    return (_clang_Type_getNumTemplateArguments ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNumTemplateArguments>>(
+                'clang_Type_getNumTemplateArguments')
+            .asFunction<_dart_clang_Type_getNumTemplateArguments>())(
       T,
     );
   }
@@ -3441,10 +3562,10 @@ class LibClang {
     CXType T,
     int i,
   ) {
-    return (_clang_Type_getTemplateArgumentAsType ??= _dylib.lookupFunction<
-            _c_clang_Type_getTemplateArgumentAsType,
-            _dart_clang_Type_getTemplateArgumentAsType>(
-        'clang_Type_getTemplateArgumentAsType'))(
+    return (_clang_Type_getTemplateArgumentAsType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getTemplateArgumentAsType>>(
+                'clang_Type_getTemplateArgumentAsType')
+            .asFunction<_dart_clang_Type_getTemplateArgumentAsType>())(
       T,
       i,
     );
@@ -3460,9 +3581,10 @@ class LibClang {
   int clang_Type_getCXXRefQualifier(
     CXType T,
   ) {
-    return (_clang_Type_getCXXRefQualifier ??= _dylib.lookupFunction<
-        _c_clang_Type_getCXXRefQualifier,
-        _dart_clang_Type_getCXXRefQualifier>('clang_Type_getCXXRefQualifier'))(
+    return (_clang_Type_getCXXRefQualifier ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getCXXRefQualifier>>(
+                'clang_Type_getCXXRefQualifier')
+            .asFunction<_dart_clang_Type_getCXXRefQualifier>())(
       T,
     );
   }
@@ -3474,9 +3596,10 @@ class LibClang {
   int clang_Cursor_isBitField(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isBitField ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isBitField,
-        _dart_clang_Cursor_isBitField>('clang_Cursor_isBitField'))(
+    return (_clang_Cursor_isBitField ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isBitField>>(
+                'clang_Cursor_isBitField')
+            .asFunction<_dart_clang_Cursor_isBitField>())(
       C,
     );
   }
@@ -3488,9 +3611,10 @@ class LibClang {
   int clang_isVirtualBase(
     CXCursor arg0,
   ) {
-    return (_clang_isVirtualBase ??= _dylib.lookupFunction<
-        _c_clang_isVirtualBase,
-        _dart_clang_isVirtualBase>('clang_isVirtualBase'))(
+    return (_clang_isVirtualBase ??=
+        _lookup<ffi.NativeFunction<_c_clang_isVirtualBase>>(
+                'clang_isVirtualBase')
+            .asFunction<_dart_clang_isVirtualBase>())(
       arg0,
     );
   }
@@ -3505,9 +3629,10 @@ class LibClang {
   int clang_getCXXAccessSpecifier(
     CXCursor arg0,
   ) {
-    return (_clang_getCXXAccessSpecifier ??= _dylib.lookupFunction<
-        _c_clang_getCXXAccessSpecifier,
-        _dart_clang_getCXXAccessSpecifier>('clang_getCXXAccessSpecifier'))(
+    return (_clang_getCXXAccessSpecifier ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCXXAccessSpecifier>>(
+                'clang_getCXXAccessSpecifier')
+            .asFunction<_dart_clang_getCXXAccessSpecifier>())(
       arg0,
     );
   }
@@ -3521,9 +3646,10 @@ class LibClang {
   int clang_Cursor_getStorageClass(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getStorageClass ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getStorageClass,
-        _dart_clang_Cursor_getStorageClass>('clang_Cursor_getStorageClass'))(
+    return (_clang_Cursor_getStorageClass ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getStorageClass>>(
+                'clang_Cursor_getStorageClass')
+            .asFunction<_dart_clang_Cursor_getStorageClass>())(
       arg0,
     );
   }
@@ -3540,9 +3666,10 @@ class LibClang {
   int clang_getNumOverloadedDecls(
     CXCursor cursor,
   ) {
-    return (_clang_getNumOverloadedDecls ??= _dylib.lookupFunction<
-        _c_clang_getNumOverloadedDecls,
-        _dart_clang_getNumOverloadedDecls>('clang_getNumOverloadedDecls'))(
+    return (_clang_getNumOverloadedDecls ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumOverloadedDecls>>(
+                'clang_getNumOverloadedDecls')
+            .asFunction<_dart_clang_getNumOverloadedDecls>())(
       cursor,
     );
   }
@@ -3565,9 +3692,10 @@ class LibClang {
     CXCursor cursor,
     int index,
   ) {
-    return (_clang_getOverloadedDecl ??= _dylib.lookupFunction<
-        _c_clang_getOverloadedDecl,
-        _dart_clang_getOverloadedDecl>('clang_getOverloadedDecl'))(
+    return (_clang_getOverloadedDecl ??=
+        _lookup<ffi.NativeFunction<_c_clang_getOverloadedDecl>>(
+                'clang_getOverloadedDecl')
+            .asFunction<_dart_clang_getOverloadedDecl>())(
       cursor,
       index,
     );
@@ -3580,10 +3708,10 @@ class LibClang {
   CXType clang_getIBOutletCollectionType(
     CXCursor arg0,
   ) {
-    return (_clang_getIBOutletCollectionType ??= _dylib.lookupFunction<
-            _c_clang_getIBOutletCollectionType,
-            _dart_clang_getIBOutletCollectionType>(
-        'clang_getIBOutletCollectionType'))(
+    return (_clang_getIBOutletCollectionType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getIBOutletCollectionType>>(
+                'clang_getIBOutletCollectionType')
+            .asFunction<_dart_clang_getIBOutletCollectionType>())(
       arg0,
     );
   }
@@ -3615,9 +3743,10 @@ class LibClang {
     ffi.Pointer<ffi.NativeFunction<CXCursorVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
-    return (_clang_visitChildren ??= _dylib.lookupFunction<
-        _c_clang_visitChildren,
-        _dart_clang_visitChildren>('clang_visitChildren'))(
+    return (_clang_visitChildren ??=
+        _lookup<ffi.NativeFunction<_c_clang_visitChildren>>(
+                'clang_visitChildren')
+            .asFunction<_dart_clang_visitChildren>())(
       parent,
       visitor,
       client_data,
@@ -3637,8 +3766,8 @@ class LibClang {
     CXCursor arg0,
   ) {
     return (_clang_getCursorUSR ??=
-        _dylib.lookupFunction<_c_clang_getCursorUSR, _dart_clang_getCursorUSR>(
-            'clang_getCursorUSR'))(
+        _lookup<ffi.NativeFunction<_c_clang_getCursorUSR>>('clang_getCursorUSR')
+            .asFunction<_dart_clang_getCursorUSR>())(
       arg0,
     );
   }
@@ -3649,9 +3778,10 @@ class LibClang {
   CXString clang_constructUSR_ObjCClass(
     ffi.Pointer<ffi.Int8> class_name,
   ) {
-    return (_clang_constructUSR_ObjCClass ??= _dylib.lookupFunction<
-        _c_clang_constructUSR_ObjCClass,
-        _dart_clang_constructUSR_ObjCClass>('clang_constructUSR_ObjCClass'))(
+    return (_clang_constructUSR_ObjCClass ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCClass>>(
+                'clang_constructUSR_ObjCClass')
+            .asFunction<_dart_clang_constructUSR_ObjCClass>())(
       class_name,
     );
   }
@@ -3663,10 +3793,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> class_name,
     ffi.Pointer<ffi.Int8> category_name,
   ) {
-    return (_clang_constructUSR_ObjCCategory ??= _dylib.lookupFunction<
-            _c_clang_constructUSR_ObjCCategory,
-            _dart_clang_constructUSR_ObjCCategory>(
-        'clang_constructUSR_ObjCCategory'))(
+    return (_clang_constructUSR_ObjCCategory ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCCategory>>(
+                'clang_constructUSR_ObjCCategory')
+            .asFunction<_dart_clang_constructUSR_ObjCCategory>())(
       class_name,
       category_name,
     );
@@ -3678,10 +3808,10 @@ class LibClang {
   CXString clang_constructUSR_ObjCProtocol(
     ffi.Pointer<ffi.Int8> protocol_name,
   ) {
-    return (_clang_constructUSR_ObjCProtocol ??= _dylib.lookupFunction<
-            _c_clang_constructUSR_ObjCProtocol,
-            _dart_clang_constructUSR_ObjCProtocol>(
-        'clang_constructUSR_ObjCProtocol'))(
+    return (_clang_constructUSR_ObjCProtocol ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCProtocol>>(
+                'clang_constructUSR_ObjCProtocol')
+            .asFunction<_dart_clang_constructUSR_ObjCProtocol>())(
       protocol_name,
     );
   }
@@ -3694,9 +3824,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> name,
     CXString classUSR,
   ) {
-    return (_clang_constructUSR_ObjCIvar ??= _dylib.lookupFunction<
-        _c_clang_constructUSR_ObjCIvar,
-        _dart_clang_constructUSR_ObjCIvar>('clang_constructUSR_ObjCIvar'))(
+    return (_clang_constructUSR_ObjCIvar ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCIvar>>(
+                'clang_constructUSR_ObjCIvar')
+            .asFunction<_dart_clang_constructUSR_ObjCIvar>())(
       name,
       classUSR,
     );
@@ -3711,9 +3842,10 @@ class LibClang {
     int isInstanceMethod,
     CXString classUSR,
   ) {
-    return (_clang_constructUSR_ObjCMethod ??= _dylib.lookupFunction<
-        _c_clang_constructUSR_ObjCMethod,
-        _dart_clang_constructUSR_ObjCMethod>('clang_constructUSR_ObjCMethod'))(
+    return (_clang_constructUSR_ObjCMethod ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCMethod>>(
+                'clang_constructUSR_ObjCMethod')
+            .asFunction<_dart_clang_constructUSR_ObjCMethod>())(
       name,
       isInstanceMethod,
       classUSR,
@@ -3728,10 +3860,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> property,
     CXString classUSR,
   ) {
-    return (_clang_constructUSR_ObjCProperty ??= _dylib.lookupFunction<
-            _c_clang_constructUSR_ObjCProperty,
-            _dart_clang_constructUSR_ObjCProperty>(
-        'clang_constructUSR_ObjCProperty'))(
+    return (_clang_constructUSR_ObjCProperty ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCProperty>>(
+                'clang_constructUSR_ObjCProperty')
+            .asFunction<_dart_clang_constructUSR_ObjCProperty>())(
       property,
       classUSR,
     );
@@ -3743,9 +3875,10 @@ class LibClang {
   CXString clang_getCursorSpelling(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorSpelling ??= _dylib.lookupFunction<
-        _c_clang_getCursorSpelling,
-        _dart_clang_getCursorSpelling>('clang_getCursorSpelling'))(
+    return (_clang_getCursorSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorSpelling>>(
+                'clang_getCursorSpelling')
+            .asFunction<_dart_clang_getCursorSpelling>())(
       arg0,
     );
   }
@@ -3766,10 +3899,10 @@ class LibClang {
     int pieceIndex,
     int options,
   ) {
-    return (_clang_Cursor_getSpellingNameRange ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getSpellingNameRange,
-            _dart_clang_Cursor_getSpellingNameRange>(
-        'clang_Cursor_getSpellingNameRange'))(
+    return (_clang_Cursor_getSpellingNameRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getSpellingNameRange>>(
+                'clang_Cursor_getSpellingNameRange')
+            .asFunction<_dart_clang_Cursor_getSpellingNameRange>())(
       arg0,
       pieceIndex,
       options,
@@ -3783,10 +3916,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Policy,
     int Property,
   ) {
-    return (_clang_PrintingPolicy_getProperty ??= _dylib.lookupFunction<
-            _c_clang_PrintingPolicy_getProperty,
-            _dart_clang_PrintingPolicy_getProperty>(
-        'clang_PrintingPolicy_getProperty'))(
+    return (_clang_PrintingPolicy_getProperty ??=
+        _lookup<ffi.NativeFunction<_c_clang_PrintingPolicy_getProperty>>(
+                'clang_PrintingPolicy_getProperty')
+            .asFunction<_dart_clang_PrintingPolicy_getProperty>())(
       Policy,
       Property,
     );
@@ -3800,10 +3933,10 @@ class LibClang {
     int Property,
     int Value,
   ) {
-    return (_clang_PrintingPolicy_setProperty ??= _dylib.lookupFunction<
-            _c_clang_PrintingPolicy_setProperty,
-            _dart_clang_PrintingPolicy_setProperty>(
-        'clang_PrintingPolicy_setProperty'))(
+    return (_clang_PrintingPolicy_setProperty ??=
+        _lookup<ffi.NativeFunction<_c_clang_PrintingPolicy_setProperty>>(
+                'clang_PrintingPolicy_setProperty')
+            .asFunction<_dart_clang_PrintingPolicy_setProperty>())(
       Policy,
       Property,
       Value,
@@ -3819,9 +3952,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getCursorPrintingPolicy(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorPrintingPolicy ??= _dylib.lookupFunction<
-        _c_clang_getCursorPrintingPolicy,
-        _dart_clang_getCursorPrintingPolicy>('clang_getCursorPrintingPolicy'))(
+    return (_clang_getCursorPrintingPolicy ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorPrintingPolicy>>(
+                'clang_getCursorPrintingPolicy')
+            .asFunction<_dart_clang_getCursorPrintingPolicy>())(
       arg0,
     );
   }
@@ -3832,9 +3966,10 @@ class LibClang {
   void clang_PrintingPolicy_dispose(
     ffi.Pointer<ffi.Void> Policy,
   ) {
-    return (_clang_PrintingPolicy_dispose ??= _dylib.lookupFunction<
-        _c_clang_PrintingPolicy_dispose,
-        _dart_clang_PrintingPolicy_dispose>('clang_PrintingPolicy_dispose'))(
+    return (_clang_PrintingPolicy_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_PrintingPolicy_dispose>>(
+                'clang_PrintingPolicy_dispose')
+            .asFunction<_dart_clang_PrintingPolicy_dispose>())(
       Policy,
     );
   }
@@ -3854,9 +3989,10 @@ class LibClang {
     CXCursor Cursor,
     ffi.Pointer<ffi.Void> Policy,
   ) {
-    return (_clang_getCursorPrettyPrinted ??= _dylib.lookupFunction<
-        _c_clang_getCursorPrettyPrinted,
-        _dart_clang_getCursorPrettyPrinted>('clang_getCursorPrettyPrinted'))(
+    return (_clang_getCursorPrettyPrinted ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorPrettyPrinted>>(
+                'clang_getCursorPrettyPrinted')
+            .asFunction<_dart_clang_getCursorPrettyPrinted>())(
       Cursor,
       Policy,
     );
@@ -3872,9 +4008,10 @@ class LibClang {
   CXString clang_getCursorDisplayName(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorDisplayName ??= _dylib.lookupFunction<
-        _c_clang_getCursorDisplayName,
-        _dart_clang_getCursorDisplayName>('clang_getCursorDisplayName'))(
+    return (_clang_getCursorDisplayName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorDisplayName>>(
+                'clang_getCursorDisplayName')
+            .asFunction<_dart_clang_getCursorDisplayName>())(
       arg0,
     );
   }
@@ -3893,9 +4030,10 @@ class LibClang {
   CXCursor clang_getCursorReferenced(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorReferenced ??= _dylib.lookupFunction<
-        _c_clang_getCursorReferenced,
-        _dart_clang_getCursorReferenced>('clang_getCursorReferenced'))(
+    return (_clang_getCursorReferenced ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorReferenced>>(
+                'clang_getCursorReferenced')
+            .asFunction<_dart_clang_getCursorReferenced>())(
       arg0,
     );
   }
@@ -3931,9 +4069,10 @@ class LibClang {
   CXCursor clang_getCursorDefinition(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorDefinition ??= _dylib.lookupFunction<
-        _c_clang_getCursorDefinition,
-        _dart_clang_getCursorDefinition>('clang_getCursorDefinition'))(
+    return (_clang_getCursorDefinition ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorDefinition>>(
+                'clang_getCursorDefinition')
+            .asFunction<_dart_clang_getCursorDefinition>())(
       arg0,
     );
   }
@@ -3945,9 +4084,10 @@ class LibClang {
   int clang_isCursorDefinition(
     CXCursor arg0,
   ) {
-    return (_clang_isCursorDefinition ??= _dylib.lookupFunction<
-        _c_clang_isCursorDefinition,
-        _dart_clang_isCursorDefinition>('clang_isCursorDefinition'))(
+    return (_clang_isCursorDefinition ??=
+        _lookup<ffi.NativeFunction<_c_clang_isCursorDefinition>>(
+                'clang_isCursorDefinition')
+            .asFunction<_dart_clang_isCursorDefinition>())(
       arg0,
     );
   }
@@ -3979,9 +4119,10 @@ class LibClang {
   CXCursor clang_getCanonicalCursor(
     CXCursor arg0,
   ) {
-    return (_clang_getCanonicalCursor ??= _dylib.lookupFunction<
-        _c_clang_getCanonicalCursor,
-        _dart_clang_getCanonicalCursor>('clang_getCanonicalCursor'))(
+    return (_clang_getCanonicalCursor ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCanonicalCursor>>(
+                'clang_getCanonicalCursor')
+            .asFunction<_dart_clang_getCanonicalCursor>())(
       arg0,
     );
   }
@@ -4000,10 +4141,10 @@ class LibClang {
   int clang_Cursor_getObjCSelectorIndex(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getObjCSelectorIndex ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCSelectorIndex,
-            _dart_clang_Cursor_getObjCSelectorIndex>(
-        'clang_Cursor_getObjCSelectorIndex'))(
+    return (_clang_Cursor_getObjCSelectorIndex ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCSelectorIndex>>(
+                'clang_Cursor_getObjCSelectorIndex')
+            .asFunction<_dart_clang_Cursor_getObjCSelectorIndex>())(
       arg0,
     );
   }
@@ -4022,9 +4163,10 @@ class LibClang {
   int clang_Cursor_isDynamicCall(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isDynamicCall ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isDynamicCall,
-        _dart_clang_Cursor_isDynamicCall>('clang_Cursor_isDynamicCall'))(
+    return (_clang_Cursor_isDynamicCall ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isDynamicCall>>(
+                'clang_Cursor_isDynamicCall')
+            .asFunction<_dart_clang_Cursor_isDynamicCall>())(
       C,
     );
   }
@@ -4036,9 +4178,10 @@ class LibClang {
   CXType clang_Cursor_getReceiverType(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getReceiverType ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getReceiverType,
-        _dart_clang_Cursor_getReceiverType>('clang_Cursor_getReceiverType'))(
+    return (_clang_Cursor_getReceiverType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getReceiverType>>(
+                'clang_Cursor_getReceiverType')
+            .asFunction<_dart_clang_Cursor_getReceiverType>())(
       C,
     );
   }
@@ -4054,10 +4197,10 @@ class LibClang {
     CXCursor C,
     int reserved,
   ) {
-    return (_clang_Cursor_getObjCPropertyAttributes ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCPropertyAttributes,
-            _dart_clang_Cursor_getObjCPropertyAttributes>(
-        'clang_Cursor_getObjCPropertyAttributes'))(
+    return (_clang_Cursor_getObjCPropertyAttributes ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCPropertyAttributes>>(
+                'clang_Cursor_getObjCPropertyAttributes')
+            .asFunction<_dart_clang_Cursor_getObjCPropertyAttributes>())(
       C,
       reserved,
     );
@@ -4071,10 +4214,10 @@ class LibClang {
   CXString clang_Cursor_getObjCPropertyGetterName(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getObjCPropertyGetterName ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCPropertyGetterName,
-            _dart_clang_Cursor_getObjCPropertyGetterName>(
-        'clang_Cursor_getObjCPropertyGetterName'))(
+    return (_clang_Cursor_getObjCPropertyGetterName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCPropertyGetterName>>(
+                'clang_Cursor_getObjCPropertyGetterName')
+            .asFunction<_dart_clang_Cursor_getObjCPropertyGetterName>())(
       C,
     );
   }
@@ -4087,10 +4230,10 @@ class LibClang {
   CXString clang_Cursor_getObjCPropertySetterName(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getObjCPropertySetterName ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCPropertySetterName,
-            _dart_clang_Cursor_getObjCPropertySetterName>(
-        'clang_Cursor_getObjCPropertySetterName'))(
+    return (_clang_Cursor_getObjCPropertySetterName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCPropertySetterName>>(
+                'clang_Cursor_getObjCPropertySetterName')
+            .asFunction<_dart_clang_Cursor_getObjCPropertySetterName>())(
       C,
     );
   }
@@ -4105,10 +4248,10 @@ class LibClang {
   int clang_Cursor_getObjCDeclQualifiers(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getObjCDeclQualifiers ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCDeclQualifiers,
-            _dart_clang_Cursor_getObjCDeclQualifiers>(
-        'clang_Cursor_getObjCDeclQualifiers'))(
+    return (_clang_Cursor_getObjCDeclQualifiers ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCDeclQualifiers>>(
+                'clang_Cursor_getObjCDeclQualifiers')
+            .asFunction<_dart_clang_Cursor_getObjCDeclQualifiers>())(
       C,
     );
   }
@@ -4121,9 +4264,10 @@ class LibClang {
   int clang_Cursor_isObjCOptional(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isObjCOptional ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isObjCOptional,
-        _dart_clang_Cursor_isObjCOptional>('clang_Cursor_isObjCOptional'))(
+    return (_clang_Cursor_isObjCOptional ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isObjCOptional>>(
+                'clang_Cursor_isObjCOptional')
+            .asFunction<_dart_clang_Cursor_isObjCOptional>())(
       C,
     );
   }
@@ -4134,9 +4278,10 @@ class LibClang {
   int clang_Cursor_isVariadic(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isVariadic ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isVariadic,
-        _dart_clang_Cursor_isVariadic>('clang_Cursor_isVariadic'))(
+    return (_clang_Cursor_isVariadic ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isVariadic>>(
+                'clang_Cursor_isVariadic')
+            .asFunction<_dart_clang_Cursor_isVariadic>())(
       C,
     );
   }
@@ -4160,9 +4305,10 @@ class LibClang {
     ffi.Pointer<CXString> definedIn,
     ffi.Pointer<ffi.Uint32> isGenerated,
   ) {
-    return (_clang_Cursor_isExternalSymbol ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isExternalSymbol,
-        _dart_clang_Cursor_isExternalSymbol>('clang_Cursor_isExternalSymbol'))(
+    return (_clang_Cursor_isExternalSymbol ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isExternalSymbol>>(
+                'clang_Cursor_isExternalSymbol')
+            .asFunction<_dart_clang_Cursor_isExternalSymbol>())(
       C,
       language,
       definedIn,
@@ -4178,9 +4324,10 @@ class LibClang {
   CXSourceRange clang_Cursor_getCommentRange(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getCommentRange ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getCommentRange,
-        _dart_clang_Cursor_getCommentRange>('clang_Cursor_getCommentRange'))(
+    return (_clang_Cursor_getCommentRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getCommentRange>>(
+                'clang_Cursor_getCommentRange')
+            .asFunction<_dart_clang_Cursor_getCommentRange>())(
       C,
     );
   }
@@ -4192,10 +4339,10 @@ class LibClang {
   CXString clang_Cursor_getRawCommentText(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getRawCommentText ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getRawCommentText,
-            _dart_clang_Cursor_getRawCommentText>(
-        'clang_Cursor_getRawCommentText'))(
+    return (_clang_Cursor_getRawCommentText ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getRawCommentText>>(
+                'clang_Cursor_getRawCommentText')
+            .asFunction<_dart_clang_Cursor_getRawCommentText>())(
       C,
     );
   }
@@ -4208,10 +4355,10 @@ class LibClang {
   CXString clang_Cursor_getBriefCommentText(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getBriefCommentText ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getBriefCommentText,
-            _dart_clang_Cursor_getBriefCommentText>(
-        'clang_Cursor_getBriefCommentText'))(
+    return (_clang_Cursor_getBriefCommentText ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getBriefCommentText>>(
+                'clang_Cursor_getBriefCommentText')
+            .asFunction<_dart_clang_Cursor_getBriefCommentText>())(
       C,
     );
   }
@@ -4222,9 +4369,10 @@ class LibClang {
   CXString clang_Cursor_getMangling(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getMangling ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getMangling,
-        _dart_clang_Cursor_getMangling>('clang_Cursor_getMangling'))(
+    return (_clang_Cursor_getMangling ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getMangling>>(
+                'clang_Cursor_getMangling')
+            .asFunction<_dart_clang_Cursor_getMangling>())(
       arg0,
     );
   }
@@ -4236,9 +4384,10 @@ class LibClang {
   ffi.Pointer<CXStringSet> clang_Cursor_getCXXManglings(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getCXXManglings ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getCXXManglings,
-        _dart_clang_Cursor_getCXXManglings>('clang_Cursor_getCXXManglings'))(
+    return (_clang_Cursor_getCXXManglings ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getCXXManglings>>(
+                'clang_Cursor_getCXXManglings')
+            .asFunction<_dart_clang_Cursor_getCXXManglings>())(
       arg0,
     );
   }
@@ -4250,9 +4399,10 @@ class LibClang {
   ffi.Pointer<CXStringSet> clang_Cursor_getObjCManglings(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getObjCManglings ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getObjCManglings,
-        _dart_clang_Cursor_getObjCManglings>('clang_Cursor_getObjCManglings'))(
+    return (_clang_Cursor_getObjCManglings ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCManglings>>(
+                'clang_Cursor_getObjCManglings')
+            .asFunction<_dart_clang_Cursor_getObjCManglings>())(
       arg0,
     );
   }
@@ -4263,9 +4413,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Cursor_getModule(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getModule ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getModule,
-        _dart_clang_Cursor_getModule>('clang_Cursor_getModule'))(
+    return (_clang_Cursor_getModule ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getModule>>(
+                'clang_Cursor_getModule')
+            .asFunction<_dart_clang_Cursor_getModule>())(
       C,
     );
   }
@@ -4278,9 +4429,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     ffi.Pointer<ffi.Void> arg1,
   ) {
-    return (_clang_getModuleForFile ??= _dylib.lookupFunction<
-        _c_clang_getModuleForFile,
-        _dart_clang_getModuleForFile>('clang_getModuleForFile'))(
+    return (_clang_getModuleForFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_getModuleForFile>>(
+                'clang_getModuleForFile')
+            .asFunction<_dart_clang_getModuleForFile>())(
       arg0,
       arg1,
     );
@@ -4294,9 +4446,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Module_getASTFile(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getASTFile ??= _dylib.lookupFunction<
-        _c_clang_Module_getASTFile,
-        _dart_clang_Module_getASTFile>('clang_Module_getASTFile'))(
+    return (_clang_Module_getASTFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getASTFile>>(
+                'clang_Module_getASTFile')
+            .asFunction<_dart_clang_Module_getASTFile>())(
       Module,
     );
   }
@@ -4310,9 +4463,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Module_getParent(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getParent ??= _dylib.lookupFunction<
-        _c_clang_Module_getParent,
-        _dart_clang_Module_getParent>('clang_Module_getParent'))(
+    return (_clang_Module_getParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getParent>>(
+                'clang_Module_getParent')
+            .asFunction<_dart_clang_Module_getParent>())(
       Module,
     );
   }
@@ -4326,9 +4480,10 @@ class LibClang {
   CXString clang_Module_getName(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getName ??= _dylib.lookupFunction<
-        _c_clang_Module_getName,
-        _dart_clang_Module_getName>('clang_Module_getName'))(
+    return (_clang_Module_getName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getName>>(
+                'clang_Module_getName')
+            .asFunction<_dart_clang_Module_getName>())(
       Module,
     );
   }
@@ -4341,9 +4496,10 @@ class LibClang {
   CXString clang_Module_getFullName(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getFullName ??= _dylib.lookupFunction<
-        _c_clang_Module_getFullName,
-        _dart_clang_Module_getFullName>('clang_Module_getFullName'))(
+    return (_clang_Module_getFullName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getFullName>>(
+                'clang_Module_getFullName')
+            .asFunction<_dart_clang_Module_getFullName>())(
       Module,
     );
   }
@@ -4356,9 +4512,10 @@ class LibClang {
   int clang_Module_isSystem(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_isSystem ??= _dylib.lookupFunction<
-        _c_clang_Module_isSystem,
-        _dart_clang_Module_isSystem>('clang_Module_isSystem'))(
+    return (_clang_Module_isSystem ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_isSystem>>(
+                'clang_Module_isSystem')
+            .asFunction<_dart_clang_Module_isSystem>())(
       Module,
     );
   }
@@ -4372,10 +4529,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getNumTopLevelHeaders ??= _dylib.lookupFunction<
-            _c_clang_Module_getNumTopLevelHeaders,
-            _dart_clang_Module_getNumTopLevelHeaders>(
-        'clang_Module_getNumTopLevelHeaders'))(
+    return (_clang_Module_getNumTopLevelHeaders ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getNumTopLevelHeaders>>(
+                'clang_Module_getNumTopLevelHeaders')
+            .asFunction<_dart_clang_Module_getNumTopLevelHeaders>())(
       arg0,
       Module,
     );
@@ -4393,10 +4550,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Module,
     int Index,
   ) {
-    return (_clang_Module_getTopLevelHeader ??= _dylib.lookupFunction<
-            _c_clang_Module_getTopLevelHeader,
-            _dart_clang_Module_getTopLevelHeader>(
-        'clang_Module_getTopLevelHeader'))(
+    return (_clang_Module_getTopLevelHeader ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getTopLevelHeader>>(
+                'clang_Module_getTopLevelHeader')
+            .asFunction<_dart_clang_Module_getTopLevelHeader>())(
       arg0,
       Module,
       Index,
@@ -4409,10 +4566,11 @@ class LibClang {
   int clang_CXXConstructor_isConvertingConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isConvertingConstructor ??=
-        _dylib.lookupFunction<_c_clang_CXXConstructor_isConvertingConstructor,
-                _dart_clang_CXXConstructor_isConvertingConstructor>(
-            'clang_CXXConstructor_isConvertingConstructor'))(
+    return (_clang_CXXConstructor_isConvertingConstructor ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_CXXConstructor_isConvertingConstructor>>(
+            'clang_CXXConstructor_isConvertingConstructor')
+        .asFunction<_dart_clang_CXXConstructor_isConvertingConstructor>())(
       C,
     );
   }
@@ -4424,10 +4582,10 @@ class LibClang {
   int clang_CXXConstructor_isCopyConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isCopyConstructor ??= _dylib.lookupFunction<
-            _c_clang_CXXConstructor_isCopyConstructor,
-            _dart_clang_CXXConstructor_isCopyConstructor>(
-        'clang_CXXConstructor_isCopyConstructor'))(
+    return (_clang_CXXConstructor_isCopyConstructor ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXConstructor_isCopyConstructor>>(
+                'clang_CXXConstructor_isCopyConstructor')
+            .asFunction<_dart_clang_CXXConstructor_isCopyConstructor>())(
       C,
     );
   }
@@ -4439,10 +4597,11 @@ class LibClang {
   int clang_CXXConstructor_isDefaultConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isDefaultConstructor ??=
-        _dylib.lookupFunction<_c_clang_CXXConstructor_isDefaultConstructor,
-                _dart_clang_CXXConstructor_isDefaultConstructor>(
-            'clang_CXXConstructor_isDefaultConstructor'))(
+    return (_clang_CXXConstructor_isDefaultConstructor ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_CXXConstructor_isDefaultConstructor>>(
+            'clang_CXXConstructor_isDefaultConstructor')
+        .asFunction<_dart_clang_CXXConstructor_isDefaultConstructor>())(
       C,
     );
   }
@@ -4454,10 +4613,10 @@ class LibClang {
   int clang_CXXConstructor_isMoveConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isMoveConstructor ??= _dylib.lookupFunction<
-            _c_clang_CXXConstructor_isMoveConstructor,
-            _dart_clang_CXXConstructor_isMoveConstructor>(
-        'clang_CXXConstructor_isMoveConstructor'))(
+    return (_clang_CXXConstructor_isMoveConstructor ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXConstructor_isMoveConstructor>>(
+                'clang_CXXConstructor_isMoveConstructor')
+            .asFunction<_dart_clang_CXXConstructor_isMoveConstructor>())(
       C,
     );
   }
@@ -4469,9 +4628,10 @@ class LibClang {
   int clang_CXXField_isMutable(
     CXCursor C,
   ) {
-    return (_clang_CXXField_isMutable ??= _dylib.lookupFunction<
-        _c_clang_CXXField_isMutable,
-        _dart_clang_CXXField_isMutable>('clang_CXXField_isMutable'))(
+    return (_clang_CXXField_isMutable ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXField_isMutable>>(
+                'clang_CXXField_isMutable')
+            .asFunction<_dart_clang_CXXField_isMutable>())(
       C,
     );
   }
@@ -4482,9 +4642,10 @@ class LibClang {
   int clang_CXXMethod_isDefaulted(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isDefaulted ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isDefaulted,
-        _dart_clang_CXXMethod_isDefaulted>('clang_CXXMethod_isDefaulted'))(
+    return (_clang_CXXMethod_isDefaulted ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isDefaulted>>(
+                'clang_CXXMethod_isDefaulted')
+            .asFunction<_dart_clang_CXXMethod_isDefaulted>())(
       C,
     );
   }
@@ -4496,9 +4657,10 @@ class LibClang {
   int clang_CXXMethod_isPureVirtual(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isPureVirtual ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isPureVirtual,
-        _dart_clang_CXXMethod_isPureVirtual>('clang_CXXMethod_isPureVirtual'))(
+    return (_clang_CXXMethod_isPureVirtual ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isPureVirtual>>(
+                'clang_CXXMethod_isPureVirtual')
+            .asFunction<_dart_clang_CXXMethod_isPureVirtual>())(
       C,
     );
   }
@@ -4510,9 +4672,10 @@ class LibClang {
   int clang_CXXMethod_isStatic(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isStatic ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isStatic,
-        _dart_clang_CXXMethod_isStatic>('clang_CXXMethod_isStatic'))(
+    return (_clang_CXXMethod_isStatic ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isStatic>>(
+                'clang_CXXMethod_isStatic')
+            .asFunction<_dart_clang_CXXMethod_isStatic>())(
       C,
     );
   }
@@ -4525,9 +4688,10 @@ class LibClang {
   int clang_CXXMethod_isVirtual(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isVirtual ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isVirtual,
-        _dart_clang_CXXMethod_isVirtual>('clang_CXXMethod_isVirtual'))(
+    return (_clang_CXXMethod_isVirtual ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isVirtual>>(
+                'clang_CXXMethod_isVirtual')
+            .asFunction<_dart_clang_CXXMethod_isVirtual>())(
       C,
     );
   }
@@ -4539,9 +4703,10 @@ class LibClang {
   int clang_CXXRecord_isAbstract(
     CXCursor C,
   ) {
-    return (_clang_CXXRecord_isAbstract ??= _dylib.lookupFunction<
-        _c_clang_CXXRecord_isAbstract,
-        _dart_clang_CXXRecord_isAbstract>('clang_CXXRecord_isAbstract'))(
+    return (_clang_CXXRecord_isAbstract ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXRecord_isAbstract>>(
+                'clang_CXXRecord_isAbstract')
+            .asFunction<_dart_clang_CXXRecord_isAbstract>())(
       C,
     );
   }
@@ -4552,9 +4717,10 @@ class LibClang {
   int clang_EnumDecl_isScoped(
     CXCursor C,
   ) {
-    return (_clang_EnumDecl_isScoped ??= _dylib.lookupFunction<
-        _c_clang_EnumDecl_isScoped,
-        _dart_clang_EnumDecl_isScoped>('clang_EnumDecl_isScoped'))(
+    return (_clang_EnumDecl_isScoped ??=
+        _lookup<ffi.NativeFunction<_c_clang_EnumDecl_isScoped>>(
+                'clang_EnumDecl_isScoped')
+            .asFunction<_dart_clang_EnumDecl_isScoped>())(
       C,
     );
   }
@@ -4566,9 +4732,10 @@ class LibClang {
   int clang_CXXMethod_isConst(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isConst ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isConst,
-        _dart_clang_CXXMethod_isConst>('clang_CXXMethod_isConst'))(
+    return (_clang_CXXMethod_isConst ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isConst>>(
+                'clang_CXXMethod_isConst')
+            .asFunction<_dart_clang_CXXMethod_isConst>())(
       C,
     );
   }
@@ -4593,9 +4760,10 @@ class LibClang {
   int clang_getTemplateCursorKind(
     CXCursor C,
   ) {
-    return (_clang_getTemplateCursorKind ??= _dylib.lookupFunction<
-        _c_clang_getTemplateCursorKind,
-        _dart_clang_getTemplateCursorKind>('clang_getTemplateCursorKind'))(
+    return (_clang_getTemplateCursorKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTemplateCursorKind>>(
+                'clang_getTemplateCursorKind')
+            .asFunction<_dart_clang_getTemplateCursorKind>())(
       C,
     );
   }
@@ -4631,10 +4799,10 @@ class LibClang {
   CXCursor clang_getSpecializedCursorTemplate(
     CXCursor C,
   ) {
-    return (_clang_getSpecializedCursorTemplate ??= _dylib.lookupFunction<
-            _c_clang_getSpecializedCursorTemplate,
-            _dart_clang_getSpecializedCursorTemplate>(
-        'clang_getSpecializedCursorTemplate'))(
+    return (_clang_getSpecializedCursorTemplate ??=
+        _lookup<ffi.NativeFunction<_c_clang_getSpecializedCursorTemplate>>(
+                'clang_getSpecializedCursorTemplate')
+            .asFunction<_dart_clang_getSpecializedCursorTemplate>())(
       C,
     );
   }
@@ -4662,10 +4830,10 @@ class LibClang {
     int NameFlags,
     int PieceIndex,
   ) {
-    return (_clang_getCursorReferenceNameRange ??= _dylib.lookupFunction<
-            _c_clang_getCursorReferenceNameRange,
-            _dart_clang_getCursorReferenceNameRange>(
-        'clang_getCursorReferenceNameRange'))(
+    return (_clang_getCursorReferenceNameRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorReferenceNameRange>>(
+                'clang_getCursorReferenceNameRange')
+            .asFunction<_dart_clang_getCursorReferenceNameRange>())(
       C,
       NameFlags,
       PieceIndex,
@@ -4688,8 +4856,8 @@ class LibClang {
     CXSourceLocation Location,
   ) {
     return (_clang_getToken ??=
-        _dylib.lookupFunction<_c_clang_getToken, _dart_clang_getToken>(
-            'clang_getToken'))(
+        _lookup<ffi.NativeFunction<_c_clang_getToken>>('clang_getToken')
+            .asFunction<_dart_clang_getToken>())(
       TU,
       Location,
     );
@@ -4702,8 +4870,8 @@ class LibClang {
     CXToken arg0,
   ) {
     return (_clang_getTokenKind ??=
-        _dylib.lookupFunction<_c_clang_getTokenKind, _dart_clang_getTokenKind>(
-            'clang_getTokenKind'))(
+        _lookup<ffi.NativeFunction<_c_clang_getTokenKind>>('clang_getTokenKind')
+            .asFunction<_dart_clang_getTokenKind>())(
       arg0,
     );
   }
@@ -4718,9 +4886,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     CXToken arg1,
   ) {
-    return (_clang_getTokenSpelling ??= _dylib.lookupFunction<
-        _c_clang_getTokenSpelling,
-        _dart_clang_getTokenSpelling>('clang_getTokenSpelling'))(
+    return (_clang_getTokenSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTokenSpelling>>(
+                'clang_getTokenSpelling')
+            .asFunction<_dart_clang_getTokenSpelling>())(
       arg0,
       arg1,
     );
@@ -4733,9 +4902,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     CXToken arg1,
   ) {
-    return (_clang_getTokenLocation ??= _dylib.lookupFunction<
-        _c_clang_getTokenLocation,
-        _dart_clang_getTokenLocation>('clang_getTokenLocation'))(
+    return (_clang_getTokenLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTokenLocation>>(
+                'clang_getTokenLocation')
+            .asFunction<_dart_clang_getTokenLocation>())(
       arg0,
       arg1,
     );
@@ -4748,9 +4918,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     CXToken arg1,
   ) {
-    return (_clang_getTokenExtent ??= _dylib.lookupFunction<
-        _c_clang_getTokenExtent,
-        _dart_clang_getTokenExtent>('clang_getTokenExtent'))(
+    return (_clang_getTokenExtent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTokenExtent>>(
+                'clang_getTokenExtent')
+            .asFunction<_dart_clang_getTokenExtent>())(
       arg0,
       arg1,
     );
@@ -4779,8 +4950,8 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> NumTokens,
   ) {
     return (_clang_tokenize ??=
-        _dylib.lookupFunction<_c_clang_tokenize, _dart_clang_tokenize>(
-            'clang_tokenize'))(
+        _lookup<ffi.NativeFunction<_c_clang_tokenize>>('clang_tokenize')
+            .asFunction<_dart_clang_tokenize>())(
       TU,
       Range,
       Tokens,
@@ -4824,9 +4995,10 @@ class LibClang {
     int NumTokens,
     ffi.Pointer<CXCursor> Cursors,
   ) {
-    return (_clang_annotateTokens ??= _dylib.lookupFunction<
-        _c_clang_annotateTokens,
-        _dart_clang_annotateTokens>('clang_annotateTokens'))(
+    return (_clang_annotateTokens ??=
+        _lookup<ffi.NativeFunction<_c_clang_annotateTokens>>(
+                'clang_annotateTokens')
+            .asFunction<_dart_clang_annotateTokens>())(
       TU,
       Tokens,
       NumTokens,
@@ -4842,9 +5014,10 @@ class LibClang {
     ffi.Pointer<CXToken> Tokens,
     int NumTokens,
   ) {
-    return (_clang_disposeTokens ??= _dylib.lookupFunction<
-        _c_clang_disposeTokens,
-        _dart_clang_disposeTokens>('clang_disposeTokens'))(
+    return (_clang_disposeTokens ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeTokens>>(
+                'clang_disposeTokens')
+            .asFunction<_dart_clang_disposeTokens>())(
       TU,
       Tokens,
       NumTokens,
@@ -4862,9 +5035,10 @@ class LibClang {
   CXString clang_getCursorKindSpelling(
     int Kind,
   ) {
-    return (_clang_getCursorKindSpelling ??= _dylib.lookupFunction<
-        _c_clang_getCursorKindSpelling,
-        _dart_clang_getCursorKindSpelling>('clang_getCursorKindSpelling'))(
+    return (_clang_getCursorKindSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorKindSpelling>>(
+                'clang_getCursorKindSpelling')
+            .asFunction<_dart_clang_getCursorKindSpelling>())(
       Kind,
     );
   }
@@ -4880,10 +5054,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> endLine,
     ffi.Pointer<ffi.Uint32> endColumn,
   ) {
-    return (_clang_getDefinitionSpellingAndExtent ??= _dylib.lookupFunction<
-            _c_clang_getDefinitionSpellingAndExtent,
-            _dart_clang_getDefinitionSpellingAndExtent>(
-        'clang_getDefinitionSpellingAndExtent'))(
+    return (_clang_getDefinitionSpellingAndExtent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDefinitionSpellingAndExtent>>(
+                'clang_getDefinitionSpellingAndExtent')
+            .asFunction<_dart_clang_getDefinitionSpellingAndExtent>())(
       arg0,
       startBuf,
       endBuf,
@@ -4898,9 +5072,10 @@ class LibClang {
       _clang_getDefinitionSpellingAndExtent;
 
   void clang_enableStackTraces() {
-    return (_clang_enableStackTraces ??= _dylib.lookupFunction<
-        _c_clang_enableStackTraces,
-        _dart_clang_enableStackTraces>('clang_enableStackTraces'))();
+    return (_clang_enableStackTraces ??=
+        _lookup<ffi.NativeFunction<_c_clang_enableStackTraces>>(
+                'clang_enableStackTraces')
+            .asFunction<_dart_clang_enableStackTraces>())();
   }
 
   _dart_clang_enableStackTraces? _clang_enableStackTraces;
@@ -4910,9 +5085,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> user_data,
     int stack_size,
   ) {
-    return (_clang_executeOnThread ??= _dylib.lookupFunction<
-        _c_clang_executeOnThread,
-        _dart_clang_executeOnThread>('clang_executeOnThread'))(
+    return (_clang_executeOnThread ??=
+        _lookup<ffi.NativeFunction<_c_clang_executeOnThread>>(
+                'clang_executeOnThread')
+            .asFunction<_dart_clang_executeOnThread>())(
       fn,
       user_data,
       stack_size,
@@ -4932,9 +5108,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int chunk_number,
   ) {
-    return (_clang_getCompletionChunkKind ??= _dylib.lookupFunction<
-        _c_clang_getCompletionChunkKind,
-        _dart_clang_getCompletionChunkKind>('clang_getCompletionChunkKind'))(
+    return (_clang_getCompletionChunkKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionChunkKind>>(
+                'clang_getCompletionChunkKind')
+            .asFunction<_dart_clang_getCompletionChunkKind>())(
       completion_string,
       chunk_number,
     );
@@ -4954,9 +5131,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int chunk_number,
   ) {
-    return (_clang_getCompletionChunkText ??= _dylib.lookupFunction<
-        _c_clang_getCompletionChunkText,
-        _dart_clang_getCompletionChunkText>('clang_getCompletionChunkText'))(
+    return (_clang_getCompletionChunkText ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionChunkText>>(
+                'clang_getCompletionChunkText')
+            .asFunction<_dart_clang_getCompletionChunkText>())(
       completion_string,
       chunk_number,
     );
@@ -4977,10 +5155,11 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int chunk_number,
   ) {
-    return (_clang_getCompletionChunkCompletionString ??= _dylib.lookupFunction<
-            _c_clang_getCompletionChunkCompletionString,
-            _dart_clang_getCompletionChunkCompletionString>(
-        'clang_getCompletionChunkCompletionString'))(
+    return (_clang_getCompletionChunkCompletionString ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_getCompletionChunkCompletionString>>(
+            'clang_getCompletionChunkCompletionString')
+        .asFunction<_dart_clang_getCompletionChunkCompletionString>())(
       completion_string,
       chunk_number,
     );
@@ -4993,9 +5172,10 @@ class LibClang {
   int clang_getNumCompletionChunks(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getNumCompletionChunks ??= _dylib.lookupFunction<
-        _c_clang_getNumCompletionChunks,
-        _dart_clang_getNumCompletionChunks>('clang_getNumCompletionChunks'))(
+    return (_clang_getNumCompletionChunks ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumCompletionChunks>>(
+                'clang_getNumCompletionChunks')
+            .asFunction<_dart_clang_getNumCompletionChunks>())(
       completion_string,
     );
   }
@@ -5015,9 +5195,10 @@ class LibClang {
   int clang_getCompletionPriority(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionPriority ??= _dylib.lookupFunction<
-        _c_clang_getCompletionPriority,
-        _dart_clang_getCompletionPriority>('clang_getCompletionPriority'))(
+    return (_clang_getCompletionPriority ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionPriority>>(
+                'clang_getCompletionPriority')
+            .asFunction<_dart_clang_getCompletionPriority>())(
       completion_string,
     );
   }
@@ -5033,10 +5214,10 @@ class LibClang {
   int clang_getCompletionAvailability(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionAvailability ??= _dylib.lookupFunction<
-            _c_clang_getCompletionAvailability,
-            _dart_clang_getCompletionAvailability>(
-        'clang_getCompletionAvailability'))(
+    return (_clang_getCompletionAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionAvailability>>(
+                'clang_getCompletionAvailability')
+            .asFunction<_dart_clang_getCompletionAvailability>())(
       completion_string,
     );
   }
@@ -5053,10 +5234,10 @@ class LibClang {
   int clang_getCompletionNumAnnotations(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionNumAnnotations ??= _dylib.lookupFunction<
-            _c_clang_getCompletionNumAnnotations,
-            _dart_clang_getCompletionNumAnnotations>(
-        'clang_getCompletionNumAnnotations'))(
+    return (_clang_getCompletionNumAnnotations ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionNumAnnotations>>(
+                'clang_getCompletionNumAnnotations')
+            .asFunction<_dart_clang_getCompletionNumAnnotations>())(
       completion_string,
     );
   }
@@ -5076,9 +5257,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int annotation_number,
   ) {
-    return (_clang_getCompletionAnnotation ??= _dylib.lookupFunction<
-        _c_clang_getCompletionAnnotation,
-        _dart_clang_getCompletionAnnotation>('clang_getCompletionAnnotation'))(
+    return (_clang_getCompletionAnnotation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionAnnotation>>(
+                'clang_getCompletionAnnotation')
+            .asFunction<_dart_clang_getCompletionAnnotation>())(
       completion_string,
       annotation_number,
     );
@@ -5104,9 +5286,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     ffi.Pointer<ffi.Int32> kind,
   ) {
-    return (_clang_getCompletionParent ??= _dylib.lookupFunction<
-        _c_clang_getCompletionParent,
-        _dart_clang_getCompletionParent>('clang_getCompletionParent'))(
+    return (_clang_getCompletionParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionParent>>(
+                'clang_getCompletionParent')
+            .asFunction<_dart_clang_getCompletionParent>())(
       completion_string,
       kind,
     );
@@ -5119,10 +5302,10 @@ class LibClang {
   CXString clang_getCompletionBriefComment(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionBriefComment ??= _dylib.lookupFunction<
-            _c_clang_getCompletionBriefComment,
-            _dart_clang_getCompletionBriefComment>(
-        'clang_getCompletionBriefComment'))(
+    return (_clang_getCompletionBriefComment ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionBriefComment>>(
+                'clang_getCompletionBriefComment')
+            .asFunction<_dart_clang_getCompletionBriefComment>())(
       completion_string,
     );
   }
@@ -5139,10 +5322,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getCursorCompletionString(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorCompletionString ??= _dylib.lookupFunction<
-            _c_clang_getCursorCompletionString,
-            _dart_clang_getCursorCompletionString>(
-        'clang_getCursorCompletionString'))(
+    return (_clang_getCursorCompletionString ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorCompletionString>>(
+                'clang_getCursorCompletionString')
+            .asFunction<_dart_clang_getCursorCompletionString>())(
       cursor,
     );
   }
@@ -5164,9 +5347,10 @@ class LibClang {
     ffi.Pointer<CXCodeCompleteResults> results,
     int completion_index,
   ) {
-    return (_clang_getCompletionNumFixIts ??= _dylib.lookupFunction<
-        _c_clang_getCompletionNumFixIts,
-        _dart_clang_getCompletionNumFixIts>('clang_getCompletionNumFixIts'))(
+    return (_clang_getCompletionNumFixIts ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionNumFixIts>>(
+                'clang_getCompletionNumFixIts')
+            .asFunction<_dart_clang_getCompletionNumFixIts>())(
       results,
       completion_index,
     );
@@ -5221,9 +5405,10 @@ class LibClang {
     int fixit_index,
     ffi.Pointer<CXSourceRange> replacement_range,
   ) {
-    return (_clang_getCompletionFixIt ??= _dylib.lookupFunction<
-        _c_clang_getCompletionFixIt,
-        _dart_clang_getCompletionFixIt>('clang_getCompletionFixIt'))(
+    return (_clang_getCompletionFixIt ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionFixIt>>(
+                'clang_getCompletionFixIt')
+            .asFunction<_dart_clang_getCompletionFixIt>())(
       results,
       completion_index,
       fixit_index,
@@ -5236,10 +5421,10 @@ class LibClang {
   /// Returns a default set of code-completion options that can be
   /// passed to\c clang_codeCompleteAt().
   int clang_defaultCodeCompleteOptions() {
-    return (_clang_defaultCodeCompleteOptions ??= _dylib.lookupFunction<
-            _c_clang_defaultCodeCompleteOptions,
-            _dart_clang_defaultCodeCompleteOptions>(
-        'clang_defaultCodeCompleteOptions'))();
+    return (_clang_defaultCodeCompleteOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultCodeCompleteOptions>>(
+                'clang_defaultCodeCompleteOptions')
+            .asFunction<_dart_clang_defaultCodeCompleteOptions>())();
   }
 
   _dart_clang_defaultCodeCompleteOptions? _clang_defaultCodeCompleteOptions;
@@ -5319,9 +5504,10 @@ class LibClang {
     int num_unsaved_files,
     int options,
   ) {
-    return (_clang_codeCompleteAt ??= _dylib.lookupFunction<
-        _c_clang_codeCompleteAt,
-        _dart_clang_codeCompleteAt>('clang_codeCompleteAt'))(
+    return (_clang_codeCompleteAt ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteAt>>(
+                'clang_codeCompleteAt')
+            .asFunction<_dart_clang_codeCompleteAt>())(
       TU,
       complete_filename,
       complete_line,
@@ -5343,10 +5529,10 @@ class LibClang {
     ffi.Pointer<CXCompletionResult> Results,
     int NumResults,
   ) {
-    return (_clang_sortCodeCompletionResults ??= _dylib.lookupFunction<
-            _c_clang_sortCodeCompletionResults,
-            _dart_clang_sortCodeCompletionResults>(
-        'clang_sortCodeCompletionResults'))(
+    return (_clang_sortCodeCompletionResults ??=
+        _lookup<ffi.NativeFunction<_c_clang_sortCodeCompletionResults>>(
+                'clang_sortCodeCompletionResults')
+            .asFunction<_dart_clang_sortCodeCompletionResults>())(
       Results,
       NumResults,
     );
@@ -5358,10 +5544,10 @@ class LibClang {
   void clang_disposeCodeCompleteResults(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_disposeCodeCompleteResults ??= _dylib.lookupFunction<
-            _c_clang_disposeCodeCompleteResults,
-            _dart_clang_disposeCodeCompleteResults>(
-        'clang_disposeCodeCompleteResults'))(
+    return (_clang_disposeCodeCompleteResults ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCodeCompleteResults>>(
+                'clang_disposeCodeCompleteResults')
+            .asFunction<_dart_clang_disposeCodeCompleteResults>())(
       Results,
     );
   }
@@ -5373,10 +5559,10 @@ class LibClang {
   int clang_codeCompleteGetNumDiagnostics(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetNumDiagnostics ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetNumDiagnostics,
-            _dart_clang_codeCompleteGetNumDiagnostics>(
-        'clang_codeCompleteGetNumDiagnostics'))(
+    return (_clang_codeCompleteGetNumDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetNumDiagnostics>>(
+                'clang_codeCompleteGetNumDiagnostics')
+            .asFunction<_dart_clang_codeCompleteGetNumDiagnostics>())(
       Results,
     );
   }
@@ -5395,10 +5581,10 @@ class LibClang {
     ffi.Pointer<CXCodeCompleteResults> Results,
     int Index,
   ) {
-    return (_clang_codeCompleteGetDiagnostic ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetDiagnostic,
-            _dart_clang_codeCompleteGetDiagnostic>(
-        'clang_codeCompleteGetDiagnostic'))(
+    return (_clang_codeCompleteGetDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetDiagnostic>>(
+                'clang_codeCompleteGetDiagnostic')
+            .asFunction<_dart_clang_codeCompleteGetDiagnostic>())(
       Results,
       Index,
     );
@@ -5416,9 +5602,10 @@ class LibClang {
   int clang_codeCompleteGetContexts(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetContexts ??= _dylib.lookupFunction<
-        _c_clang_codeCompleteGetContexts,
-        _dart_clang_codeCompleteGetContexts>('clang_codeCompleteGetContexts'))(
+    return (_clang_codeCompleteGetContexts ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetContexts>>(
+                'clang_codeCompleteGetContexts')
+            .asFunction<_dart_clang_codeCompleteGetContexts>())(
       Results,
     );
   }
@@ -5443,10 +5630,10 @@ class LibClang {
     ffi.Pointer<CXCodeCompleteResults> Results,
     ffi.Pointer<ffi.Uint32> IsIncomplete,
   ) {
-    return (_clang_codeCompleteGetContainerKind ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetContainerKind,
-            _dart_clang_codeCompleteGetContainerKind>(
-        'clang_codeCompleteGetContainerKind'))(
+    return (_clang_codeCompleteGetContainerKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetContainerKind>>(
+                'clang_codeCompleteGetContainerKind')
+            .asFunction<_dart_clang_codeCompleteGetContainerKind>())(
       Results,
       IsIncomplete,
     );
@@ -5464,10 +5651,10 @@ class LibClang {
   CXString clang_codeCompleteGetContainerUSR(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetContainerUSR ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetContainerUSR,
-            _dart_clang_codeCompleteGetContainerUSR>(
-        'clang_codeCompleteGetContainerUSR'))(
+    return (_clang_codeCompleteGetContainerUSR ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetContainerUSR>>(
+                'clang_codeCompleteGetContainerUSR')
+            .asFunction<_dart_clang_codeCompleteGetContainerUSR>())(
       Results,
     );
   }
@@ -5486,10 +5673,10 @@ class LibClang {
   CXString clang_codeCompleteGetObjCSelector(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetObjCSelector ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetObjCSelector,
-            _dart_clang_codeCompleteGetObjCSelector>(
-        'clang_codeCompleteGetObjCSelector'))(
+    return (_clang_codeCompleteGetObjCSelector ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetObjCSelector>>(
+                'clang_codeCompleteGetObjCSelector')
+            .asFunction<_dart_clang_codeCompleteGetObjCSelector>())(
       Results,
     );
   }
@@ -5499,9 +5686,10 @@ class LibClang {
   /// Return a version string, suitable for showing to a user, but not
   /// intended to be parsed (the format is not guaranteed to be stable).
   CXString clang_getClangVersion() {
-    return (_clang_getClangVersion ??= _dylib.lookupFunction<
-        _c_clang_getClangVersion,
-        _dart_clang_getClangVersion>('clang_getClangVersion'))();
+    return (_clang_getClangVersion ??=
+        _lookup<ffi.NativeFunction<_c_clang_getClangVersion>>(
+                'clang_getClangVersion')
+            .asFunction<_dart_clang_getClangVersion>())();
   }
 
   _dart_clang_getClangVersion? _clang_getClangVersion;
@@ -5513,9 +5701,10 @@ class LibClang {
   void clang_toggleCrashRecovery(
     int isEnabled,
   ) {
-    return (_clang_toggleCrashRecovery ??= _dylib.lookupFunction<
-        _c_clang_toggleCrashRecovery,
-        _dart_clang_toggleCrashRecovery>('clang_toggleCrashRecovery'))(
+    return (_clang_toggleCrashRecovery ??=
+        _lookup<ffi.NativeFunction<_c_clang_toggleCrashRecovery>>(
+                'clang_toggleCrashRecovery')
+            .asFunction<_dart_clang_toggleCrashRecovery>())(
       isEnabled,
     );
   }
@@ -5531,9 +5720,10 @@ class LibClang {
     ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
-    return (_clang_getInclusions ??= _dylib.lookupFunction<
-        _c_clang_getInclusions,
-        _dart_clang_getInclusions>('clang_getInclusions'))(
+    return (_clang_getInclusions ??=
+        _lookup<ffi.NativeFunction<_c_clang_getInclusions>>(
+                'clang_getInclusions')
+            .asFunction<_dart_clang_getInclusions>())(
       tu,
       visitor,
       client_data,
@@ -5548,9 +5738,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Cursor_Evaluate(
     CXCursor C,
   ) {
-    return (_clang_Cursor_Evaluate ??= _dylib.lookupFunction<
-        _c_clang_Cursor_Evaluate,
-        _dart_clang_Cursor_Evaluate>('clang_Cursor_Evaluate'))(
+    return (_clang_Cursor_Evaluate ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_Evaluate>>(
+                'clang_Cursor_Evaluate')
+            .asFunction<_dart_clang_Cursor_Evaluate>())(
       C,
     );
   }
@@ -5561,9 +5752,10 @@ class LibClang {
   int clang_EvalResult_getKind(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getKind ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getKind,
-        _dart_clang_EvalResult_getKind>('clang_EvalResult_getKind'))(
+    return (_clang_EvalResult_getKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getKind>>(
+                'clang_EvalResult_getKind')
+            .asFunction<_dart_clang_EvalResult_getKind>())(
       E,
     );
   }
@@ -5575,9 +5767,10 @@ class LibClang {
   int clang_EvalResult_getAsInt(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsInt ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getAsInt,
-        _dart_clang_EvalResult_getAsInt>('clang_EvalResult_getAsInt'))(
+    return (_clang_EvalResult_getAsInt ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsInt>>(
+                'clang_EvalResult_getAsInt')
+            .asFunction<_dart_clang_EvalResult_getAsInt>())(
       E,
     );
   }
@@ -5590,10 +5783,10 @@ class LibClang {
   int clang_EvalResult_getAsLongLong(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsLongLong ??= _dylib.lookupFunction<
-            _c_clang_EvalResult_getAsLongLong,
-            _dart_clang_EvalResult_getAsLongLong>(
-        'clang_EvalResult_getAsLongLong'))(
+    return (_clang_EvalResult_getAsLongLong ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsLongLong>>(
+                'clang_EvalResult_getAsLongLong')
+            .asFunction<_dart_clang_EvalResult_getAsLongLong>())(
       E,
     );
   }
@@ -5605,10 +5798,10 @@ class LibClang {
   int clang_EvalResult_isUnsignedInt(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_isUnsignedInt ??= _dylib.lookupFunction<
-            _c_clang_EvalResult_isUnsignedInt,
-            _dart_clang_EvalResult_isUnsignedInt>(
-        'clang_EvalResult_isUnsignedInt'))(
+    return (_clang_EvalResult_isUnsignedInt ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_isUnsignedInt>>(
+                'clang_EvalResult_isUnsignedInt')
+            .asFunction<_dart_clang_EvalResult_isUnsignedInt>())(
       E,
     );
   }
@@ -5620,10 +5813,10 @@ class LibClang {
   int clang_EvalResult_getAsUnsigned(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsUnsigned ??= _dylib.lookupFunction<
-            _c_clang_EvalResult_getAsUnsigned,
-            _dart_clang_EvalResult_getAsUnsigned>(
-        'clang_EvalResult_getAsUnsigned'))(
+    return (_clang_EvalResult_getAsUnsigned ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsUnsigned>>(
+                'clang_EvalResult_getAsUnsigned')
+            .asFunction<_dart_clang_EvalResult_getAsUnsigned>())(
       E,
     );
   }
@@ -5635,9 +5828,10 @@ class LibClang {
   double clang_EvalResult_getAsDouble(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsDouble ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getAsDouble,
-        _dart_clang_EvalResult_getAsDouble>('clang_EvalResult_getAsDouble'))(
+    return (_clang_EvalResult_getAsDouble ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsDouble>>(
+                'clang_EvalResult_getAsDouble')
+            .asFunction<_dart_clang_EvalResult_getAsDouble>())(
       E,
     );
   }
@@ -5651,9 +5845,10 @@ class LibClang {
   ffi.Pointer<ffi.Int8> clang_EvalResult_getAsStr(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsStr ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getAsStr,
-        _dart_clang_EvalResult_getAsStr>('clang_EvalResult_getAsStr'))(
+    return (_clang_EvalResult_getAsStr ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsStr>>(
+                'clang_EvalResult_getAsStr')
+            .asFunction<_dart_clang_EvalResult_getAsStr>())(
       E,
     );
   }
@@ -5664,9 +5859,10 @@ class LibClang {
   void clang_EvalResult_dispose(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_dispose ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_dispose,
-        _dart_clang_EvalResult_dispose>('clang_EvalResult_dispose'))(
+    return (_clang_EvalResult_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_dispose>>(
+                'clang_EvalResult_dispose')
+            .asFunction<_dart_clang_EvalResult_dispose>())(
       E,
     );
   }
@@ -5682,9 +5878,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getRemappings(
     ffi.Pointer<ffi.Int8> path,
   ) {
-    return (_clang_getRemappings ??= _dylib.lookupFunction<
-        _c_clang_getRemappings,
-        _dart_clang_getRemappings>('clang_getRemappings'))(
+    return (_clang_getRemappings ??=
+        _lookup<ffi.NativeFunction<_c_clang_getRemappings>>(
+                'clang_getRemappings')
+            .asFunction<_dart_clang_getRemappings>())(
       path,
     );
   }
@@ -5703,10 +5900,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> filePaths,
     int numFiles,
   ) {
-    return (_clang_getRemappingsFromFileList ??= _dylib.lookupFunction<
-            _c_clang_getRemappingsFromFileList,
-            _dart_clang_getRemappingsFromFileList>(
-        'clang_getRemappingsFromFileList'))(
+    return (_clang_getRemappingsFromFileList ??=
+        _lookup<ffi.NativeFunction<_c_clang_getRemappingsFromFileList>>(
+                'clang_getRemappingsFromFileList')
+            .asFunction<_dart_clang_getRemappingsFromFileList>())(
       filePaths,
       numFiles,
     );
@@ -5718,9 +5915,10 @@ class LibClang {
   int clang_remap_getNumFiles(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_remap_getNumFiles ??= _dylib.lookupFunction<
-        _c_clang_remap_getNumFiles,
-        _dart_clang_remap_getNumFiles>('clang_remap_getNumFiles'))(
+    return (_clang_remap_getNumFiles ??=
+        _lookup<ffi.NativeFunction<_c_clang_remap_getNumFiles>>(
+                'clang_remap_getNumFiles')
+            .asFunction<_dart_clang_remap_getNumFiles>())(
       arg0,
     );
   }
@@ -5739,9 +5937,10 @@ class LibClang {
     ffi.Pointer<CXString> original,
     ffi.Pointer<CXString> transformed,
   ) {
-    return (_clang_remap_getFilenames ??= _dylib.lookupFunction<
-        _c_clang_remap_getFilenames,
-        _dart_clang_remap_getFilenames>('clang_remap_getFilenames'))(
+    return (_clang_remap_getFilenames ??=
+        _lookup<ffi.NativeFunction<_c_clang_remap_getFilenames>>(
+                'clang_remap_getFilenames')
+            .asFunction<_dart_clang_remap_getFilenames>())(
       arg0,
       index,
       original,
@@ -5755,9 +5954,10 @@ class LibClang {
   void clang_remap_dispose(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_remap_dispose ??= _dylib.lookupFunction<
-        _c_clang_remap_dispose,
-        _dart_clang_remap_dispose>('clang_remap_dispose'))(
+    return (_clang_remap_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_remap_dispose>>(
+                'clang_remap_dispose')
+            .asFunction<_dart_clang_remap_dispose>())(
       arg0,
     );
   }
@@ -5781,9 +5981,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     CXCursorAndRangeVisitor visitor,
   ) {
-    return (_clang_findReferencesInFile ??= _dylib.lookupFunction<
-        _c_clang_findReferencesInFile,
-        _dart_clang_findReferencesInFile>('clang_findReferencesInFile'))(
+    return (_clang_findReferencesInFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_findReferencesInFile>>(
+                'clang_findReferencesInFile')
+            .asFunction<_dart_clang_findReferencesInFile>())(
       cursor,
       file,
       visitor,
@@ -5807,9 +6008,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     CXCursorAndRangeVisitor visitor,
   ) {
-    return (_clang_findIncludesInFile ??= _dylib.lookupFunction<
-        _c_clang_findIncludesInFile,
-        _dart_clang_findIncludesInFile>('clang_findIncludesInFile'))(
+    return (_clang_findIncludesInFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_findIncludesInFile>>(
+                'clang_findIncludesInFile')
+            .asFunction<_dart_clang_findIncludesInFile>())(
       TU,
       file,
       visitor,
@@ -5821,10 +6023,10 @@ class LibClang {
   int clang_index_isEntityObjCContainerKind(
     int arg0,
   ) {
-    return (_clang_index_isEntityObjCContainerKind ??= _dylib.lookupFunction<
-            _c_clang_index_isEntityObjCContainerKind,
-            _dart_clang_index_isEntityObjCContainerKind>(
-        'clang_index_isEntityObjCContainerKind'))(
+    return (_clang_index_isEntityObjCContainerKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_isEntityObjCContainerKind>>(
+                'clang_index_isEntityObjCContainerKind')
+            .asFunction<_dart_clang_index_isEntityObjCContainerKind>())(
       arg0,
     );
   }
@@ -5835,10 +6037,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCContainerDeclInfo> clang_index_getObjCContainerDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCContainerDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCContainerDeclInfo,
-            _dart_clang_index_getObjCContainerDeclInfo>(
-        'clang_index_getObjCContainerDeclInfo'))(
+    return (_clang_index_getObjCContainerDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCContainerDeclInfo>>(
+                'clang_index_getObjCContainerDeclInfo')
+            .asFunction<_dart_clang_index_getObjCContainerDeclInfo>())(
       arg0,
     );
   }
@@ -5849,10 +6051,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCInterfaceDeclInfo> clang_index_getObjCInterfaceDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCInterfaceDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCInterfaceDeclInfo,
-            _dart_clang_index_getObjCInterfaceDeclInfo>(
-        'clang_index_getObjCInterfaceDeclInfo'))(
+    return (_clang_index_getObjCInterfaceDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCInterfaceDeclInfo>>(
+                'clang_index_getObjCInterfaceDeclInfo')
+            .asFunction<_dart_clang_index_getObjCInterfaceDeclInfo>())(
       arg0,
     );
   }
@@ -5863,10 +6065,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCCategoryDeclInfo> clang_index_getObjCCategoryDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCCategoryDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCCategoryDeclInfo,
-            _dart_clang_index_getObjCCategoryDeclInfo>(
-        'clang_index_getObjCCategoryDeclInfo'))(
+    return (_clang_index_getObjCCategoryDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCCategoryDeclInfo>>(
+                'clang_index_getObjCCategoryDeclInfo')
+            .asFunction<_dart_clang_index_getObjCCategoryDeclInfo>())(
       arg0,
     );
   }
@@ -5878,10 +6080,10 @@ class LibClang {
       clang_index_getObjCProtocolRefListInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCProtocolRefListInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCProtocolRefListInfo,
-            _dart_clang_index_getObjCProtocolRefListInfo>(
-        'clang_index_getObjCProtocolRefListInfo'))(
+    return (_clang_index_getObjCProtocolRefListInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCProtocolRefListInfo>>(
+                'clang_index_getObjCProtocolRefListInfo')
+            .asFunction<_dart_clang_index_getObjCProtocolRefListInfo>())(
       arg0,
     );
   }
@@ -5892,10 +6094,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCPropertyDeclInfo> clang_index_getObjCPropertyDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCPropertyDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCPropertyDeclInfo,
-            _dart_clang_index_getObjCPropertyDeclInfo>(
-        'clang_index_getObjCPropertyDeclInfo'))(
+    return (_clang_index_getObjCPropertyDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCPropertyDeclInfo>>(
+                'clang_index_getObjCPropertyDeclInfo')
+            .asFunction<_dart_clang_index_getObjCPropertyDeclInfo>())(
       arg0,
     );
   }
@@ -5907,10 +6109,11 @@ class LibClang {
       clang_index_getIBOutletCollectionAttrInfo(
     ffi.Pointer<CXIdxAttrInfo> arg0,
   ) {
-    return (_clang_index_getIBOutletCollectionAttrInfo ??=
-        _dylib.lookupFunction<_c_clang_index_getIBOutletCollectionAttrInfo,
-                _dart_clang_index_getIBOutletCollectionAttrInfo>(
-            'clang_index_getIBOutletCollectionAttrInfo'))(
+    return (_clang_index_getIBOutletCollectionAttrInfo ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_index_getIBOutletCollectionAttrInfo>>(
+            'clang_index_getIBOutletCollectionAttrInfo')
+        .asFunction<_dart_clang_index_getIBOutletCollectionAttrInfo>())(
       arg0,
     );
   }
@@ -5921,10 +6124,10 @@ class LibClang {
   ffi.Pointer<CXIdxCXXClassDeclInfo> clang_index_getCXXClassDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getCXXClassDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getCXXClassDeclInfo,
-            _dart_clang_index_getCXXClassDeclInfo>(
-        'clang_index_getCXXClassDeclInfo'))(
+    return (_clang_index_getCXXClassDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getCXXClassDeclInfo>>(
+                'clang_index_getCXXClassDeclInfo')
+            .asFunction<_dart_clang_index_getCXXClassDeclInfo>())(
       arg0,
     );
   }
@@ -5936,10 +6139,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_index_getClientContainer(
     ffi.Pointer<CXIdxContainerInfo> arg0,
   ) {
-    return (_clang_index_getClientContainer ??= _dylib.lookupFunction<
-            _c_clang_index_getClientContainer,
-            _dart_clang_index_getClientContainer>(
-        'clang_index_getClientContainer'))(
+    return (_clang_index_getClientContainer ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getClientContainer>>(
+                'clang_index_getClientContainer')
+            .asFunction<_dart_clang_index_getClientContainer>())(
       arg0,
     );
   }
@@ -5952,10 +6155,10 @@ class LibClang {
     ffi.Pointer<CXIdxContainerInfo> arg0,
     ffi.Pointer<ffi.Void> arg1,
   ) {
-    return (_clang_index_setClientContainer ??= _dylib.lookupFunction<
-            _c_clang_index_setClientContainer,
-            _dart_clang_index_setClientContainer>(
-        'clang_index_setClientContainer'))(
+    return (_clang_index_setClientContainer ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_setClientContainer>>(
+                'clang_index_setClientContainer')
+            .asFunction<_dart_clang_index_setClientContainer>())(
       arg0,
       arg1,
     );
@@ -5967,9 +6170,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_index_getClientEntity(
     ffi.Pointer<CXIdxEntityInfo> arg0,
   ) {
-    return (_clang_index_getClientEntity ??= _dylib.lookupFunction<
-        _c_clang_index_getClientEntity,
-        _dart_clang_index_getClientEntity>('clang_index_getClientEntity'))(
+    return (_clang_index_getClientEntity ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getClientEntity>>(
+                'clang_index_getClientEntity')
+            .asFunction<_dart_clang_index_getClientEntity>())(
       arg0,
     );
   }
@@ -5981,9 +6185,10 @@ class LibClang {
     ffi.Pointer<CXIdxEntityInfo> arg0,
     ffi.Pointer<ffi.Void> arg1,
   ) {
-    return (_clang_index_setClientEntity ??= _dylib.lookupFunction<
-        _c_clang_index_setClientEntity,
-        _dart_clang_index_setClientEntity>('clang_index_setClientEntity'))(
+    return (_clang_index_setClientEntity ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_setClientEntity>>(
+                'clang_index_setClientEntity')
+            .asFunction<_dart_clang_index_setClientEntity>())(
       arg0,
       arg1,
     );
@@ -5998,9 +6203,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_IndexAction_create(
     ffi.Pointer<ffi.Void> CIdx,
   ) {
-    return (_clang_IndexAction_create ??= _dylib.lookupFunction<
-        _c_clang_IndexAction_create,
-        _dart_clang_IndexAction_create>('clang_IndexAction_create'))(
+    return (_clang_IndexAction_create ??=
+        _lookup<ffi.NativeFunction<_c_clang_IndexAction_create>>(
+                'clang_IndexAction_create')
+            .asFunction<_dart_clang_IndexAction_create>())(
       CIdx,
     );
   }
@@ -6014,9 +6220,10 @@ class LibClang {
   void clang_IndexAction_dispose(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_IndexAction_dispose ??= _dylib.lookupFunction<
-        _c_clang_IndexAction_dispose,
-        _dart_clang_IndexAction_dispose>('clang_IndexAction_dispose'))(
+    return (_clang_IndexAction_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_IndexAction_dispose>>(
+                'clang_IndexAction_dispose')
+            .asFunction<_dart_clang_IndexAction_dispose>())(
       arg0,
     );
   }
@@ -6060,9 +6267,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
     int TU_options,
   ) {
-    return (_clang_indexSourceFile ??= _dylib.lookupFunction<
-        _c_clang_indexSourceFile,
-        _dart_clang_indexSourceFile>('clang_indexSourceFile'))(
+    return (_clang_indexSourceFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexSourceFile>>(
+                'clang_indexSourceFile')
+            .asFunction<_dart_clang_indexSourceFile>())(
       arg0,
       client_data,
       index_callbacks,
@@ -6097,9 +6305,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
     int TU_options,
   ) {
-    return (_clang_indexSourceFileFullArgv ??= _dylib.lookupFunction<
-        _c_clang_indexSourceFileFullArgv,
-        _dart_clang_indexSourceFileFullArgv>('clang_indexSourceFileFullArgv'))(
+    return (_clang_indexSourceFileFullArgv ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexSourceFileFullArgv>>(
+                'clang_indexSourceFileFullArgv')
+            .asFunction<_dart_clang_indexSourceFileFullArgv>())(
       arg0,
       client_data,
       index_callbacks,
@@ -6139,9 +6348,10 @@ class LibClang {
     int index_options,
     ffi.Pointer<CXTranslationUnitImpl> arg5,
   ) {
-    return (_clang_indexTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_indexTranslationUnit,
-        _dart_clang_indexTranslationUnit>('clang_indexTranslationUnit'))(
+    return (_clang_indexTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexTranslationUnit>>(
+                'clang_indexTranslationUnit')
+            .asFunction<_dart_clang_indexTranslationUnit>())(
       arg0,
       client_data,
       index_callbacks,
@@ -6167,10 +6377,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_indexLoc_getFileLocation ??= _dylib.lookupFunction<
-            _c_clang_indexLoc_getFileLocation,
-            _dart_clang_indexLoc_getFileLocation>(
-        'clang_indexLoc_getFileLocation'))(
+    return (_clang_indexLoc_getFileLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexLoc_getFileLocation>>(
+                'clang_indexLoc_getFileLocation')
+            .asFunction<_dart_clang_indexLoc_getFileLocation>())(
       loc,
       indexFile,
       file,
@@ -6186,10 +6396,10 @@ class LibClang {
   CXSourceLocation clang_indexLoc_getCXSourceLocation(
     CXIdxLoc loc,
   ) {
-    return (_clang_indexLoc_getCXSourceLocation ??= _dylib.lookupFunction<
-            _c_clang_indexLoc_getCXSourceLocation,
-            _dart_clang_indexLoc_getCXSourceLocation>(
-        'clang_indexLoc_getCXSourceLocation'))(
+    return (_clang_indexLoc_getCXSourceLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexLoc_getCXSourceLocation>>(
+                'clang_indexLoc_getCXSourceLocation')
+            .asFunction<_dart_clang_indexLoc_getCXSourceLocation>())(
       loc,
     );
   }
@@ -6218,9 +6428,10 @@ class LibClang {
     ffi.Pointer<ffi.NativeFunction<CXFieldVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
-    return (_clang_Type_visitFields ??= _dylib.lookupFunction<
-        _c_clang_Type_visitFields,
-        _dart_clang_Type_visitFields>('clang_Type_visitFields'))(
+    return (_clang_Type_visitFields ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_visitFields>>(
+                'clang_Type_visitFields')
+            .asFunction<_dart_clang_Type_visitFields>())(
       T,
       visitor,
       client_data,
@@ -6343,7 +6554,7 @@ class ArrayHelper_CXFileUniqueID_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6407,7 +6618,7 @@ class ArrayHelper_CXSourceLocation_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6468,7 +6679,7 @@ class ArrayHelper_CXSourceRange_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6571,7 +6782,7 @@ class ArrayHelper_CXCursor_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6793,7 +7004,7 @@ class ArrayHelper_CXType_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6853,7 +7064,7 @@ class ArrayHelper_CXToken_int_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6957,7 +7168,7 @@ class ArrayHelper_CXIdxLoc_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 

--- a/example/libclang-example/pubspec.yaml
+++ b/example/libclang-example/pubspec.yaml
@@ -5,7 +5,7 @@
 name: libclang_example
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   ffigen:

--- a/example/simple/generated_bindings.dart
+++ b/example/simple/generated_bindings.dart
@@ -5,18 +5,27 @@ import 'dart:ffi' as ffi;
 
 /// Bindings to `headers/example.h`.
 class NativeLibrary {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  NativeLibrary(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  NativeLibrary(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  NativeLibrary.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   /// Adds 2 integers.
   int sum(
     int a,
     int b,
   ) {
-    return (_sum ??= _dylib.lookupFunction<_c_sum, _dart_sum>('sum'))(
+    return (_sum ??=
+        _lookup<ffi.NativeFunction<_c_sum>>('sum').asFunction<_dart_sum>())(
       a,
       b,
     );
@@ -29,8 +38,8 @@ class NativeLibrary {
     ffi.Pointer<ffi.Int32> a,
     int b,
   ) {
-    return (_subtract ??=
-        _dylib.lookupFunction<_c_subtract, _dart_subtract>('subtract'))(
+    return (_subtract ??= _lookup<ffi.NativeFunction<_c_subtract>>('subtract')
+        .asFunction<_dart_subtract>())(
       a,
       b,
     );
@@ -43,8 +52,8 @@ class NativeLibrary {
     int a,
     int b,
   ) {
-    return (_multiply ??=
-        _dylib.lookupFunction<_c_multiply, _dart_multiply>('multiply'))(
+    return (_multiply ??= _lookup<ffi.NativeFunction<_c_multiply>>('multiply')
+        .asFunction<_dart_multiply>())(
       a,
       b,
     );
@@ -57,8 +66,8 @@ class NativeLibrary {
     int a,
     int b,
   ) {
-    return (_divide ??=
-        _dylib.lookupFunction<_c_divide, _dart_divide>('divide'))(
+    return (_divide ??= _lookup<ffi.NativeFunction<_c_divide>>('divide')
+        .asFunction<_dart_divide>())(
       a,
       b,
     );
@@ -72,8 +81,8 @@ class NativeLibrary {
     ffi.Pointer<ffi.Float> b,
   ) {
     return (_dividePercision ??=
-        _dylib.lookupFunction<_c_dividePercision, _dart_dividePercision>(
-            'dividePercision'))(
+        _lookup<ffi.NativeFunction<_c_dividePercision>>('dividePercision')
+            .asFunction<_dart_dividePercision>())(
       a,
       b,
     );

--- a/example/simple/pubspec.yaml
+++ b/example/simple/pubspec.yaml
@@ -5,7 +5,7 @@
 name: simple_example
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   ffigen:

--- a/lib/src/code_generator/constant.dart
+++ b/lib/src/code_generator/constant.dart
@@ -50,7 +50,7 @@ class Constant extends NoLookUpBinding {
       s.write(makeDartDoc(dartDoc!));
     }
 
-    s.write('const ${rawType} $constantName = $rawValue;\n\n');
+    s.write('const $rawType $constantName = $rawValue;\n\n');
 
     return BindingString(
         type: BindingStringType.constant, string: s.toString());

--- a/lib/src/code_generator/enum_class.dart
+++ b/lib/src/code_generator/enum_class.dart
@@ -61,7 +61,7 @@ class EnumClass extends NoLookUpBinding {
         s.writeAll(ec.dartDoc!.split('\n'), '\n' + depth + '/// ');
         s.write('\n');
       }
-      s.write(depth + 'static const int ${enum_value_name} = ${ec.value};\n');
+      s.write(depth + 'static const int $enum_value_name = ${ec.value};\n');
     }
     s.write('}\n\n');
 

--- a/lib/src/code_generator/func.dart
+++ b/lib/src/code_generator/func.dart
@@ -128,7 +128,7 @@ class Func extends LookUpBinding {
     }
     s.write(') {\n');
     s.write(
-        "return ($funcVarName ??= ${w.dylibIdentifier}.lookupFunction<${cType.name},${dartType.name}>('$originalName'))");
+        "return ($funcVarName ??= ${w.lookupFuncIdentifier}<${w.ffiLibraryPrefix}.NativeFunction<${cType.name}>>('$originalName').asFunction<${dartType.name}>())");
 
     s.write('(\n');
     for (final p in parameters) {

--- a/lib/src/code_generator/global.dart
+++ b/lib/src/code_generator/global.dart
@@ -63,7 +63,7 @@ class Global extends LookUpBinding {
     final cType = type.getCType(w);
 
     s.write(
-        "late final ${w.ffiLibraryPrefix}.Pointer<$cType> $pointerName = ${w.dylibIdentifier}.lookup<$cType>('$originalName');\n\n");
+        "late final ${w.ffiLibraryPrefix}.Pointer<$cType> $pointerName = ${w.lookupFuncIdentifier}<$cType>('$originalName');\n\n");
     if (type.broadType == BroadType.Struct) {
       if (type.struc!.isOpaque) {
         s.write(

--- a/lib/src/code_generator/struc.dart
+++ b/lib/src/code_generator/struc.dart
@@ -111,12 +111,12 @@ class Struc extends NoLookUpBinding {
         // TODO(5): Remove array helpers when inline array support arives.
         final arrayHelper = ArrayHelper(
           helperClassGroupName:
-              '${w.arrayHelperClassPrefix}_${enclosingClassName}_${memberName}',
+              '${w.arrayHelperClassPrefix}_${enclosingClassName}_$memberName',
           elementType: m.type.getBaseArrayType(),
           dimensions: _getArrayDimensionLengths(m.type),
           name: memberName,
           structName: enclosingClassName,
-          elementNamePrefix: '${expandedArrayItemPrefix}${memberName}_item_',
+          elementNamePrefix: '$expandedArrayItemPrefix${memberName}_item_',
         );
         s.write(arrayHelper.declarationString(w));
         helpers.add(arrayHelper);
@@ -130,7 +130,7 @@ class Struc extends NoLookUpBinding {
         if (m.type.isPrimitive) {
           s.write('$depth@${m.type.getCType(w)}()\n');
         }
-        s.write('${depth}external ${m.type.getDartType(w)} ${memberName};\n\n');
+        s.write('${depth}external ${m.type.getDartType(w)} $memberName;\n\n');
       }
     }
     s.write('}\n\n');
@@ -152,7 +152,7 @@ class Struc extends NoLookUpBinding {
         // Not a unique prefix, start over with a new suffix.
         i = -1;
         suffixInt++;
-        expandedArrayItemPrefix = '${base}${suffixInt}';
+        expandedArrayItemPrefix = '$base$suffixInt';
       }
     }
     return expandedArrayItemPrefix + '_';
@@ -211,9 +211,9 @@ class ArrayHelper {
 
     for (var i = 0; i < expandedArrayLength; i++) {
       if (elementType.isPrimitive) {
-        s.write('  @${arrayCType}()\n');
+        s.write('  @$arrayCType()\n');
       }
-      s.write('  external ${arrayDartType} ${elementNamePrefix}$i;\n');
+      s.write('  external $arrayDartType $elementNamePrefix$i;\n');
     }
 
     s.write('/// Helper for array `$name`.\n');
@@ -227,7 +227,7 @@ class ArrayHelper {
     final s = StringBuffer();
     final arrayType = elementType.getDartType(w);
     for (var dim = 0; dim < dimensions.length; dim++) {
-      final helperClassName = '${helperClassGroupName}_level${dim}';
+      final helperClassName = '${helperClassGroupName}_level$dim';
       final structIdentifier = '_struct';
       final dimensionsIdentifier = 'dimensions';
       final levelIdentifier = 'level';
@@ -238,7 +238,7 @@ class ArrayHelper {
       s.write('/// Helper for array `$name` in struct `$structName`.\n');
 
       // Write class declaration.
-      s.write('class ${helperClassName}{\n');
+      s.write('class $helperClassName{\n');
       s.write('final $structName $structIdentifier;\n');
       s.write('final List<int> $dimensionsIdentifier;\n');
       s.write('final int $levelIdentifier;\n');
@@ -280,7 +280,7 @@ class ArrayHelper {
         s.write('switch($absoluteIndexIdentifier+index){\n');
         for (var i = 0; i < expandedArrayLength; i++) {
           s.write('case $i:\n');
-          s.write('  return $structIdentifier.${elementNamePrefix}$i;\n');
+          s.write('  return $structIdentifier.$elementNamePrefix$i;\n');
         }
         s.write('default:\n');
         s.write("  throw Exception('Invalid Array Helper generated.');");
@@ -293,7 +293,7 @@ class ArrayHelper {
         s.write('switch($absoluteIndexIdentifier+index){\n');
         for (var i = 0; i < expandedArrayLength; i++) {
           s.write('case $i:\n');
-          s.write('  $structIdentifier.${elementNamePrefix}$i = value;\n');
+          s.write('  $structIdentifier.$elementNamePrefix$i = value;\n');
           s.write('  break;\n');
         }
         s.write('default:\n');

--- a/lib/src/code_generator/struc.dart
+++ b/lib/src/code_generator/struc.dart
@@ -254,7 +254,7 @@ class ArrayHelper {
       s.write('''
   void $checkBoundsFunctionIdentifier(int index) {
     if (index >= $legthIdentifier || index < 0) {
-      throw RangeError('Dimension \$$levelIdentifier: index not in range 0..\${$legthIdentifier} exclusive.');
+      throw RangeError('Dimension \$$levelIdentifier: index not in range 0..\$$legthIdentifier exclusive.');
     }
   }
   ''');

--- a/lib/src/code_generator/type.dart
+++ b/lib/src/code_generator/type.dart
@@ -220,6 +220,6 @@ class Type {
 
   @override
   String toString() {
-    return 'Type: ${broadType}';
+    return 'Type: $broadType';
   }
 }

--- a/lib/src/code_generator/typedef.dart
+++ b/lib/src/code_generator/typedef.dart
@@ -65,7 +65,7 @@ class Typedef {
       s.write('typedef $typedefName = ${returnType.getCType(w)} Function(\n');
       for (final p in parameters) {
         final name = p.name.isNotEmpty ? paramNamer.makeUnique(p.name) : p.name;
-        s.write('  ${p.type.getCType(w)} ${name},\n');
+        s.write('  ${p.type.getCType(w)} $name,\n');
       }
       s.write(');\n\n');
     } else {
@@ -74,7 +74,7 @@ class Typedef {
       for (final p in parameters) {
         final name = p.name.isNotEmpty ? paramNamer.makeUnique(p.name) : p.name;
 
-        s.write('  ${p.type.getDartType(w)} ${name},\n');
+        s.write('  ${p.type.getDartType(w)} $name,\n');
       }
       s.write(');\n\n');
     }

--- a/lib/src/code_generator/writer.dart
+++ b/lib/src/code_generator/writer.dart
@@ -23,8 +23,8 @@ class Writer {
   String? _ffiLibraryPrefix;
   String? get ffiLibraryPrefix => _ffiLibraryPrefix;
 
-  String? _dylibIdentifier;
-  String? get dylibIdentifier => _dylibIdentifier;
+  String? _lookupFuncIdentifier;
+  String? get lookupFuncIdentifier => _lookupFuncIdentifier;
 
   final bool dartBool;
 
@@ -70,8 +70,8 @@ class Writer {
     /// [_ffiLibraryPrefix] should be unique in top level.
     _ffiLibraryPrefix = _initialTopLevelUniqueNamer.makeUnique('ffi');
 
-    /// [_dylibIdentifier] should be unique in top level.
-    _dylibIdentifier = _initialTopLevelUniqueNamer.makeUnique('_dylib');
+    /// [_lookupFuncIdentifier] should be unique in top level.
+    _lookupFuncIdentifier = _initialTopLevelUniqueNamer.makeUnique('_lookup');
 
     /// Finding a unique prefix for Array Helper Classes and store into
     /// [_arrayHelperClassPrefix].
@@ -140,14 +140,20 @@ class Writer {
       // Write wrapper classs.
       s.write('class $_className{\n');
       // Write dylib.
-      s.write('/// Holds the Dynamic library.\n');
-      s.write('final $ffiLibraryPrefix.DynamicLibrary $dylibIdentifier;\n');
+      s.write('/// Holds the symbol lookup function.\n');
+      s.write(
+          'final $ffiLibraryPrefix.Pointer<T> Function<T extends $ffiLibraryPrefix.NativeType>(String symbolName) $lookupFuncIdentifier;\n');
       s.write('\n');
       //Write doc comment for wrapper class constructor.
       s.write(makeDartDoc('The symbols are looked up in [dynamicLibrary].'));
       // Write wrapper class constructor.
       s.write(
-          '$_className($ffiLibraryPrefix.DynamicLibrary dynamicLibrary): $dylibIdentifier = dynamicLibrary;\n\n');
+          '$_className($ffiLibraryPrefix.DynamicLibrary dynamicLibrary): $lookupFuncIdentifier = dynamicLibrary.lookup;\n\n');
+      //Write doc comment for wrapper class named constructor.
+      s.write(makeDartDoc('The symbols are looked up with [lookup].'));
+      // Write wrapper class named constructor.
+      s.write(
+          '$_className.fromLookup($ffiLibraryPrefix.Pointer<T> Function<T extends $ffiLibraryPrefix.NativeType>(String symbolName) lookup): $lookupFuncIdentifier = lookup;\n\n');
       for (final b in lookUpBindings) {
         s.write(b.toBindingString(this).string);
       }

--- a/lib/src/code_generator/writer.dart
+++ b/lib/src/code_generator/writer.dart
@@ -83,7 +83,7 @@ class Writer {
         // Not a unique prefix, start over with a new suffix.
         i = -1;
         suffixInt++;
-        _arrayHelperClassPrefix = '${base}${suffixInt}';
+        _arrayHelperClassPrefix = '$base$suffixInt';
       }
     }
 
@@ -141,13 +141,13 @@ class Writer {
       s.write('class $_className{\n');
       // Write dylib.
       s.write('/// Holds the Dynamic library.\n');
-      s.write('final $ffiLibraryPrefix.DynamicLibrary ${dylibIdentifier};\n');
+      s.write('final $ffiLibraryPrefix.DynamicLibrary $dylibIdentifier;\n');
       s.write('\n');
       //Write doc comment for wrapper class constructor.
       s.write(makeDartDoc('The symbols are looked up in [dynamicLibrary].'));
       // Write wrapper class constructor.
       s.write(
-          '${_className}($ffiLibraryPrefix.DynamicLibrary dynamicLibrary): $dylibIdentifier = dynamicLibrary;\n\n');
+          '$_className($ffiLibraryPrefix.DynamicLibrary dynamicLibrary): $dylibIdentifier = dynamicLibrary;\n\n');
       for (final b in lookUpBindings) {
         s.write(b.toBindingString(this).string);
       }

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -129,7 +129,7 @@ class Config {
       if (map.containsKey(key)) {
         _result = _result && spec!.validator(key, map[key]);
       } else if (spec!.requirement == Requirement.yes) {
-        _logger.severe("Key '${key}' is required.");
+        _logger.severe("Key '$key' is required.");
         _result = false;
       } else if (spec.requirement == Requirement.prefer) {
         _logger.warning("Prefer adding Key '$key' to your config.");

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -32,7 +32,7 @@ String _replaceSeparators(String path) {
 bool checkType<T>(List<String> keys, dynamic value) {
   if (value is! T) {
     _logger.severe(
-        "Expected value of key '${keys.join(' -> ')}' to be of type '${T}'.");
+        "Expected value of key '${keys.join(' -> ')}' to be of type '$T'.");
     return false;
   }
   return true;
@@ -127,7 +127,7 @@ Headers headersExtractor(dynamic yamlConfig) {
               followLinks: true)) {
             final fixedPath = _replaceSeparators(file.path);
             entryPoints.add(fixedPath);
-            _logger.fine('Adding header/file: ${fixedPath}');
+            _logger.fine('Adding header/file: $fixedPath');
           }
         }
       }

--- a/lib/src/executables/ffigen.dart
+++ b/lib/src/executables/ffigen.dart
@@ -174,14 +174,14 @@ void setupLogger(ArgResults result) {
     // Setup logger for printing (if verbosity was set by user).
     Logger.root.onRecord.listen((record) {
       final level = '[${record.level.name}]'.padRight(9);
-      printLog('${level}: ${record.message}', record.level);
+      printLog('$level: ${record.message}', record.level);
     });
   } else {
     // Setup logger for printing (if verbosity was not set by user).
     Logger.root.onRecord.listen((record) {
       if (record.level.value > Level.INFO.value) {
         final level = '[${record.level.name}]'.padRight(9);
-        printLog('${level}: ${record.message}', record.level);
+        printLog('$level: ${record.message}', record.level);
       } else {
         printLog(record.message, record.level);
       }

--- a/lib/src/header_parser/clang_bindings/clang_bindings.dart
+++ b/lib/src/header_parser/clang_bindings/clang_bindings.dart
@@ -997,7 +997,7 @@ class ArrayHelper_CXSourceLocation_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -1058,7 +1058,7 @@ class ArrayHelper_CXSourceRange_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -2093,7 +2093,7 @@ class ArrayHelper_CXCursor_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -2284,7 +2284,7 @@ class ArrayHelper_CXType_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 

--- a/lib/src/header_parser/sub_parsers/macro_parser.dart
+++ b/lib/src/header_parser/sub_parsers/macro_parser.dart
@@ -140,7 +140,7 @@ int _macroVariablevisitor(clang_types.CXCursor cursor,
             originalName: savedMacros[macroName]!.originalName,
             name: macroName,
             rawType: 'String',
-            rawValue: "'${rawValue}'",
+            rawValue: "'$rawValue'",
           );
           break;
       }
@@ -201,7 +201,7 @@ File createFileForMacros() {
     // Write macro.
     final macroVarName = MacroVariableString.encode(prefixedMacroName);
     sb.writeln(
-        'auto ${macroVarName} = ${savedMacros[prefixedMacroName]!.originalName};');
+        'auto $macroVarName = ${savedMacros[prefixedMacroName]!.originalName};');
     // Add to _macroVarNames.
     _macroVarNames.add(macroVarName);
   }
@@ -291,7 +291,7 @@ String _getWritableChar(int char, {bool utf8 = true}) {
         return r'\r';
       default:
         final h = char.toRadixString(16).toUpperCase().padLeft(2, '0');
-        return '\\x${h}';
+        return '\\x$h';
     }
   }
 
@@ -309,7 +309,7 @@ String _getWritableChar(int char, {bool utf8 = true}) {
   /// Print range [128..255] as `\xHH`.
   if (!utf8) {
     final h = char.toRadixString(16).toUpperCase().padLeft(2, '0');
-    return '\\x${h}';
+    return '\\x$h';
   }
 
   /// In all other cases, simply convert to string.

--- a/lib/src/header_parser/sub_parsers/structdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/structdecl_parser.dart
@@ -68,7 +68,7 @@ Struc? parseStructDeclaration(
   } else if ((ignoreFilter || shouldIncludeStruct(structUsr, structName)) &&
       (!bindingsIndex.isSeenStruct(structUsr))) {
     _logger.fine(
-        '++++ Adding Structure: structName: ${structName}, ${cursor.completeStringRepr()}');
+        '++++ Adding Structure: structName: $structName, ${cursor.completeStringRepr()}');
     _stack.top.struc = Struc(
       usr: structUsr,
       originalName: structName,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.0.3
+version: 2.0.4
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,12 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.0.4
+version: 2.1.0
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   ffi: ^1.0.0

--- a/test/code_generator_tests/expected_bindings/_expected_boolean_dartbool_bindings.dart
+++ b/test/code_generator_tests/expected_bindings/_expected_boolean_dartbool_bindings.dart
@@ -4,17 +4,25 @@
 import 'dart:ffi' as ffi;
 
 class Bindings {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  Bindings(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  Bindings(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  Bindings.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   bool test1(
     bool a,
     ffi.Pointer<ffi.Uint8> b,
   ) {
-    return (_test1 ??= _dylib.lookupFunction<_c_test1, _dart_test1>('test1'))(
+    return (_test1 ??= _lookup<ffi.NativeFunction<_c_test1>>('test1')
+            .asFunction<_dart_test1>())(
           a ? 1 : 0,
           b,
         ) !=

--- a/test/code_generator_tests/expected_bindings/_expected_boolean_no_dartbool_bindings.dart
+++ b/test/code_generator_tests/expected_bindings/_expected_boolean_no_dartbool_bindings.dart
@@ -4,17 +4,25 @@
 import 'dart:ffi' as ffi;
 
 class Bindings {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  Bindings(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  Bindings(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  Bindings.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   int test1(
     int a,
     ffi.Pointer<ffi.Uint8> b,
   ) {
-    return (_test1 ??= _dylib.lookupFunction<_c_test1, _dart_test1>('test1'))(
+    return (_test1 ??= _lookup<ffi.NativeFunction<_c_test1>>('test1')
+        .asFunction<_dart_test1>())(
       a,
       b,
     );

--- a/test/code_generator_tests/expected_bindings/_expected_function_bindings.dart
+++ b/test/code_generator_tests/expected_bindings/_expected_function_bindings.dart
@@ -4,17 +4,24 @@
 import 'dart:ffi' as ffi;
 
 class Bindings {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  Bindings(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  Bindings(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  Bindings.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   /// Just a test function
   /// heres another line
   int noParam() {
-    return (_noParam ??=
-        _dylib.lookupFunction<_c_noParam, _dart_noParam>('noParam'))();
+    return (_noParam ??= _lookup<ffi.NativeFunction<_c_noParam>>('noParam')
+        .asFunction<_dart_noParam>())();
   }
 
   _dart_noParam? _noParam;
@@ -24,8 +31,8 @@ class Bindings {
     int b,
   ) {
     return (_withPrimitiveParam ??=
-        _dylib.lookupFunction<_c_withPrimitiveParam, _dart_withPrimitiveParam>(
-            'withPrimitiveParam'))(
+        _lookup<ffi.NativeFunction<_c_withPrimitiveParam>>('withPrimitiveParam')
+            .asFunction<_dart_withPrimitiveParam>())(
       a,
       b,
     );
@@ -38,8 +45,8 @@ class Bindings {
     ffi.Pointer<ffi.Pointer<ffi.Uint8>> b,
   ) {
     return (_withPointerParam ??=
-        _dylib.lookupFunction<_c_withPointerParam, _dart_withPointerParam>(
-            'withPointerParam'))(
+        _lookup<ffi.NativeFunction<_c_withPointerParam>>('withPointerParam')
+            .asFunction<_dart_withPointerParam>())(
       a,
       b,
     );

--- a/test/code_generator_tests/expected_bindings/_expected_function_n_struct_bindings.dart
+++ b/test/code_generator_tests/expected_bindings/_expected_function_n_struct_bindings.dart
@@ -4,17 +4,24 @@
 import 'dart:ffi' as ffi;
 
 class Bindings {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  Bindings(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  Bindings(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  Bindings.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   ffi.Pointer<SomeStruc> someFunc(
     ffi.Pointer<ffi.Pointer<SomeStruc>> some,
   ) {
-    return (_someFunc ??=
-        _dylib.lookupFunction<_c_someFunc, _dart_someFunc>('someFunc'))(
+    return (_someFunc ??= _lookup<ffi.NativeFunction<_c_someFunc>>('someFunc')
+        .asFunction<_dart_someFunc>())(
       some,
     );
   }

--- a/test/code_generator_tests/expected_bindings/_expected_global_bindings.dart
+++ b/test/code_generator_tests/expected_bindings/_expected_global_bindings.dart
@@ -4,34 +4,41 @@
 import 'dart:ffi' as ffi;
 
 class Bindings {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  Bindings(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  Bindings(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
 
-  late final ffi.Pointer<ffi.Int32> _test1 = _dylib.lookup<ffi.Int32>('test1');
+  /// The symbols are looked up with [lookup].
+  Bindings.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
+
+  late final ffi.Pointer<ffi.Int32> _test1 = _lookup<ffi.Int32>('test1');
 
   int get test1 => _test1.value;
 
   set test1(int value) => _test1.value = value;
 
   late final ffi.Pointer<ffi.Pointer<ffi.Float>> _test2 =
-      _dylib.lookup<ffi.Pointer<ffi.Float>>('test2');
+      _lookup<ffi.Pointer<ffi.Float>>('test2');
 
   ffi.Pointer<ffi.Float> get test2 => _test2.value;
 
   set test2(ffi.Pointer<ffi.Float> value) => _test2.value = value;
 
   late final ffi.Pointer<ffi.Pointer<Some>> _test5 =
-      _dylib.lookup<ffi.Pointer<Some>>('test5');
+      _lookup<ffi.Pointer<Some>>('test5');
 
   ffi.Pointer<Some> get test5 => _test5.value;
 
   set test5(ffi.Pointer<Some> value) => _test5.value = value;
 
   late final ffi.Pointer<EmptyStruct> _globalStruct =
-      _dylib.lookup<EmptyStruct>('globalStruct');
+      _lookup<EmptyStruct>('globalStruct');
 
   ffi.Pointer<EmptyStruct> get globalStruct => _globalStruct;
 }

--- a/test/code_generator_tests/expected_bindings/_expected_internal_conflict_resolution_bindings.dart
+++ b/test/code_generator_tests/expected_bindings/_expected_internal_conflict_resolution_bindings.dart
@@ -68,7 +68,7 @@ class ArrayHelper1__Test_array_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 

--- a/test/code_generator_tests/expected_bindings/_expected_internal_conflict_resolution_bindings.dart
+++ b/test/code_generator_tests/expected_bindings/_expected_internal_conflict_resolution_bindings.dart
@@ -6,40 +6,52 @@
 import 'dart:ffi' as ffi;
 
 class init_dylib_1 {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  init_dylib_1(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  init_dylib_1(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  init_dylib_1.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   void test() {
-    return (_test_1 ??= _dylib.lookupFunction<_c_test1, _dart_test1>('test'))();
+    return (_test_1 ??= _lookup<ffi.NativeFunction<_c_test1>>('test')
+        .asFunction<_dart_test1>())();
   }
 
   _dart_test1? _test_1;
 
   void _test() {
-    return (__test ??= _dylib.lookupFunction<_c__test, _dart__test>('_test'))();
+    return (__test ??= _lookup<ffi.NativeFunction<_c__test>>('_test')
+        .asFunction<_dart__test>())();
   }
 
   _dart__test? __test;
 
   void _c_test() {
-    return (__c_test ??=
-        _dylib.lookupFunction<_c__c_test, _dart__c_test>('_c_test'))();
+    return (__c_test ??= _lookup<ffi.NativeFunction<_c__c_test>>('_c_test')
+        .asFunction<_dart__c_test>())();
   }
 
   _dart__c_test? __c_test;
 
   void _dart_test() {
     return (__dart_test ??=
-        _dylib.lookupFunction<_c__dart_test, _dart__dart_test>('_dart_test'))();
+        _lookup<ffi.NativeFunction<_c__dart_test>>('_dart_test')
+            .asFunction<_dart__dart_test>())();
   }
 
   _dart__dart_test? __dart_test;
 
   void Test() {
-    return (_Test ??= _dylib.lookupFunction<_c_Test1, _dart_Test>('Test'))();
+    return (_Test ??= _lookup<ffi.NativeFunction<_c_Test1>>('Test')
+        .asFunction<_dart_Test>())();
   }
 
   _dart_Test? _Test;

--- a/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
@@ -5,16 +5,25 @@ import 'dart:ffi' as ffi;
 
 /// Unnamed Enums Test
 class NativeLibrary {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  NativeLibrary(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  NativeLibrary(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  NativeLibrary.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   void func(
     ffi.Pointer<ffi.NativeFunction<_typedefC_4>> unnamed1,
   ) {
-    return (_func ??= _dylib.lookupFunction<_c_func, _dart_func>('func'))(
+    return (_func ??=
+        _lookup<ffi.NativeFunction<_c_func>>('func').asFunction<_dart_func>())(
       unnamed1,
     );
   }
@@ -25,8 +34,8 @@ class NativeLibrary {
     ffi.Pointer<ffi.NativeFunction<withTypedefReturnType>> named,
   ) {
     return (_funcWithNativeFunc ??=
-        _dylib.lookupFunction<_c_funcWithNativeFunc, _dart_funcWithNativeFunc>(
-            'funcWithNativeFunc'))(
+        _lookup<ffi.NativeFunction<_c_funcWithNativeFunc>>('funcWithNativeFunc')
+            .asFunction<_dart_funcWithNativeFunc>())(
       named,
     );
   }

--- a/test/large_integration_tests/_expected_cjson_bindings.dart
+++ b/test/large_integration_tests/_expected_cjson_bindings.dart
@@ -5,16 +5,23 @@ import 'dart:ffi' as ffi;
 
 /// Bindings to Cjson.
 class CJson {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  CJson(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  CJson(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  CJson.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   ffi.Pointer<ffi.Int8> cJSON_Version() {
     return (_cJSON_Version ??=
-        _dylib.lookupFunction<_c_cJSON_Version, _dart_cJSON_Version>(
-            'cJSON_Version'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_Version>>('cJSON_Version')
+            .asFunction<_dart_cJSON_Version>())();
   }
 
   _dart_cJSON_Version? _cJSON_Version;
@@ -23,8 +30,8 @@ class CJson {
     ffi.Pointer<cJSON_Hooks> hooks,
   ) {
     return (_cJSON_InitHooks ??=
-        _dylib.lookupFunction<_c_cJSON_InitHooks, _dart_cJSON_InitHooks>(
-            'cJSON_InitHooks'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_InitHooks>>('cJSON_InitHooks')
+            .asFunction<_dart_cJSON_InitHooks>())(
       hooks,
     );
   }
@@ -34,8 +41,9 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_Parse(
     ffi.Pointer<ffi.Int8> value,
   ) {
-    return (_cJSON_Parse ??= _dylib
-        .lookupFunction<_c_cJSON_Parse, _dart_cJSON_Parse>('cJSON_Parse'))(
+    return (_cJSON_Parse ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Parse>>('cJSON_Parse')
+            .asFunction<_dart_cJSON_Parse>())(
       value,
     );
   }
@@ -47,9 +55,10 @@ class CJson {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> return_parse_end,
     int require_null_terminated,
   ) {
-    return (_cJSON_ParseWithOpts ??= _dylib.lookupFunction<
-        _c_cJSON_ParseWithOpts,
-        _dart_cJSON_ParseWithOpts>('cJSON_ParseWithOpts'))(
+    return (_cJSON_ParseWithOpts ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ParseWithOpts>>(
+                'cJSON_ParseWithOpts')
+            .asFunction<_dart_cJSON_ParseWithOpts>())(
       value,
       return_parse_end,
       require_null_terminated,
@@ -61,8 +70,9 @@ class CJson {
   ffi.Pointer<ffi.Int8> cJSON_Print(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_Print ??= _dylib
-        .lookupFunction<_c_cJSON_Print, _dart_cJSON_Print>('cJSON_Print'))(
+    return (_cJSON_Print ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Print>>('cJSON_Print')
+            .asFunction<_dart_cJSON_Print>())(
       item,
     );
   }
@@ -72,9 +82,10 @@ class CJson {
   ffi.Pointer<ffi.Int8> cJSON_PrintUnformatted(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_PrintUnformatted ??= _dylib.lookupFunction<
-        _c_cJSON_PrintUnformatted,
-        _dart_cJSON_PrintUnformatted>('cJSON_PrintUnformatted'))(
+    return (_cJSON_PrintUnformatted ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_PrintUnformatted>>(
+                'cJSON_PrintUnformatted')
+            .asFunction<_dart_cJSON_PrintUnformatted>())(
       item,
     );
   }
@@ -86,9 +97,10 @@ class CJson {
     int prebuffer,
     int fmt,
   ) {
-    return (_cJSON_PrintBuffered ??= _dylib.lookupFunction<
-        _c_cJSON_PrintBuffered,
-        _dart_cJSON_PrintBuffered>('cJSON_PrintBuffered'))(
+    return (_cJSON_PrintBuffered ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_PrintBuffered>>(
+                'cJSON_PrintBuffered')
+            .asFunction<_dart_cJSON_PrintBuffered>())(
       item,
       prebuffer,
       fmt,
@@ -103,9 +115,10 @@ class CJson {
     int length,
     int format,
   ) {
-    return (_cJSON_PrintPreallocated ??= _dylib.lookupFunction<
-        _c_cJSON_PrintPreallocated,
-        _dart_cJSON_PrintPreallocated>('cJSON_PrintPreallocated'))(
+    return (_cJSON_PrintPreallocated ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_PrintPreallocated>>(
+                'cJSON_PrintPreallocated')
+            .asFunction<_dart_cJSON_PrintPreallocated>())(
       item,
       buffer,
       length,
@@ -118,8 +131,9 @@ class CJson {
   void cJSON_Delete(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_Delete ??= _dylib
-        .lookupFunction<_c_cJSON_Delete, _dart_cJSON_Delete>('cJSON_Delete'))(
+    return (_cJSON_Delete ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Delete>>('cJSON_Delete')
+            .asFunction<_dart_cJSON_Delete>())(
       item,
     );
   }
@@ -130,8 +144,8 @@ class CJson {
     ffi.Pointer<cJSON> array,
   ) {
     return (_cJSON_GetArraySize ??=
-        _dylib.lookupFunction<_c_cJSON_GetArraySize, _dart_cJSON_GetArraySize>(
-            'cJSON_GetArraySize'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_GetArraySize>>('cJSON_GetArraySize')
+            .asFunction<_dart_cJSON_GetArraySize>())(
       array,
     );
   }
@@ -143,8 +157,8 @@ class CJson {
     int index,
   ) {
     return (_cJSON_GetArrayItem ??=
-        _dylib.lookupFunction<_c_cJSON_GetArrayItem, _dart_cJSON_GetArrayItem>(
-            'cJSON_GetArrayItem'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_GetArrayItem>>('cJSON_GetArrayItem')
+            .asFunction<_dart_cJSON_GetArrayItem>())(
       array,
       index,
     );
@@ -156,9 +170,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_GetObjectItem ??= _dylib.lookupFunction<
-        _c_cJSON_GetObjectItem,
-        _dart_cJSON_GetObjectItem>('cJSON_GetObjectItem'))(
+    return (_cJSON_GetObjectItem ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_GetObjectItem>>(
+                'cJSON_GetObjectItem')
+            .asFunction<_dart_cJSON_GetObjectItem>())(
       object,
       string,
     );
@@ -170,10 +185,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_GetObjectItemCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_GetObjectItemCaseSensitive,
-            _dart_cJSON_GetObjectItemCaseSensitive>(
-        'cJSON_GetObjectItemCaseSensitive'))(
+    return (_cJSON_GetObjectItemCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_GetObjectItemCaseSensitive>>(
+                'cJSON_GetObjectItemCaseSensitive')
+            .asFunction<_dart_cJSON_GetObjectItemCaseSensitive>())(
       object,
       string,
     );
@@ -185,9 +200,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_HasObjectItem ??= _dylib.lookupFunction<
-        _c_cJSON_HasObjectItem,
-        _dart_cJSON_HasObjectItem>('cJSON_HasObjectItem'))(
+    return (_cJSON_HasObjectItem ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_HasObjectItem>>(
+                'cJSON_HasObjectItem')
+            .asFunction<_dart_cJSON_HasObjectItem>())(
       object,
       string,
     );
@@ -197,8 +213,8 @@ class CJson {
 
   ffi.Pointer<ffi.Int8> cJSON_GetErrorPtr() {
     return (_cJSON_GetErrorPtr ??=
-        _dylib.lookupFunction<_c_cJSON_GetErrorPtr, _dart_cJSON_GetErrorPtr>(
-            'cJSON_GetErrorPtr'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_GetErrorPtr>>('cJSON_GetErrorPtr')
+            .asFunction<_dart_cJSON_GetErrorPtr>())();
   }
 
   _dart_cJSON_GetErrorPtr? _cJSON_GetErrorPtr;
@@ -206,9 +222,10 @@ class CJson {
   ffi.Pointer<ffi.Int8> cJSON_GetStringValue(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_GetStringValue ??= _dylib.lookupFunction<
-        _c_cJSON_GetStringValue,
-        _dart_cJSON_GetStringValue>('cJSON_GetStringValue'))(
+    return (_cJSON_GetStringValue ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_GetStringValue>>(
+                'cJSON_GetStringValue')
+            .asFunction<_dart_cJSON_GetStringValue>())(
       item,
     );
   }
@@ -219,8 +236,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsInvalid ??=
-        _dylib.lookupFunction<_c_cJSON_IsInvalid, _dart_cJSON_IsInvalid>(
-            'cJSON_IsInvalid'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsInvalid>>('cJSON_IsInvalid')
+            .asFunction<_dart_cJSON_IsInvalid>())(
       item,
     );
   }
@@ -231,8 +248,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsFalse ??=
-        _dylib.lookupFunction<_c_cJSON_IsFalse, _dart_cJSON_IsFalse>(
-            'cJSON_IsFalse'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsFalse>>('cJSON_IsFalse')
+            .asFunction<_dart_cJSON_IsFalse>())(
       item,
     );
   }
@@ -242,8 +259,9 @@ class CJson {
   int cJSON_IsTrue(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsTrue ??= _dylib
-        .lookupFunction<_c_cJSON_IsTrue, _dart_cJSON_IsTrue>('cJSON_IsTrue'))(
+    return (_cJSON_IsTrue ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsTrue>>('cJSON_IsTrue')
+            .asFunction<_dart_cJSON_IsTrue>())(
       item,
     );
   }
@@ -253,8 +271,9 @@ class CJson {
   int cJSON_IsBool(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsBool ??= _dylib
-        .lookupFunction<_c_cJSON_IsBool, _dart_cJSON_IsBool>('cJSON_IsBool'))(
+    return (_cJSON_IsBool ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsBool>>('cJSON_IsBool')
+            .asFunction<_dart_cJSON_IsBool>())(
       item,
     );
   }
@@ -264,8 +283,9 @@ class CJson {
   int cJSON_IsNull(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsNull ??= _dylib
-        .lookupFunction<_c_cJSON_IsNull, _dart_cJSON_IsNull>('cJSON_IsNull'))(
+    return (_cJSON_IsNull ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsNull>>('cJSON_IsNull')
+            .asFunction<_dart_cJSON_IsNull>())(
       item,
     );
   }
@@ -276,8 +296,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsNumber ??=
-        _dylib.lookupFunction<_c_cJSON_IsNumber, _dart_cJSON_IsNumber>(
-            'cJSON_IsNumber'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsNumber>>('cJSON_IsNumber')
+            .asFunction<_dart_cJSON_IsNumber>())(
       item,
     );
   }
@@ -288,8 +308,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsString ??=
-        _dylib.lookupFunction<_c_cJSON_IsString, _dart_cJSON_IsString>(
-            'cJSON_IsString'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsString>>('cJSON_IsString')
+            .asFunction<_dart_cJSON_IsString>())(
       item,
     );
   }
@@ -300,8 +320,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsArray ??=
-        _dylib.lookupFunction<_c_cJSON_IsArray, _dart_cJSON_IsArray>(
-            'cJSON_IsArray'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsArray>>('cJSON_IsArray')
+            .asFunction<_dart_cJSON_IsArray>())(
       item,
     );
   }
@@ -312,8 +332,8 @@ class CJson {
     ffi.Pointer<cJSON> item,
   ) {
     return (_cJSON_IsObject ??=
-        _dylib.lookupFunction<_c_cJSON_IsObject, _dart_cJSON_IsObject>(
-            'cJSON_IsObject'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_IsObject>>('cJSON_IsObject')
+            .asFunction<_dart_cJSON_IsObject>())(
       item,
     );
   }
@@ -323,8 +343,9 @@ class CJson {
   int cJSON_IsRaw(
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_IsRaw ??= _dylib
-        .lookupFunction<_c_cJSON_IsRaw, _dart_cJSON_IsRaw>('cJSON_IsRaw'))(
+    return (_cJSON_IsRaw ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_IsRaw>>('cJSON_IsRaw')
+            .asFunction<_dart_cJSON_IsRaw>())(
       item,
     );
   }
@@ -333,24 +354,24 @@ class CJson {
 
   ffi.Pointer<cJSON> cJSON_CreateNull() {
     return (_cJSON_CreateNull ??=
-        _dylib.lookupFunction<_c_cJSON_CreateNull, _dart_cJSON_CreateNull>(
-            'cJSON_CreateNull'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateNull>>('cJSON_CreateNull')
+            .asFunction<_dart_cJSON_CreateNull>())();
   }
 
   _dart_cJSON_CreateNull? _cJSON_CreateNull;
 
   ffi.Pointer<cJSON> cJSON_CreateTrue() {
     return (_cJSON_CreateTrue ??=
-        _dylib.lookupFunction<_c_cJSON_CreateTrue, _dart_cJSON_CreateTrue>(
-            'cJSON_CreateTrue'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateTrue>>('cJSON_CreateTrue')
+            .asFunction<_dart_cJSON_CreateTrue>())();
   }
 
   _dart_cJSON_CreateTrue? _cJSON_CreateTrue;
 
   ffi.Pointer<cJSON> cJSON_CreateFalse() {
     return (_cJSON_CreateFalse ??=
-        _dylib.lookupFunction<_c_cJSON_CreateFalse, _dart_cJSON_CreateFalse>(
-            'cJSON_CreateFalse'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateFalse>>('cJSON_CreateFalse')
+            .asFunction<_dart_cJSON_CreateFalse>())();
   }
 
   _dart_cJSON_CreateFalse? _cJSON_CreateFalse;
@@ -359,8 +380,8 @@ class CJson {
     int boolean,
   ) {
     return (_cJSON_CreateBool ??=
-        _dylib.lookupFunction<_c_cJSON_CreateBool, _dart_cJSON_CreateBool>(
-            'cJSON_CreateBool'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateBool>>('cJSON_CreateBool')
+            .asFunction<_dart_cJSON_CreateBool>())(
       boolean,
     );
   }
@@ -371,8 +392,8 @@ class CJson {
     double num,
   ) {
     return (_cJSON_CreateNumber ??=
-        _dylib.lookupFunction<_c_cJSON_CreateNumber, _dart_cJSON_CreateNumber>(
-            'cJSON_CreateNumber'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateNumber>>('cJSON_CreateNumber')
+            .asFunction<_dart_cJSON_CreateNumber>())(
       num,
     );
   }
@@ -383,8 +404,8 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
   ) {
     return (_cJSON_CreateString ??=
-        _dylib.lookupFunction<_c_cJSON_CreateString, _dart_cJSON_CreateString>(
-            'cJSON_CreateString'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateString>>('cJSON_CreateString')
+            .asFunction<_dart_cJSON_CreateString>())(
       string,
     );
   }
@@ -395,8 +416,8 @@ class CJson {
     ffi.Pointer<ffi.Int8> raw,
   ) {
     return (_cJSON_CreateRaw ??=
-        _dylib.lookupFunction<_c_cJSON_CreateRaw, _dart_cJSON_CreateRaw>(
-            'cJSON_CreateRaw'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateRaw>>('cJSON_CreateRaw')
+            .asFunction<_dart_cJSON_CreateRaw>())(
       raw,
     );
   }
@@ -405,16 +426,16 @@ class CJson {
 
   ffi.Pointer<cJSON> cJSON_CreateArray() {
     return (_cJSON_CreateArray ??=
-        _dylib.lookupFunction<_c_cJSON_CreateArray, _dart_cJSON_CreateArray>(
-            'cJSON_CreateArray'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateArray>>('cJSON_CreateArray')
+            .asFunction<_dart_cJSON_CreateArray>())();
   }
 
   _dart_cJSON_CreateArray? _cJSON_CreateArray;
 
   ffi.Pointer<cJSON> cJSON_CreateObject() {
     return (_cJSON_CreateObject ??=
-        _dylib.lookupFunction<_c_cJSON_CreateObject, _dart_cJSON_CreateObject>(
-            'cJSON_CreateObject'))();
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateObject>>('cJSON_CreateObject')
+            .asFunction<_dart_cJSON_CreateObject>())();
   }
 
   _dart_cJSON_CreateObject? _cJSON_CreateObject;
@@ -422,9 +443,10 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_CreateStringReference(
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_CreateStringReference ??= _dylib.lookupFunction<
-        _c_cJSON_CreateStringReference,
-        _dart_cJSON_CreateStringReference>('cJSON_CreateStringReference'))(
+    return (_cJSON_CreateStringReference ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateStringReference>>(
+                'cJSON_CreateStringReference')
+            .asFunction<_dart_cJSON_CreateStringReference>())(
       string,
     );
   }
@@ -434,9 +456,10 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_CreateObjectReference(
     ffi.Pointer<cJSON> child,
   ) {
-    return (_cJSON_CreateObjectReference ??= _dylib.lookupFunction<
-        _c_cJSON_CreateObjectReference,
-        _dart_cJSON_CreateObjectReference>('cJSON_CreateObjectReference'))(
+    return (_cJSON_CreateObjectReference ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateObjectReference>>(
+                'cJSON_CreateObjectReference')
+            .asFunction<_dart_cJSON_CreateObjectReference>())(
       child,
     );
   }
@@ -446,9 +469,10 @@ class CJson {
   ffi.Pointer<cJSON> cJSON_CreateArrayReference(
     ffi.Pointer<cJSON> child,
   ) {
-    return (_cJSON_CreateArrayReference ??= _dylib.lookupFunction<
-        _c_cJSON_CreateArrayReference,
-        _dart_cJSON_CreateArrayReference>('cJSON_CreateArrayReference'))(
+    return (_cJSON_CreateArrayReference ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateArrayReference>>(
+                'cJSON_CreateArrayReference')
+            .asFunction<_dart_cJSON_CreateArrayReference>())(
       child,
     );
   }
@@ -459,9 +483,10 @@ class CJson {
     ffi.Pointer<ffi.Int32> numbers,
     int count,
   ) {
-    return (_cJSON_CreateIntArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateIntArray,
-        _dart_cJSON_CreateIntArray>('cJSON_CreateIntArray'))(
+    return (_cJSON_CreateIntArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateIntArray>>(
+                'cJSON_CreateIntArray')
+            .asFunction<_dart_cJSON_CreateIntArray>())(
       numbers,
       count,
     );
@@ -473,9 +498,10 @@ class CJson {
     ffi.Pointer<ffi.Float> numbers,
     int count,
   ) {
-    return (_cJSON_CreateFloatArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateFloatArray,
-        _dart_cJSON_CreateFloatArray>('cJSON_CreateFloatArray'))(
+    return (_cJSON_CreateFloatArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateFloatArray>>(
+                'cJSON_CreateFloatArray')
+            .asFunction<_dart_cJSON_CreateFloatArray>())(
       numbers,
       count,
     );
@@ -487,9 +513,10 @@ class CJson {
     ffi.Pointer<ffi.Double> numbers,
     int count,
   ) {
-    return (_cJSON_CreateDoubleArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateDoubleArray,
-        _dart_cJSON_CreateDoubleArray>('cJSON_CreateDoubleArray'))(
+    return (_cJSON_CreateDoubleArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateDoubleArray>>(
+                'cJSON_CreateDoubleArray')
+            .asFunction<_dart_cJSON_CreateDoubleArray>())(
       numbers,
       count,
     );
@@ -501,9 +528,10 @@ class CJson {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> strings,
     int count,
   ) {
-    return (_cJSON_CreateStringArray ??= _dylib.lookupFunction<
-        _c_cJSON_CreateStringArray,
-        _dart_cJSON_CreateStringArray>('cJSON_CreateStringArray'))(
+    return (_cJSON_CreateStringArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_CreateStringArray>>(
+                'cJSON_CreateStringArray')
+            .asFunction<_dart_cJSON_CreateStringArray>())(
       strings,
       count,
     );
@@ -515,9 +543,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemToArray ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemToArray,
-        _dart_cJSON_AddItemToArray>('cJSON_AddItemToArray'))(
+    return (_cJSON_AddItemToArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemToArray>>(
+                'cJSON_AddItemToArray')
+            .asFunction<_dart_cJSON_AddItemToArray>())(
       array,
       item,
     );
@@ -530,9 +559,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemToObject,
-        _dart_cJSON_AddItemToObject>('cJSON_AddItemToObject'))(
+    return (_cJSON_AddItemToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemToObject>>(
+                'cJSON_AddItemToObject')
+            .asFunction<_dart_cJSON_AddItemToObject>())(
       object,
       string,
       item,
@@ -546,9 +576,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemToObjectCS ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemToObjectCS,
-        _dart_cJSON_AddItemToObjectCS>('cJSON_AddItemToObjectCS'))(
+    return (_cJSON_AddItemToObjectCS ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemToObjectCS>>(
+                'cJSON_AddItemToObjectCS')
+            .asFunction<_dart_cJSON_AddItemToObjectCS>())(
       object,
       string,
       item,
@@ -561,9 +592,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemReferenceToArray ??= _dylib.lookupFunction<
-        _c_cJSON_AddItemReferenceToArray,
-        _dart_cJSON_AddItemReferenceToArray>('cJSON_AddItemReferenceToArray'))(
+    return (_cJSON_AddItemReferenceToArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemReferenceToArray>>(
+                'cJSON_AddItemReferenceToArray')
+            .asFunction<_dart_cJSON_AddItemReferenceToArray>())(
       array,
       item,
     );
@@ -576,10 +608,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_AddItemReferenceToObject ??= _dylib.lookupFunction<
-            _c_cJSON_AddItemReferenceToObject,
-            _dart_cJSON_AddItemReferenceToObject>(
-        'cJSON_AddItemReferenceToObject'))(
+    return (_cJSON_AddItemReferenceToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddItemReferenceToObject>>(
+                'cJSON_AddItemReferenceToObject')
+            .asFunction<_dart_cJSON_AddItemReferenceToObject>())(
       object,
       string,
       item,
@@ -592,9 +624,10 @@ class CJson {
     ffi.Pointer<cJSON> parent,
     ffi.Pointer<cJSON> item,
   ) {
-    return (_cJSON_DetachItemViaPointer ??= _dylib.lookupFunction<
-        _c_cJSON_DetachItemViaPointer,
-        _dart_cJSON_DetachItemViaPointer>('cJSON_DetachItemViaPointer'))(
+    return (_cJSON_DetachItemViaPointer ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemViaPointer>>(
+                'cJSON_DetachItemViaPointer')
+            .asFunction<_dart_cJSON_DetachItemViaPointer>())(
       parent,
       item,
     );
@@ -606,9 +639,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     int which,
   ) {
-    return (_cJSON_DetachItemFromArray ??= _dylib.lookupFunction<
-        _c_cJSON_DetachItemFromArray,
-        _dart_cJSON_DetachItemFromArray>('cJSON_DetachItemFromArray'))(
+    return (_cJSON_DetachItemFromArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemFromArray>>(
+                'cJSON_DetachItemFromArray')
+            .asFunction<_dart_cJSON_DetachItemFromArray>())(
       array,
       which,
     );
@@ -620,9 +654,10 @@ class CJson {
     ffi.Pointer<cJSON> array,
     int which,
   ) {
-    return (_cJSON_DeleteItemFromArray ??= _dylib.lookupFunction<
-        _c_cJSON_DeleteItemFromArray,
-        _dart_cJSON_DeleteItemFromArray>('cJSON_DeleteItemFromArray'))(
+    return (_cJSON_DeleteItemFromArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DeleteItemFromArray>>(
+                'cJSON_DeleteItemFromArray')
+            .asFunction<_dart_cJSON_DeleteItemFromArray>())(
       array,
       which,
     );
@@ -634,9 +669,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DetachItemFromObject ??= _dylib.lookupFunction<
-        _c_cJSON_DetachItemFromObject,
-        _dart_cJSON_DetachItemFromObject>('cJSON_DetachItemFromObject'))(
+    return (_cJSON_DetachItemFromObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemFromObject>>(
+                'cJSON_DetachItemFromObject')
+            .asFunction<_dart_cJSON_DetachItemFromObject>())(
       object,
       string,
     );
@@ -648,10 +684,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DetachItemFromObjectCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_DetachItemFromObjectCaseSensitive,
-            _dart_cJSON_DetachItemFromObjectCaseSensitive>(
-        'cJSON_DetachItemFromObjectCaseSensitive'))(
+    return (_cJSON_DetachItemFromObjectCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DetachItemFromObjectCaseSensitive>>(
+                'cJSON_DetachItemFromObjectCaseSensitive')
+            .asFunction<_dart_cJSON_DetachItemFromObjectCaseSensitive>())(
       object,
       string,
     );
@@ -664,9 +700,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DeleteItemFromObject ??= _dylib.lookupFunction<
-        _c_cJSON_DeleteItemFromObject,
-        _dart_cJSON_DeleteItemFromObject>('cJSON_DeleteItemFromObject'))(
+    return (_cJSON_DeleteItemFromObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DeleteItemFromObject>>(
+                'cJSON_DeleteItemFromObject')
+            .asFunction<_dart_cJSON_DeleteItemFromObject>())(
       object,
       string,
     );
@@ -678,10 +715,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_DeleteItemFromObjectCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_DeleteItemFromObjectCaseSensitive,
-            _dart_cJSON_DeleteItemFromObjectCaseSensitive>(
-        'cJSON_DeleteItemFromObjectCaseSensitive'))(
+    return (_cJSON_DeleteItemFromObjectCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_DeleteItemFromObjectCaseSensitive>>(
+                'cJSON_DeleteItemFromObjectCaseSensitive')
+            .asFunction<_dart_cJSON_DeleteItemFromObjectCaseSensitive>())(
       object,
       string,
     );
@@ -695,9 +732,10 @@ class CJson {
     int which,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_InsertItemInArray ??= _dylib.lookupFunction<
-        _c_cJSON_InsertItemInArray,
-        _dart_cJSON_InsertItemInArray>('cJSON_InsertItemInArray'))(
+    return (_cJSON_InsertItemInArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_InsertItemInArray>>(
+                'cJSON_InsertItemInArray')
+            .asFunction<_dart_cJSON_InsertItemInArray>())(
       array,
       which,
       newitem,
@@ -711,9 +749,10 @@ class CJson {
     ffi.Pointer<cJSON> item,
     ffi.Pointer<cJSON> replacement,
   ) {
-    return (_cJSON_ReplaceItemViaPointer ??= _dylib.lookupFunction<
-        _c_cJSON_ReplaceItemViaPointer,
-        _dart_cJSON_ReplaceItemViaPointer>('cJSON_ReplaceItemViaPointer'))(
+    return (_cJSON_ReplaceItemViaPointer ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemViaPointer>>(
+                'cJSON_ReplaceItemViaPointer')
+            .asFunction<_dart_cJSON_ReplaceItemViaPointer>())(
       parent,
       item,
       replacement,
@@ -727,9 +766,10 @@ class CJson {
     int which,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_ReplaceItemInArray ??= _dylib.lookupFunction<
-        _c_cJSON_ReplaceItemInArray,
-        _dart_cJSON_ReplaceItemInArray>('cJSON_ReplaceItemInArray'))(
+    return (_cJSON_ReplaceItemInArray ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemInArray>>(
+                'cJSON_ReplaceItemInArray')
+            .asFunction<_dart_cJSON_ReplaceItemInArray>())(
       array,
       which,
       newitem,
@@ -743,9 +783,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_ReplaceItemInObject ??= _dylib.lookupFunction<
-        _c_cJSON_ReplaceItemInObject,
-        _dart_cJSON_ReplaceItemInObject>('cJSON_ReplaceItemInObject'))(
+    return (_cJSON_ReplaceItemInObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemInObject>>(
+                'cJSON_ReplaceItemInObject')
+            .asFunction<_dart_cJSON_ReplaceItemInObject>())(
       object,
       string,
       newitem,
@@ -759,10 +800,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> string,
     ffi.Pointer<cJSON> newitem,
   ) {
-    return (_cJSON_ReplaceItemInObjectCaseSensitive ??= _dylib.lookupFunction<
-            _c_cJSON_ReplaceItemInObjectCaseSensitive,
-            _dart_cJSON_ReplaceItemInObjectCaseSensitive>(
-        'cJSON_ReplaceItemInObjectCaseSensitive'))(
+    return (_cJSON_ReplaceItemInObjectCaseSensitive ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_ReplaceItemInObjectCaseSensitive>>(
+                'cJSON_ReplaceItemInObjectCaseSensitive')
+            .asFunction<_dart_cJSON_ReplaceItemInObjectCaseSensitive>())(
       object,
       string,
       newitem,
@@ -777,8 +818,8 @@ class CJson {
     int recurse,
   ) {
     return (_cJSON_Duplicate ??=
-        _dylib.lookupFunction<_c_cJSON_Duplicate, _dart_cJSON_Duplicate>(
-            'cJSON_Duplicate'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_Duplicate>>('cJSON_Duplicate')
+            .asFunction<_dart_cJSON_Duplicate>())(
       item,
       recurse,
     );
@@ -792,8 +833,8 @@ class CJson {
     int case_sensitive,
   ) {
     return (_cJSON_Compare ??=
-        _dylib.lookupFunction<_c_cJSON_Compare, _dart_cJSON_Compare>(
-            'cJSON_Compare'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_Compare>>('cJSON_Compare')
+            .asFunction<_dart_cJSON_Compare>())(
       a,
       b,
       case_sensitive,
@@ -805,8 +846,9 @@ class CJson {
   void cJSON_Minify(
     ffi.Pointer<ffi.Int8> json,
   ) {
-    return (_cJSON_Minify ??= _dylib
-        .lookupFunction<_c_cJSON_Minify, _dart_cJSON_Minify>('cJSON_Minify'))(
+    return (_cJSON_Minify ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_Minify>>('cJSON_Minify')
+            .asFunction<_dart_cJSON_Minify>())(
       json,
     );
   }
@@ -817,9 +859,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddNullToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddNullToObject,
-        _dart_cJSON_AddNullToObject>('cJSON_AddNullToObject'))(
+    return (_cJSON_AddNullToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddNullToObject>>(
+                'cJSON_AddNullToObject')
+            .asFunction<_dart_cJSON_AddNullToObject>())(
       object,
       name,
     );
@@ -831,9 +874,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddTrueToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddTrueToObject,
-        _dart_cJSON_AddTrueToObject>('cJSON_AddTrueToObject'))(
+    return (_cJSON_AddTrueToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddTrueToObject>>(
+                'cJSON_AddTrueToObject')
+            .asFunction<_dart_cJSON_AddTrueToObject>())(
       object,
       name,
     );
@@ -845,9 +889,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddFalseToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddFalseToObject,
-        _dart_cJSON_AddFalseToObject>('cJSON_AddFalseToObject'))(
+    return (_cJSON_AddFalseToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddFalseToObject>>(
+                'cJSON_AddFalseToObject')
+            .asFunction<_dart_cJSON_AddFalseToObject>())(
       object,
       name,
     );
@@ -860,9 +905,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     int boolean,
   ) {
-    return (_cJSON_AddBoolToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddBoolToObject,
-        _dart_cJSON_AddBoolToObject>('cJSON_AddBoolToObject'))(
+    return (_cJSON_AddBoolToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddBoolToObject>>(
+                'cJSON_AddBoolToObject')
+            .asFunction<_dart_cJSON_AddBoolToObject>())(
       object,
       name,
       boolean,
@@ -876,9 +922,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     double number,
   ) {
-    return (_cJSON_AddNumberToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddNumberToObject,
-        _dart_cJSON_AddNumberToObject>('cJSON_AddNumberToObject'))(
+    return (_cJSON_AddNumberToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddNumberToObject>>(
+                'cJSON_AddNumberToObject')
+            .asFunction<_dart_cJSON_AddNumberToObject>())(
       object,
       name,
       number,
@@ -892,9 +939,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     ffi.Pointer<ffi.Int8> string,
   ) {
-    return (_cJSON_AddStringToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddStringToObject,
-        _dart_cJSON_AddStringToObject>('cJSON_AddStringToObject'))(
+    return (_cJSON_AddStringToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddStringToObject>>(
+                'cJSON_AddStringToObject')
+            .asFunction<_dart_cJSON_AddStringToObject>())(
       object,
       name,
       string,
@@ -908,9 +956,10 @@ class CJson {
     ffi.Pointer<ffi.Int8> name,
     ffi.Pointer<ffi.Int8> raw,
   ) {
-    return (_cJSON_AddRawToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddRawToObject,
-        _dart_cJSON_AddRawToObject>('cJSON_AddRawToObject'))(
+    return (_cJSON_AddRawToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddRawToObject>>(
+                'cJSON_AddRawToObject')
+            .asFunction<_dart_cJSON_AddRawToObject>())(
       object,
       name,
       raw,
@@ -923,9 +972,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddObjectToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddObjectToObject,
-        _dart_cJSON_AddObjectToObject>('cJSON_AddObjectToObject'))(
+    return (_cJSON_AddObjectToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddObjectToObject>>(
+                'cJSON_AddObjectToObject')
+            .asFunction<_dart_cJSON_AddObjectToObject>())(
       object,
       name,
     );
@@ -937,9 +987,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_cJSON_AddArrayToObject ??= _dylib.lookupFunction<
-        _c_cJSON_AddArrayToObject,
-        _dart_cJSON_AddArrayToObject>('cJSON_AddArrayToObject'))(
+    return (_cJSON_AddArrayToObject ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_AddArrayToObject>>(
+                'cJSON_AddArrayToObject')
+            .asFunction<_dart_cJSON_AddArrayToObject>())(
       object,
       name,
     );
@@ -951,9 +1002,10 @@ class CJson {
     ffi.Pointer<cJSON> object,
     double number,
   ) {
-    return (_cJSON_SetNumberHelper ??= _dylib.lookupFunction<
-        _c_cJSON_SetNumberHelper,
-        _dart_cJSON_SetNumberHelper>('cJSON_SetNumberHelper'))(
+    return (_cJSON_SetNumberHelper ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_SetNumberHelper>>(
+                'cJSON_SetNumberHelper')
+            .asFunction<_dart_cJSON_SetNumberHelper>())(
       object,
       number,
     );
@@ -964,8 +1016,9 @@ class CJson {
   ffi.Pointer<ffi.Void> cJSON_malloc(
     int size,
   ) {
-    return (_cJSON_malloc ??= _dylib
-        .lookupFunction<_c_cJSON_malloc, _dart_cJSON_malloc>('cJSON_malloc'))(
+    return (_cJSON_malloc ??=
+        _lookup<ffi.NativeFunction<_c_cJSON_malloc>>('cJSON_malloc')
+            .asFunction<_dart_cJSON_malloc>())(
       size,
     );
   }
@@ -976,7 +1029,8 @@ class CJson {
     ffi.Pointer<ffi.Void> object,
   ) {
     return (_cJSON_free ??=
-        _dylib.lookupFunction<_c_cJSON_free, _dart_cJSON_free>('cJSON_free'))(
+        _lookup<ffi.NativeFunction<_c_cJSON_free>>('cJSON_free')
+            .asFunction<_dart_cJSON_free>())(
       object,
     );
   }

--- a/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -5181,7 +5181,7 @@ class ArrayHelper_CXFileUniqueID_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -5241,7 +5241,7 @@ class ArrayHelper_CXSourceLocation_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -5299,7 +5299,7 @@ class ArrayHelper_CXSourceRange_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6218,7 +6218,7 @@ class ArrayHelper_CXCursor_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6511,7 +6511,7 @@ class ArrayHelper_CXType_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -6762,7 +6762,7 @@ class ArrayHelper_CXToken_int_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -7071,7 +7071,7 @@ class ArrayHelper_CXIdxLoc_ptr_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 

--- a/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -5,19 +5,26 @@ import 'dart:ffi' as ffi;
 
 /// Bindings to LibClang.
 class LibClang {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  LibClang(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  LibClang(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  LibClang.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   /// Retrieve the character data associated with the given string.
   ffi.Pointer<ffi.Int8> clang_getCString(
     CXString string,
   ) {
     return (_clang_getCString ??=
-        _dylib.lookupFunction<_c_clang_getCString, _dart_clang_getCString>(
-            'clang_getCString'))(
+        _lookup<ffi.NativeFunction<_c_clang_getCString>>('clang_getCString')
+            .asFunction<_dart_clang_getCString>())(
       string,
     );
   }
@@ -28,9 +35,10 @@ class LibClang {
   void clang_disposeString(
     CXString string,
   ) {
-    return (_clang_disposeString ??= _dylib.lookupFunction<
-        _c_clang_disposeString,
-        _dart_clang_disposeString>('clang_disposeString'))(
+    return (_clang_disposeString ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeString>>(
+                'clang_disposeString')
+            .asFunction<_dart_clang_disposeString>())(
       string,
     );
   }
@@ -41,9 +49,10 @@ class LibClang {
   void clang_disposeStringSet(
     ffi.Pointer<CXStringSet> set_1,
   ) {
-    return (_clang_disposeStringSet ??= _dylib.lookupFunction<
-        _c_clang_disposeStringSet,
-        _dart_clang_disposeStringSet>('clang_disposeStringSet'))(
+    return (_clang_disposeStringSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeStringSet>>(
+                'clang_disposeStringSet')
+            .asFunction<_dart_clang_disposeStringSet>())(
       set_1,
     );
   }
@@ -53,10 +62,10 @@ class LibClang {
   /// Return the timestamp for use with Clang's -fbuild-session-timestamp=
   /// option.
   int clang_getBuildSessionTimestamp() {
-    return (_clang_getBuildSessionTimestamp ??= _dylib.lookupFunction<
-            _c_clang_getBuildSessionTimestamp,
-            _dart_clang_getBuildSessionTimestamp>(
-        'clang_getBuildSessionTimestamp'))();
+    return (_clang_getBuildSessionTimestamp ??=
+        _lookup<ffi.NativeFunction<_c_clang_getBuildSessionTimestamp>>(
+                'clang_getBuildSessionTimestamp')
+            .asFunction<_dart_clang_getBuildSessionTimestamp>())();
   }
 
   _dart_clang_getBuildSessionTimestamp? _clang_getBuildSessionTimestamp;
@@ -66,10 +75,10 @@ class LibClang {
   ffi.Pointer<CXVirtualFileOverlayImpl> clang_VirtualFileOverlay_create(
     int options,
   ) {
-    return (_clang_VirtualFileOverlay_create ??= _dylib.lookupFunction<
-            _c_clang_VirtualFileOverlay_create,
-            _dart_clang_VirtualFileOverlay_create>(
-        'clang_VirtualFileOverlay_create'))(
+    return (_clang_VirtualFileOverlay_create ??=
+        _lookup<ffi.NativeFunction<_c_clang_VirtualFileOverlay_create>>(
+                'clang_VirtualFileOverlay_create')
+            .asFunction<_dart_clang_VirtualFileOverlay_create>())(
       options,
     );
   }
@@ -83,10 +92,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> virtualPath,
     ffi.Pointer<ffi.Int8> realPath,
   ) {
-    return (_clang_VirtualFileOverlay_addFileMapping ??= _dylib.lookupFunction<
-            _c_clang_VirtualFileOverlay_addFileMapping,
-            _dart_clang_VirtualFileOverlay_addFileMapping>(
-        'clang_VirtualFileOverlay_addFileMapping'))(
+    return (_clang_VirtualFileOverlay_addFileMapping ??=
+        _lookup<ffi.NativeFunction<_c_clang_VirtualFileOverlay_addFileMapping>>(
+                'clang_VirtualFileOverlay_addFileMapping')
+            .asFunction<_dart_clang_VirtualFileOverlay_addFileMapping>())(
       arg0,
       virtualPath,
       realPath,
@@ -103,10 +112,11 @@ class LibClang {
     ffi.Pointer<CXVirtualFileOverlayImpl> arg0,
     int caseSensitive,
   ) {
-    return (_clang_VirtualFileOverlay_setCaseSensitivity ??=
-        _dylib.lookupFunction<_c_clang_VirtualFileOverlay_setCaseSensitivity,
-                _dart_clang_VirtualFileOverlay_setCaseSensitivity>(
-            'clang_VirtualFileOverlay_setCaseSensitivity'))(
+    return (_clang_VirtualFileOverlay_setCaseSensitivity ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_VirtualFileOverlay_setCaseSensitivity>>(
+            'clang_VirtualFileOverlay_setCaseSensitivity')
+        .asFunction<_dart_clang_VirtualFileOverlay_setCaseSensitivity>())(
       arg0,
       caseSensitive,
     );
@@ -122,10 +132,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> out_buffer_ptr,
     ffi.Pointer<ffi.Uint32> out_buffer_size,
   ) {
-    return (_clang_VirtualFileOverlay_writeToBuffer ??= _dylib.lookupFunction<
-            _c_clang_VirtualFileOverlay_writeToBuffer,
-            _dart_clang_VirtualFileOverlay_writeToBuffer>(
-        'clang_VirtualFileOverlay_writeToBuffer'))(
+    return (_clang_VirtualFileOverlay_writeToBuffer ??=
+        _lookup<ffi.NativeFunction<_c_clang_VirtualFileOverlay_writeToBuffer>>(
+                'clang_VirtualFileOverlay_writeToBuffer')
+            .asFunction<_dart_clang_VirtualFileOverlay_writeToBuffer>())(
       arg0,
       options,
       out_buffer_ptr,
@@ -142,7 +152,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> buffer,
   ) {
     return (_clang_free ??=
-        _dylib.lookupFunction<_c_clang_free, _dart_clang_free>('clang_free'))(
+        _lookup<ffi.NativeFunction<_c_clang_free>>('clang_free')
+            .asFunction<_dart_clang_free>())(
       buffer,
     );
   }
@@ -153,10 +164,10 @@ class LibClang {
   void clang_VirtualFileOverlay_dispose(
     ffi.Pointer<CXVirtualFileOverlayImpl> arg0,
   ) {
-    return (_clang_VirtualFileOverlay_dispose ??= _dylib.lookupFunction<
-            _c_clang_VirtualFileOverlay_dispose,
-            _dart_clang_VirtualFileOverlay_dispose>(
-        'clang_VirtualFileOverlay_dispose'))(
+    return (_clang_VirtualFileOverlay_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_VirtualFileOverlay_dispose>>(
+                'clang_VirtualFileOverlay_dispose')
+            .asFunction<_dart_clang_VirtualFileOverlay_dispose>())(
       arg0,
     );
   }
@@ -168,10 +179,10 @@ class LibClang {
   ffi.Pointer<CXModuleMapDescriptorImpl> clang_ModuleMapDescriptor_create(
     int options,
   ) {
-    return (_clang_ModuleMapDescriptor_create ??= _dylib.lookupFunction<
-            _c_clang_ModuleMapDescriptor_create,
-            _dart_clang_ModuleMapDescriptor_create>(
-        'clang_ModuleMapDescriptor_create'))(
+    return (_clang_ModuleMapDescriptor_create ??=
+        _lookup<ffi.NativeFunction<_c_clang_ModuleMapDescriptor_create>>(
+                'clang_ModuleMapDescriptor_create')
+            .asFunction<_dart_clang_ModuleMapDescriptor_create>())(
       options,
     );
   }
@@ -183,11 +194,11 @@ class LibClang {
     ffi.Pointer<CXModuleMapDescriptorImpl> arg0,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_clang_ModuleMapDescriptor_setFrameworkModuleName ??=
-        _dylib.lookupFunction<
-                _c_clang_ModuleMapDescriptor_setFrameworkModuleName,
-                _dart_clang_ModuleMapDescriptor_setFrameworkModuleName>(
-            'clang_ModuleMapDescriptor_setFrameworkModuleName'))(
+    return (_clang_ModuleMapDescriptor_setFrameworkModuleName ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_ModuleMapDescriptor_setFrameworkModuleName>>(
+            'clang_ModuleMapDescriptor_setFrameworkModuleName')
+        .asFunction<_dart_clang_ModuleMapDescriptor_setFrameworkModuleName>())(
       arg0,
       name,
     );
@@ -201,10 +212,11 @@ class LibClang {
     ffi.Pointer<CXModuleMapDescriptorImpl> arg0,
     ffi.Pointer<ffi.Int8> name,
   ) {
-    return (_clang_ModuleMapDescriptor_setUmbrellaHeader ??=
-        _dylib.lookupFunction<_c_clang_ModuleMapDescriptor_setUmbrellaHeader,
-                _dart_clang_ModuleMapDescriptor_setUmbrellaHeader>(
-            'clang_ModuleMapDescriptor_setUmbrellaHeader'))(
+    return (_clang_ModuleMapDescriptor_setUmbrellaHeader ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_ModuleMapDescriptor_setUmbrellaHeader>>(
+            'clang_ModuleMapDescriptor_setUmbrellaHeader')
+        .asFunction<_dart_clang_ModuleMapDescriptor_setUmbrellaHeader>())(
       arg0,
       name,
     );
@@ -220,10 +232,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> out_buffer_ptr,
     ffi.Pointer<ffi.Uint32> out_buffer_size,
   ) {
-    return (_clang_ModuleMapDescriptor_writeToBuffer ??= _dylib.lookupFunction<
-            _c_clang_ModuleMapDescriptor_writeToBuffer,
-            _dart_clang_ModuleMapDescriptor_writeToBuffer>(
-        'clang_ModuleMapDescriptor_writeToBuffer'))(
+    return (_clang_ModuleMapDescriptor_writeToBuffer ??=
+        _lookup<ffi.NativeFunction<_c_clang_ModuleMapDescriptor_writeToBuffer>>(
+                'clang_ModuleMapDescriptor_writeToBuffer')
+            .asFunction<_dart_clang_ModuleMapDescriptor_writeToBuffer>())(
       arg0,
       options,
       out_buffer_ptr,
@@ -238,10 +250,10 @@ class LibClang {
   void clang_ModuleMapDescriptor_dispose(
     ffi.Pointer<CXModuleMapDescriptorImpl> arg0,
   ) {
-    return (_clang_ModuleMapDescriptor_dispose ??= _dylib.lookupFunction<
-            _c_clang_ModuleMapDescriptor_dispose,
-            _dart_clang_ModuleMapDescriptor_dispose>(
-        'clang_ModuleMapDescriptor_dispose'))(
+    return (_clang_ModuleMapDescriptor_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_ModuleMapDescriptor_dispose>>(
+                'clang_ModuleMapDescriptor_dispose')
+            .asFunction<_dart_clang_ModuleMapDescriptor_dispose>())(
       arg0,
     );
   }
@@ -254,8 +266,8 @@ class LibClang {
     int displayDiagnostics,
   ) {
     return (_clang_createIndex ??=
-        _dylib.lookupFunction<_c_clang_createIndex, _dart_clang_createIndex>(
-            'clang_createIndex'))(
+        _lookup<ffi.NativeFunction<_c_clang_createIndex>>('clang_createIndex')
+            .asFunction<_dart_clang_createIndex>())(
       excludeDeclarationsFromPCH,
       displayDiagnostics,
     );
@@ -268,8 +280,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> index,
   ) {
     return (_clang_disposeIndex ??=
-        _dylib.lookupFunction<_c_clang_disposeIndex, _dart_clang_disposeIndex>(
-            'clang_disposeIndex'))(
+        _lookup<ffi.NativeFunction<_c_clang_disposeIndex>>('clang_disposeIndex')
+            .asFunction<_dart_clang_disposeIndex>())(
       index,
     );
   }
@@ -281,10 +293,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> arg0,
     int options,
   ) {
-    return (_clang_CXIndex_setGlobalOptions ??= _dylib.lookupFunction<
-            _c_clang_CXIndex_setGlobalOptions,
-            _dart_clang_CXIndex_setGlobalOptions>(
-        'clang_CXIndex_setGlobalOptions'))(
+    return (_clang_CXIndex_setGlobalOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXIndex_setGlobalOptions>>(
+                'clang_CXIndex_setGlobalOptions')
+            .asFunction<_dart_clang_CXIndex_setGlobalOptions>())(
       arg0,
       options,
     );
@@ -296,10 +308,10 @@ class LibClang {
   int clang_CXIndex_getGlobalOptions(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_CXIndex_getGlobalOptions ??= _dylib.lookupFunction<
-            _c_clang_CXIndex_getGlobalOptions,
-            _dart_clang_CXIndex_getGlobalOptions>(
-        'clang_CXIndex_getGlobalOptions'))(
+    return (_clang_CXIndex_getGlobalOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXIndex_getGlobalOptions>>(
+                'clang_CXIndex_getGlobalOptions')
+            .asFunction<_dart_clang_CXIndex_getGlobalOptions>())(
       arg0,
     );
   }
@@ -311,10 +323,11 @@ class LibClang {
     ffi.Pointer<ffi.Void> arg0,
     ffi.Pointer<ffi.Int8> Path,
   ) {
-    return (_clang_CXIndex_setInvocationEmissionPathOption ??=
-        _dylib.lookupFunction<_c_clang_CXIndex_setInvocationEmissionPathOption,
-                _dart_clang_CXIndex_setInvocationEmissionPathOption>(
-            'clang_CXIndex_setInvocationEmissionPathOption'))(
+    return (_clang_CXIndex_setInvocationEmissionPathOption ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_CXIndex_setInvocationEmissionPathOption>>(
+            'clang_CXIndex_setInvocationEmissionPathOption')
+        .asFunction<_dart_clang_CXIndex_setInvocationEmissionPathOption>())(
       arg0,
       Path,
     );
@@ -328,8 +341,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> SFile,
   ) {
     return (_clang_getFileName ??=
-        _dylib.lookupFunction<_c_clang_getFileName, _dart_clang_getFileName>(
-            'clang_getFileName'))(
+        _lookup<ffi.NativeFunction<_c_clang_getFileName>>('clang_getFileName')
+            .asFunction<_dart_clang_getFileName>())(
       SFile,
     );
   }
@@ -341,8 +354,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> SFile,
   ) {
     return (_clang_getFileTime ??=
-        _dylib.lookupFunction<_c_clang_getFileTime, _dart_clang_getFileTime>(
-            'clang_getFileTime'))(
+        _lookup<ffi.NativeFunction<_c_clang_getFileTime>>('clang_getFileTime')
+            .asFunction<_dart_clang_getFileTime>())(
       SFile,
     );
   }
@@ -354,9 +367,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     ffi.Pointer<CXFileUniqueID> outID,
   ) {
-    return (_clang_getFileUniqueID ??= _dylib.lookupFunction<
-        _c_clang_getFileUniqueID,
-        _dart_clang_getFileUniqueID>('clang_getFileUniqueID'))(
+    return (_clang_getFileUniqueID ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFileUniqueID>>(
+                'clang_getFileUniqueID')
+            .asFunction<_dart_clang_getFileUniqueID>())(
       file,
       outID,
     );
@@ -371,10 +385,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> tu,
     ffi.Pointer<ffi.Void> file,
   ) {
-    return (_clang_isFileMultipleIncludeGuarded ??= _dylib.lookupFunction<
-            _c_clang_isFileMultipleIncludeGuarded,
-            _dart_clang_isFileMultipleIncludeGuarded>(
-        'clang_isFileMultipleIncludeGuarded'))(
+    return (_clang_isFileMultipleIncludeGuarded ??=
+        _lookup<ffi.NativeFunction<_c_clang_isFileMultipleIncludeGuarded>>(
+                'clang_isFileMultipleIncludeGuarded')
+            .asFunction<_dart_clang_isFileMultipleIncludeGuarded>())(
       tu,
       file,
     );
@@ -388,8 +402,8 @@ class LibClang {
     ffi.Pointer<ffi.Int8> file_name,
   ) {
     return (_clang_getFile ??=
-        _dylib.lookupFunction<_c_clang_getFile, _dart_clang_getFile>(
-            'clang_getFile'))(
+        _lookup<ffi.NativeFunction<_c_clang_getFile>>('clang_getFile')
+            .asFunction<_dart_clang_getFile>())(
       tu,
       file_name,
     );
@@ -403,9 +417,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     ffi.Pointer<ffi.Uint64> size,
   ) {
-    return (_clang_getFileContents ??= _dylib.lookupFunction<
-        _c_clang_getFileContents,
-        _dart_clang_getFileContents>('clang_getFileContents'))(
+    return (_clang_getFileContents ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFileContents>>(
+                'clang_getFileContents')
+            .asFunction<_dart_clang_getFileContents>())(
       tu,
       file,
       size,
@@ -421,8 +436,8 @@ class LibClang {
     ffi.Pointer<ffi.Void> file2,
   ) {
     return (_clang_File_isEqual ??=
-        _dylib.lookupFunction<_c_clang_File_isEqual, _dart_clang_File_isEqual>(
-            'clang_File_isEqual'))(
+        _lookup<ffi.NativeFunction<_c_clang_File_isEqual>>('clang_File_isEqual')
+            .asFunction<_dart_clang_File_isEqual>())(
       file1,
       file2,
     );
@@ -434,9 +449,10 @@ class LibClang {
   CXString clang_File_tryGetRealPathName(
     ffi.Pointer<ffi.Void> file,
   ) {
-    return (_clang_File_tryGetRealPathName ??= _dylib.lookupFunction<
-        _c_clang_File_tryGetRealPathName,
-        _dart_clang_File_tryGetRealPathName>('clang_File_tryGetRealPathName'))(
+    return (_clang_File_tryGetRealPathName ??=
+        _lookup<ffi.NativeFunction<_c_clang_File_tryGetRealPathName>>(
+                'clang_File_tryGetRealPathName')
+            .asFunction<_dart_clang_File_tryGetRealPathName>())(
       file,
     );
   }
@@ -445,9 +461,10 @@ class LibClang {
 
   /// Retrieve a NULL (invalid) source location.
   CXSourceLocation clang_getNullLocation() {
-    return (_clang_getNullLocation ??= _dylib.lookupFunction<
-        _c_clang_getNullLocation,
-        _dart_clang_getNullLocation>('clang_getNullLocation'))();
+    return (_clang_getNullLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNullLocation>>(
+                'clang_getNullLocation')
+            .asFunction<_dart_clang_getNullLocation>())();
   }
 
   _dart_clang_getNullLocation? _clang_getNullLocation;
@@ -458,9 +475,10 @@ class LibClang {
     CXSourceLocation loc1,
     CXSourceLocation loc2,
   ) {
-    return (_clang_equalLocations ??= _dylib.lookupFunction<
-        _c_clang_equalLocations,
-        _dart_clang_equalLocations>('clang_equalLocations'))(
+    return (_clang_equalLocations ??=
+        _lookup<ffi.NativeFunction<_c_clang_equalLocations>>(
+                'clang_equalLocations')
+            .asFunction<_dart_clang_equalLocations>())(
       loc1,
       loc2,
     );
@@ -477,8 +495,8 @@ class LibClang {
     int column,
   ) {
     return (_clang_getLocation ??=
-        _dylib.lookupFunction<_c_clang_getLocation, _dart_clang_getLocation>(
-            'clang_getLocation'))(
+        _lookup<ffi.NativeFunction<_c_clang_getLocation>>('clang_getLocation')
+            .asFunction<_dart_clang_getLocation>())(
       tu,
       file,
       line,
@@ -495,9 +513,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     int offset,
   ) {
-    return (_clang_getLocationForOffset ??= _dylib.lookupFunction<
-        _c_clang_getLocationForOffset,
-        _dart_clang_getLocationForOffset>('clang_getLocationForOffset'))(
+    return (_clang_getLocationForOffset ??=
+        _lookup<ffi.NativeFunction<_c_clang_getLocationForOffset>>(
+                'clang_getLocationForOffset')
+            .asFunction<_dart_clang_getLocationForOffset>())(
       tu,
       file,
       offset,
@@ -510,10 +529,10 @@ class LibClang {
   int clang_Location_isInSystemHeader(
     CXSourceLocation location,
   ) {
-    return (_clang_Location_isInSystemHeader ??= _dylib.lookupFunction<
-            _c_clang_Location_isInSystemHeader,
-            _dart_clang_Location_isInSystemHeader>(
-        'clang_Location_isInSystemHeader'))(
+    return (_clang_Location_isInSystemHeader ??=
+        _lookup<ffi.NativeFunction<_c_clang_Location_isInSystemHeader>>(
+                'clang_Location_isInSystemHeader')
+            .asFunction<_dart_clang_Location_isInSystemHeader>())(
       location,
     );
   }
@@ -525,9 +544,10 @@ class LibClang {
   int clang_Location_isFromMainFile(
     CXSourceLocation location,
   ) {
-    return (_clang_Location_isFromMainFile ??= _dylib.lookupFunction<
-        _c_clang_Location_isFromMainFile,
-        _dart_clang_Location_isFromMainFile>('clang_Location_isFromMainFile'))(
+    return (_clang_Location_isFromMainFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_Location_isFromMainFile>>(
+                'clang_Location_isFromMainFile')
+            .asFunction<_dart_clang_Location_isFromMainFile>())(
       location,
     );
   }
@@ -537,8 +557,8 @@ class LibClang {
   /// Retrieve a NULL (invalid) source range.
   CXSourceRange clang_getNullRange() {
     return (_clang_getNullRange ??=
-        _dylib.lookupFunction<_c_clang_getNullRange, _dart_clang_getNullRange>(
-            'clang_getNullRange'))();
+        _lookup<ffi.NativeFunction<_c_clang_getNullRange>>('clang_getNullRange')
+            .asFunction<_dart_clang_getNullRange>())();
   }
 
   _dart_clang_getNullRange? _clang_getNullRange;
@@ -549,8 +569,8 @@ class LibClang {
     CXSourceLocation end,
   ) {
     return (_clang_getRange ??=
-        _dylib.lookupFunction<_c_clang_getRange, _dart_clang_getRange>(
-            'clang_getRange'))(
+        _lookup<ffi.NativeFunction<_c_clang_getRange>>('clang_getRange')
+            .asFunction<_dart_clang_getRange>())(
       begin,
       end,
     );
@@ -564,8 +584,8 @@ class LibClang {
     CXSourceRange range2,
   ) {
     return (_clang_equalRanges ??=
-        _dylib.lookupFunction<_c_clang_equalRanges, _dart_clang_equalRanges>(
-            'clang_equalRanges'))(
+        _lookup<ffi.NativeFunction<_c_clang_equalRanges>>('clang_equalRanges')
+            .asFunction<_dart_clang_equalRanges>())(
       range1,
       range2,
     );
@@ -578,8 +598,8 @@ class LibClang {
     CXSourceRange range,
   ) {
     return (_clang_Range_isNull ??=
-        _dylib.lookupFunction<_c_clang_Range_isNull, _dart_clang_Range_isNull>(
-            'clang_Range_isNull'))(
+        _lookup<ffi.NativeFunction<_c_clang_Range_isNull>>('clang_Range_isNull')
+            .asFunction<_dart_clang_Range_isNull>())(
       range,
     );
   }
@@ -595,9 +615,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getExpansionLocation ??= _dylib.lookupFunction<
-        _c_clang_getExpansionLocation,
-        _dart_clang_getExpansionLocation>('clang_getExpansionLocation'))(
+    return (_clang_getExpansionLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getExpansionLocation>>(
+                'clang_getExpansionLocation')
+            .asFunction<_dart_clang_getExpansionLocation>())(
       location,
       file,
       line,
@@ -616,9 +637,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> line,
     ffi.Pointer<ffi.Uint32> column,
   ) {
-    return (_clang_getPresumedLocation ??= _dylib.lookupFunction<
-        _c_clang_getPresumedLocation,
-        _dart_clang_getPresumedLocation>('clang_getPresumedLocation'))(
+    return (_clang_getPresumedLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getPresumedLocation>>(
+                'clang_getPresumedLocation')
+            .asFunction<_dart_clang_getPresumedLocation>())(
       location,
       filename,
       line,
@@ -637,10 +659,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getInstantiationLocation ??= _dylib.lookupFunction<
-            _c_clang_getInstantiationLocation,
-            _dart_clang_getInstantiationLocation>(
-        'clang_getInstantiationLocation'))(
+    return (_clang_getInstantiationLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getInstantiationLocation>>(
+                'clang_getInstantiationLocation')
+            .asFunction<_dart_clang_getInstantiationLocation>())(
       location,
       file,
       line,
@@ -660,9 +682,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getSpellingLocation ??= _dylib.lookupFunction<
-        _c_clang_getSpellingLocation,
-        _dart_clang_getSpellingLocation>('clang_getSpellingLocation'))(
+    return (_clang_getSpellingLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getSpellingLocation>>(
+                'clang_getSpellingLocation')
+            .asFunction<_dart_clang_getSpellingLocation>())(
       location,
       file,
       line,
@@ -682,9 +705,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_getFileLocation ??= _dylib.lookupFunction<
-        _c_clang_getFileLocation,
-        _dart_clang_getFileLocation>('clang_getFileLocation'))(
+    return (_clang_getFileLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFileLocation>>(
+                'clang_getFileLocation')
+            .asFunction<_dart_clang_getFileLocation>())(
       location,
       file,
       line,
@@ -700,9 +724,10 @@ class LibClang {
   CXSourceLocation clang_getRangeStart(
     CXSourceRange range,
   ) {
-    return (_clang_getRangeStart ??= _dylib.lookupFunction<
-        _c_clang_getRangeStart,
-        _dart_clang_getRangeStart>('clang_getRangeStart'))(
+    return (_clang_getRangeStart ??=
+        _lookup<ffi.NativeFunction<_c_clang_getRangeStart>>(
+                'clang_getRangeStart')
+            .asFunction<_dart_clang_getRangeStart>())(
       range,
     );
   }
@@ -715,8 +740,8 @@ class LibClang {
     CXSourceRange range,
   ) {
     return (_clang_getRangeEnd ??=
-        _dylib.lookupFunction<_c_clang_getRangeEnd, _dart_clang_getRangeEnd>(
-            'clang_getRangeEnd'))(
+        _lookup<ffi.NativeFunction<_c_clang_getRangeEnd>>('clang_getRangeEnd')
+            .asFunction<_dart_clang_getRangeEnd>())(
       range,
     );
   }
@@ -728,9 +753,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> tu,
     ffi.Pointer<ffi.Void> file,
   ) {
-    return (_clang_getSkippedRanges ??= _dylib.lookupFunction<
-        _c_clang_getSkippedRanges,
-        _dart_clang_getSkippedRanges>('clang_getSkippedRanges'))(
+    return (_clang_getSkippedRanges ??=
+        _lookup<ffi.NativeFunction<_c_clang_getSkippedRanges>>(
+                'clang_getSkippedRanges')
+            .asFunction<_dart_clang_getSkippedRanges>())(
       tu,
       file,
     );
@@ -742,9 +768,10 @@ class LibClang {
   ffi.Pointer<CXSourceRangeList> clang_getAllSkippedRanges(
     ffi.Pointer<CXTranslationUnitImpl> tu,
   ) {
-    return (_clang_getAllSkippedRanges ??= _dylib.lookupFunction<
-        _c_clang_getAllSkippedRanges,
-        _dart_clang_getAllSkippedRanges>('clang_getAllSkippedRanges'))(
+    return (_clang_getAllSkippedRanges ??=
+        _lookup<ffi.NativeFunction<_c_clang_getAllSkippedRanges>>(
+                'clang_getAllSkippedRanges')
+            .asFunction<_dart_clang_getAllSkippedRanges>())(
       tu,
     );
   }
@@ -755,9 +782,10 @@ class LibClang {
   void clang_disposeSourceRangeList(
     ffi.Pointer<CXSourceRangeList> ranges,
   ) {
-    return (_clang_disposeSourceRangeList ??= _dylib.lookupFunction<
-        _c_clang_disposeSourceRangeList,
-        _dart_clang_disposeSourceRangeList>('clang_disposeSourceRangeList'))(
+    return (_clang_disposeSourceRangeList ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeSourceRangeList>>(
+                'clang_disposeSourceRangeList')
+            .asFunction<_dart_clang_disposeSourceRangeList>())(
       ranges,
     );
   }
@@ -768,9 +796,10 @@ class LibClang {
   int clang_getNumDiagnosticsInSet(
     ffi.Pointer<ffi.Void> Diags,
   ) {
-    return (_clang_getNumDiagnosticsInSet ??= _dylib.lookupFunction<
-        _c_clang_getNumDiagnosticsInSet,
-        _dart_clang_getNumDiagnosticsInSet>('clang_getNumDiagnosticsInSet'))(
+    return (_clang_getNumDiagnosticsInSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumDiagnosticsInSet>>(
+                'clang_getNumDiagnosticsInSet')
+            .asFunction<_dart_clang_getNumDiagnosticsInSet>())(
       Diags,
     );
   }
@@ -782,9 +811,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diags,
     int Index,
   ) {
-    return (_clang_getDiagnosticInSet ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticInSet,
-        _dart_clang_getDiagnosticInSet>('clang_getDiagnosticInSet'))(
+    return (_clang_getDiagnosticInSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticInSet>>(
+                'clang_getDiagnosticInSet')
+            .asFunction<_dart_clang_getDiagnosticInSet>())(
       Diags,
       Index,
     );
@@ -798,9 +828,10 @@ class LibClang {
     ffi.Pointer<ffi.Int32> error,
     ffi.Pointer<CXString> errorString,
   ) {
-    return (_clang_loadDiagnostics ??= _dylib.lookupFunction<
-        _c_clang_loadDiagnostics,
-        _dart_clang_loadDiagnostics>('clang_loadDiagnostics'))(
+    return (_clang_loadDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_loadDiagnostics>>(
+                'clang_loadDiagnostics')
+            .asFunction<_dart_clang_loadDiagnostics>())(
       file,
       error,
       errorString,
@@ -813,9 +844,10 @@ class LibClang {
   void clang_disposeDiagnosticSet(
     ffi.Pointer<ffi.Void> Diags,
   ) {
-    return (_clang_disposeDiagnosticSet ??= _dylib.lookupFunction<
-        _c_clang_disposeDiagnosticSet,
-        _dart_clang_disposeDiagnosticSet>('clang_disposeDiagnosticSet'))(
+    return (_clang_disposeDiagnosticSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeDiagnosticSet>>(
+                'clang_disposeDiagnosticSet')
+            .asFunction<_dart_clang_disposeDiagnosticSet>())(
       Diags,
     );
   }
@@ -826,9 +858,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getChildDiagnostics(
     ffi.Pointer<ffi.Void> D,
   ) {
-    return (_clang_getChildDiagnostics ??= _dylib.lookupFunction<
-        _c_clang_getChildDiagnostics,
-        _dart_clang_getChildDiagnostics>('clang_getChildDiagnostics'))(
+    return (_clang_getChildDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_getChildDiagnostics>>(
+                'clang_getChildDiagnostics')
+            .asFunction<_dart_clang_getChildDiagnostics>())(
       D,
     );
   }
@@ -840,9 +873,10 @@ class LibClang {
   int clang_getNumDiagnostics(
     ffi.Pointer<CXTranslationUnitImpl> Unit,
   ) {
-    return (_clang_getNumDiagnostics ??= _dylib.lookupFunction<
-        _c_clang_getNumDiagnostics,
-        _dart_clang_getNumDiagnostics>('clang_getNumDiagnostics'))(
+    return (_clang_getNumDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumDiagnostics>>(
+                'clang_getNumDiagnostics')
+            .asFunction<_dart_clang_getNumDiagnostics>())(
       Unit,
     );
   }
@@ -854,9 +888,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> Unit,
     int Index,
   ) {
-    return (_clang_getDiagnostic ??= _dylib.lookupFunction<
-        _c_clang_getDiagnostic,
-        _dart_clang_getDiagnostic>('clang_getDiagnostic'))(
+    return (_clang_getDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnostic>>(
+                'clang_getDiagnostic')
+            .asFunction<_dart_clang_getDiagnostic>())(
       Unit,
       Index,
     );
@@ -869,9 +904,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getDiagnosticSetFromTU(
     ffi.Pointer<CXTranslationUnitImpl> Unit,
   ) {
-    return (_clang_getDiagnosticSetFromTU ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticSetFromTU,
-        _dart_clang_getDiagnosticSetFromTU>('clang_getDiagnosticSetFromTU'))(
+    return (_clang_getDiagnosticSetFromTU ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticSetFromTU>>(
+                'clang_getDiagnosticSetFromTU')
+            .asFunction<_dart_clang_getDiagnosticSetFromTU>())(
       Unit,
     );
   }
@@ -882,9 +918,10 @@ class LibClang {
   void clang_disposeDiagnostic(
     ffi.Pointer<ffi.Void> Diagnostic,
   ) {
-    return (_clang_disposeDiagnostic ??= _dylib.lookupFunction<
-        _c_clang_disposeDiagnostic,
-        _dart_clang_disposeDiagnostic>('clang_disposeDiagnostic'))(
+    return (_clang_disposeDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeDiagnostic>>(
+                'clang_disposeDiagnostic')
+            .asFunction<_dart_clang_disposeDiagnostic>())(
       Diagnostic,
     );
   }
@@ -896,9 +933,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diagnostic,
     int Options,
   ) {
-    return (_clang_formatDiagnostic ??= _dylib.lookupFunction<
-        _c_clang_formatDiagnostic,
-        _dart_clang_formatDiagnostic>('clang_formatDiagnostic'))(
+    return (_clang_formatDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_formatDiagnostic>>(
+                'clang_formatDiagnostic')
+            .asFunction<_dart_clang_formatDiagnostic>())(
       Diagnostic,
       Options,
     );
@@ -909,10 +947,10 @@ class LibClang {
   /// Retrieve the set of display options most similar to the default behavior
   /// of the clang compiler.
   int clang_defaultDiagnosticDisplayOptions() {
-    return (_clang_defaultDiagnosticDisplayOptions ??= _dylib.lookupFunction<
-            _c_clang_defaultDiagnosticDisplayOptions,
-            _dart_clang_defaultDiagnosticDisplayOptions>(
-        'clang_defaultDiagnosticDisplayOptions'))();
+    return (_clang_defaultDiagnosticDisplayOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultDiagnosticDisplayOptions>>(
+                'clang_defaultDiagnosticDisplayOptions')
+            .asFunction<_dart_clang_defaultDiagnosticDisplayOptions>())();
   }
 
   _dart_clang_defaultDiagnosticDisplayOptions?
@@ -922,9 +960,10 @@ class LibClang {
   int clang_getDiagnosticSeverity(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticSeverity ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticSeverity,
-        _dart_clang_getDiagnosticSeverity>('clang_getDiagnosticSeverity'))(
+    return (_clang_getDiagnosticSeverity ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticSeverity>>(
+                'clang_getDiagnosticSeverity')
+            .asFunction<_dart_clang_getDiagnosticSeverity>())(
       arg0,
     );
   }
@@ -935,9 +974,10 @@ class LibClang {
   CXSourceLocation clang_getDiagnosticLocation(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticLocation ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticLocation,
-        _dart_clang_getDiagnosticLocation>('clang_getDiagnosticLocation'))(
+    return (_clang_getDiagnosticLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticLocation>>(
+                'clang_getDiagnosticLocation')
+            .asFunction<_dart_clang_getDiagnosticLocation>())(
       arg0,
     );
   }
@@ -948,9 +988,10 @@ class LibClang {
   CXString clang_getDiagnosticSpelling(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticSpelling ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticSpelling,
-        _dart_clang_getDiagnosticSpelling>('clang_getDiagnosticSpelling'))(
+    return (_clang_getDiagnosticSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticSpelling>>(
+                'clang_getDiagnosticSpelling')
+            .asFunction<_dart_clang_getDiagnosticSpelling>())(
       arg0,
     );
   }
@@ -962,9 +1003,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diag,
     ffi.Pointer<CXString> Disable,
   ) {
-    return (_clang_getDiagnosticOption ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticOption,
-        _dart_clang_getDiagnosticOption>('clang_getDiagnosticOption'))(
+    return (_clang_getDiagnosticOption ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticOption>>(
+                'clang_getDiagnosticOption')
+            .asFunction<_dart_clang_getDiagnosticOption>())(
       Diag,
       Disable,
     );
@@ -976,9 +1018,10 @@ class LibClang {
   int clang_getDiagnosticCategory(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticCategory ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticCategory,
-        _dart_clang_getDiagnosticCategory>('clang_getDiagnosticCategory'))(
+    return (_clang_getDiagnosticCategory ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticCategory>>(
+                'clang_getDiagnosticCategory')
+            .asFunction<_dart_clang_getDiagnosticCategory>())(
       arg0,
     );
   }
@@ -990,10 +1033,10 @@ class LibClang {
   CXString clang_getDiagnosticCategoryName(
     int Category,
   ) {
-    return (_clang_getDiagnosticCategoryName ??= _dylib.lookupFunction<
-            _c_clang_getDiagnosticCategoryName,
-            _dart_clang_getDiagnosticCategoryName>(
-        'clang_getDiagnosticCategoryName'))(
+    return (_clang_getDiagnosticCategoryName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticCategoryName>>(
+                'clang_getDiagnosticCategoryName')
+            .asFunction<_dart_clang_getDiagnosticCategoryName>())(
       Category,
     );
   }
@@ -1004,10 +1047,10 @@ class LibClang {
   CXString clang_getDiagnosticCategoryText(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticCategoryText ??= _dylib.lookupFunction<
-            _c_clang_getDiagnosticCategoryText,
-            _dart_clang_getDiagnosticCategoryText>(
-        'clang_getDiagnosticCategoryText'))(
+    return (_clang_getDiagnosticCategoryText ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticCategoryText>>(
+                'clang_getDiagnosticCategoryText')
+            .asFunction<_dart_clang_getDiagnosticCategoryText>())(
       arg0,
     );
   }
@@ -1019,9 +1062,10 @@ class LibClang {
   int clang_getDiagnosticNumRanges(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_getDiagnosticNumRanges ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticNumRanges,
-        _dart_clang_getDiagnosticNumRanges>('clang_getDiagnosticNumRanges'))(
+    return (_clang_getDiagnosticNumRanges ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticNumRanges>>(
+                'clang_getDiagnosticNumRanges')
+            .asFunction<_dart_clang_getDiagnosticNumRanges>())(
       arg0,
     );
   }
@@ -1033,9 +1077,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Diagnostic,
     int Range,
   ) {
-    return (_clang_getDiagnosticRange ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticRange,
-        _dart_clang_getDiagnosticRange>('clang_getDiagnosticRange'))(
+    return (_clang_getDiagnosticRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticRange>>(
+                'clang_getDiagnosticRange')
+            .asFunction<_dart_clang_getDiagnosticRange>())(
       Diagnostic,
       Range,
     );
@@ -1047,9 +1092,10 @@ class LibClang {
   int clang_getDiagnosticNumFixIts(
     ffi.Pointer<ffi.Void> Diagnostic,
   ) {
-    return (_clang_getDiagnosticNumFixIts ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticNumFixIts,
-        _dart_clang_getDiagnosticNumFixIts>('clang_getDiagnosticNumFixIts'))(
+    return (_clang_getDiagnosticNumFixIts ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticNumFixIts>>(
+                'clang_getDiagnosticNumFixIts')
+            .asFunction<_dart_clang_getDiagnosticNumFixIts>())(
       Diagnostic,
     );
   }
@@ -1062,9 +1108,10 @@ class LibClang {
     int FixIt,
     ffi.Pointer<CXSourceRange> ReplacementRange,
   ) {
-    return (_clang_getDiagnosticFixIt ??= _dylib.lookupFunction<
-        _c_clang_getDiagnosticFixIt,
-        _dart_clang_getDiagnosticFixIt>('clang_getDiagnosticFixIt'))(
+    return (_clang_getDiagnosticFixIt ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDiagnosticFixIt>>(
+                'clang_getDiagnosticFixIt')
+            .asFunction<_dart_clang_getDiagnosticFixIt>())(
       Diagnostic,
       FixIt,
       ReplacementRange,
@@ -1077,10 +1124,10 @@ class LibClang {
   CXString clang_getTranslationUnitSpelling(
     ffi.Pointer<CXTranslationUnitImpl> CTUnit,
   ) {
-    return (_clang_getTranslationUnitSpelling ??= _dylib.lookupFunction<
-            _c_clang_getTranslationUnitSpelling,
-            _dart_clang_getTranslationUnitSpelling>(
-        'clang_getTranslationUnitSpelling'))(
+    return (_clang_getTranslationUnitSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTranslationUnitSpelling>>(
+                'clang_getTranslationUnitSpelling')
+            .asFunction<_dart_clang_getTranslationUnitSpelling>())(
       CTUnit,
     );
   }
@@ -1097,10 +1144,11 @@ class LibClang {
     int num_unsaved_files,
     ffi.Pointer<CXUnsavedFile> unsaved_files,
   ) {
-    return (_clang_createTranslationUnitFromSourceFile ??=
-        _dylib.lookupFunction<_c_clang_createTranslationUnitFromSourceFile,
-                _dart_clang_createTranslationUnitFromSourceFile>(
-            'clang_createTranslationUnitFromSourceFile'))(
+    return (_clang_createTranslationUnitFromSourceFile ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_createTranslationUnitFromSourceFile>>(
+            'clang_createTranslationUnitFromSourceFile')
+        .asFunction<_dart_clang_createTranslationUnitFromSourceFile>())(
       CIdx,
       source_filename,
       num_clang_command_line_args,
@@ -1120,9 +1168,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> CIdx,
     ffi.Pointer<ffi.Int8> ast_filename,
   ) {
-    return (_clang_createTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_createTranslationUnit,
-        _dart_clang_createTranslationUnit>('clang_createTranslationUnit'))(
+    return (_clang_createTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_createTranslationUnit>>(
+                'clang_createTranslationUnit')
+            .asFunction<_dart_clang_createTranslationUnit>())(
       CIdx,
       ast_filename,
     );
@@ -1136,9 +1185,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> ast_filename,
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
   ) {
-    return (_clang_createTranslationUnit2 ??= _dylib.lookupFunction<
-        _c_clang_createTranslationUnit2,
-        _dart_clang_createTranslationUnit2>('clang_createTranslationUnit2'))(
+    return (_clang_createTranslationUnit2 ??=
+        _lookup<ffi.NativeFunction<_c_clang_createTranslationUnit2>>(
+                'clang_createTranslationUnit2')
+            .asFunction<_dart_clang_createTranslationUnit2>())(
       CIdx,
       ast_filename,
       out_TU,
@@ -1150,10 +1200,11 @@ class LibClang {
   /// Returns the set of flags that is suitable for parsing a translation unit
   /// that is being edited.
   int clang_defaultEditingTranslationUnitOptions() {
-    return (_clang_defaultEditingTranslationUnitOptions ??=
-        _dylib.lookupFunction<_c_clang_defaultEditingTranslationUnitOptions,
-                _dart_clang_defaultEditingTranslationUnitOptions>(
-            'clang_defaultEditingTranslationUnitOptions'))();
+    return (_clang_defaultEditingTranslationUnitOptions ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_defaultEditingTranslationUnitOptions>>(
+            'clang_defaultEditingTranslationUnitOptions')
+        .asFunction<_dart_clang_defaultEditingTranslationUnitOptions>())();
   }
 
   _dart_clang_defaultEditingTranslationUnitOptions?
@@ -1171,9 +1222,10 @@ class LibClang {
     int num_unsaved_files,
     int options,
   ) {
-    return (_clang_parseTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_parseTranslationUnit,
-        _dart_clang_parseTranslationUnit>('clang_parseTranslationUnit'))(
+    return (_clang_parseTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_parseTranslationUnit>>(
+                'clang_parseTranslationUnit')
+            .asFunction<_dart_clang_parseTranslationUnit>())(
       CIdx,
       source_filename,
       command_line_args,
@@ -1198,9 +1250,10 @@ class LibClang {
     int options,
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
   ) {
-    return (_clang_parseTranslationUnit2 ??= _dylib.lookupFunction<
-        _c_clang_parseTranslationUnit2,
-        _dart_clang_parseTranslationUnit2>('clang_parseTranslationUnit2'))(
+    return (_clang_parseTranslationUnit2 ??=
+        _lookup<ffi.NativeFunction<_c_clang_parseTranslationUnit2>>(
+                'clang_parseTranslationUnit2')
+            .asFunction<_dart_clang_parseTranslationUnit2>())(
       CIdx,
       source_filename,
       command_line_args,
@@ -1227,10 +1280,10 @@ class LibClang {
     int options,
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
   ) {
-    return (_clang_parseTranslationUnit2FullArgv ??= _dylib.lookupFunction<
-            _c_clang_parseTranslationUnit2FullArgv,
-            _dart_clang_parseTranslationUnit2FullArgv>(
-        'clang_parseTranslationUnit2FullArgv'))(
+    return (_clang_parseTranslationUnit2FullArgv ??=
+        _lookup<ffi.NativeFunction<_c_clang_parseTranslationUnit2FullArgv>>(
+                'clang_parseTranslationUnit2FullArgv')
+            .asFunction<_dart_clang_parseTranslationUnit2FullArgv>())(
       CIdx,
       source_filename,
       command_line_args,
@@ -1249,9 +1302,10 @@ class LibClang {
   int clang_defaultSaveOptions(
     ffi.Pointer<CXTranslationUnitImpl> TU,
   ) {
-    return (_clang_defaultSaveOptions ??= _dylib.lookupFunction<
-        _c_clang_defaultSaveOptions,
-        _dart_clang_defaultSaveOptions>('clang_defaultSaveOptions'))(
+    return (_clang_defaultSaveOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultSaveOptions>>(
+                'clang_defaultSaveOptions')
+            .asFunction<_dart_clang_defaultSaveOptions>())(
       TU,
     );
   }
@@ -1265,9 +1319,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> FileName,
     int options,
   ) {
-    return (_clang_saveTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_saveTranslationUnit,
-        _dart_clang_saveTranslationUnit>('clang_saveTranslationUnit'))(
+    return (_clang_saveTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_saveTranslationUnit>>(
+                'clang_saveTranslationUnit')
+            .asFunction<_dart_clang_saveTranslationUnit>())(
       TU,
       FileName,
       options,
@@ -1280,9 +1335,10 @@ class LibClang {
   int clang_suspendTranslationUnit(
     ffi.Pointer<CXTranslationUnitImpl> arg0,
   ) {
-    return (_clang_suspendTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_suspendTranslationUnit,
-        _dart_clang_suspendTranslationUnit>('clang_suspendTranslationUnit'))(
+    return (_clang_suspendTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_suspendTranslationUnit>>(
+                'clang_suspendTranslationUnit')
+            .asFunction<_dart_clang_suspendTranslationUnit>())(
       arg0,
     );
   }
@@ -1293,9 +1349,10 @@ class LibClang {
   void clang_disposeTranslationUnit(
     ffi.Pointer<CXTranslationUnitImpl> arg0,
   ) {
-    return (_clang_disposeTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_disposeTranslationUnit,
-        _dart_clang_disposeTranslationUnit>('clang_disposeTranslationUnit'))(
+    return (_clang_disposeTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeTranslationUnit>>(
+                'clang_disposeTranslationUnit')
+            .asFunction<_dart_clang_disposeTranslationUnit>())(
       arg0,
     );
   }
@@ -1307,9 +1364,10 @@ class LibClang {
   int clang_defaultReparseOptions(
     ffi.Pointer<CXTranslationUnitImpl> TU,
   ) {
-    return (_clang_defaultReparseOptions ??= _dylib.lookupFunction<
-        _c_clang_defaultReparseOptions,
-        _dart_clang_defaultReparseOptions>('clang_defaultReparseOptions'))(
+    return (_clang_defaultReparseOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultReparseOptions>>(
+                'clang_defaultReparseOptions')
+            .asFunction<_dart_clang_defaultReparseOptions>())(
       TU,
     );
   }
@@ -1323,9 +1381,10 @@ class LibClang {
     ffi.Pointer<CXUnsavedFile> unsaved_files,
     int options,
   ) {
-    return (_clang_reparseTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_reparseTranslationUnit,
-        _dart_clang_reparseTranslationUnit>('clang_reparseTranslationUnit'))(
+    return (_clang_reparseTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_reparseTranslationUnit>>(
+                'clang_reparseTranslationUnit')
+            .asFunction<_dart_clang_reparseTranslationUnit>())(
       TU,
       num_unsaved_files,
       unsaved_files,
@@ -1340,9 +1399,10 @@ class LibClang {
   ffi.Pointer<ffi.Int8> clang_getTUResourceUsageName(
     int kind,
   ) {
-    return (_clang_getTUResourceUsageName ??= _dylib.lookupFunction<
-        _c_clang_getTUResourceUsageName,
-        _dart_clang_getTUResourceUsageName>('clang_getTUResourceUsageName'))(
+    return (_clang_getTUResourceUsageName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTUResourceUsageName>>(
+                'clang_getTUResourceUsageName')
+            .asFunction<_dart_clang_getTUResourceUsageName>())(
       kind,
     );
   }
@@ -1354,9 +1414,10 @@ class LibClang {
   CXTUResourceUsage clang_getCXTUResourceUsage(
     ffi.Pointer<CXTranslationUnitImpl> TU,
   ) {
-    return (_clang_getCXTUResourceUsage ??= _dylib.lookupFunction<
-        _c_clang_getCXTUResourceUsage,
-        _dart_clang_getCXTUResourceUsage>('clang_getCXTUResourceUsage'))(
+    return (_clang_getCXTUResourceUsage ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCXTUResourceUsage>>(
+                'clang_getCXTUResourceUsage')
+            .asFunction<_dart_clang_getCXTUResourceUsage>())(
       TU,
     );
   }
@@ -1366,10 +1427,10 @@ class LibClang {
   void clang_disposeCXTUResourceUsage(
     CXTUResourceUsage usage,
   ) {
-    return (_clang_disposeCXTUResourceUsage ??= _dylib.lookupFunction<
-            _c_clang_disposeCXTUResourceUsage,
-            _dart_clang_disposeCXTUResourceUsage>(
-        'clang_disposeCXTUResourceUsage'))(
+    return (_clang_disposeCXTUResourceUsage ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCXTUResourceUsage>>(
+                'clang_disposeCXTUResourceUsage')
+            .asFunction<_dart_clang_disposeCXTUResourceUsage>())(
       usage,
     );
   }
@@ -1380,10 +1441,10 @@ class LibClang {
   ffi.Pointer<CXTargetInfoImpl> clang_getTranslationUnitTargetInfo(
     ffi.Pointer<CXTranslationUnitImpl> CTUnit,
   ) {
-    return (_clang_getTranslationUnitTargetInfo ??= _dylib.lookupFunction<
-            _c_clang_getTranslationUnitTargetInfo,
-            _dart_clang_getTranslationUnitTargetInfo>(
-        'clang_getTranslationUnitTargetInfo'))(
+    return (_clang_getTranslationUnitTargetInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTranslationUnitTargetInfo>>(
+                'clang_getTranslationUnitTargetInfo')
+            .asFunction<_dart_clang_getTranslationUnitTargetInfo>())(
       CTUnit,
     );
   }
@@ -1394,9 +1455,10 @@ class LibClang {
   void clang_TargetInfo_dispose(
     ffi.Pointer<CXTargetInfoImpl> Info,
   ) {
-    return (_clang_TargetInfo_dispose ??= _dylib.lookupFunction<
-        _c_clang_TargetInfo_dispose,
-        _dart_clang_TargetInfo_dispose>('clang_TargetInfo_dispose'))(
+    return (_clang_TargetInfo_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_TargetInfo_dispose>>(
+                'clang_TargetInfo_dispose')
+            .asFunction<_dart_clang_TargetInfo_dispose>())(
       Info,
     );
   }
@@ -1407,9 +1469,10 @@ class LibClang {
   CXString clang_TargetInfo_getTriple(
     ffi.Pointer<CXTargetInfoImpl> Info,
   ) {
-    return (_clang_TargetInfo_getTriple ??= _dylib.lookupFunction<
-        _c_clang_TargetInfo_getTriple,
-        _dart_clang_TargetInfo_getTriple>('clang_TargetInfo_getTriple'))(
+    return (_clang_TargetInfo_getTriple ??=
+        _lookup<ffi.NativeFunction<_c_clang_TargetInfo_getTriple>>(
+                'clang_TargetInfo_getTriple')
+            .asFunction<_dart_clang_TargetInfo_getTriple>())(
       Info,
     );
   }
@@ -1420,10 +1483,10 @@ class LibClang {
   int clang_TargetInfo_getPointerWidth(
     ffi.Pointer<CXTargetInfoImpl> Info,
   ) {
-    return (_clang_TargetInfo_getPointerWidth ??= _dylib.lookupFunction<
-            _c_clang_TargetInfo_getPointerWidth,
-            _dart_clang_TargetInfo_getPointerWidth>(
-        'clang_TargetInfo_getPointerWidth'))(
+    return (_clang_TargetInfo_getPointerWidth ??=
+        _lookup<ffi.NativeFunction<_c_clang_TargetInfo_getPointerWidth>>(
+                'clang_TargetInfo_getPointerWidth')
+            .asFunction<_dart_clang_TargetInfo_getPointerWidth>())(
       Info,
     );
   }
@@ -1432,9 +1495,10 @@ class LibClang {
 
   /// Retrieve the NULL cursor, which represents no entity.
   CXCursor clang_getNullCursor() {
-    return (_clang_getNullCursor ??= _dylib.lookupFunction<
-        _c_clang_getNullCursor,
-        _dart_clang_getNullCursor>('clang_getNullCursor'))();
+    return (_clang_getNullCursor ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNullCursor>>(
+                'clang_getNullCursor')
+            .asFunction<_dart_clang_getNullCursor>())();
   }
 
   _dart_clang_getNullCursor? _clang_getNullCursor;
@@ -1443,10 +1507,10 @@ class LibClang {
   CXCursor clang_getTranslationUnitCursor(
     ffi.Pointer<CXTranslationUnitImpl> arg0,
   ) {
-    return (_clang_getTranslationUnitCursor ??= _dylib.lookupFunction<
-            _c_clang_getTranslationUnitCursor,
-            _dart_clang_getTranslationUnitCursor>(
-        'clang_getTranslationUnitCursor'))(
+    return (_clang_getTranslationUnitCursor ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTranslationUnitCursor>>(
+                'clang_getTranslationUnitCursor')
+            .asFunction<_dart_clang_getTranslationUnitCursor>())(
       arg0,
     );
   }
@@ -1459,8 +1523,8 @@ class LibClang {
     CXCursor arg1,
   ) {
     return (_clang_equalCursors ??=
-        _dylib.lookupFunction<_c_clang_equalCursors, _dart_clang_equalCursors>(
-            'clang_equalCursors'))(
+        _lookup<ffi.NativeFunction<_c_clang_equalCursors>>('clang_equalCursors')
+            .asFunction<_dart_clang_equalCursors>())(
       arg0,
       arg1,
     );
@@ -1472,9 +1536,10 @@ class LibClang {
   int clang_Cursor_isNull(
     CXCursor cursor,
   ) {
-    return (_clang_Cursor_isNull ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isNull,
-        _dart_clang_Cursor_isNull>('clang_Cursor_isNull'))(
+    return (_clang_Cursor_isNull ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isNull>>(
+                'clang_Cursor_isNull')
+            .asFunction<_dart_clang_Cursor_isNull>())(
       cursor,
     );
   }
@@ -1486,8 +1551,8 @@ class LibClang {
     CXCursor arg0,
   ) {
     return (_clang_hashCursor ??=
-        _dylib.lookupFunction<_c_clang_hashCursor, _dart_clang_hashCursor>(
-            'clang_hashCursor'))(
+        _lookup<ffi.NativeFunction<_c_clang_hashCursor>>('clang_hashCursor')
+            .asFunction<_dart_clang_hashCursor>())(
       arg0,
     );
   }
@@ -1498,9 +1563,10 @@ class LibClang {
   int clang_getCursorKind(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorKind ??= _dylib.lookupFunction<
-        _c_clang_getCursorKind,
-        _dart_clang_getCursorKind>('clang_getCursorKind'))(
+    return (_clang_getCursorKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorKind>>(
+                'clang_getCursorKind')
+            .asFunction<_dart_clang_getCursorKind>())(
       arg0,
     );
   }
@@ -1511,9 +1577,10 @@ class LibClang {
   int clang_isDeclaration(
     int arg0,
   ) {
-    return (_clang_isDeclaration ??= _dylib.lookupFunction<
-        _c_clang_isDeclaration,
-        _dart_clang_isDeclaration>('clang_isDeclaration'))(
+    return (_clang_isDeclaration ??=
+        _lookup<ffi.NativeFunction<_c_clang_isDeclaration>>(
+                'clang_isDeclaration')
+            .asFunction<_dart_clang_isDeclaration>())(
       arg0,
     );
   }
@@ -1524,9 +1591,10 @@ class LibClang {
   int clang_isInvalidDeclaration(
     CXCursor arg0,
   ) {
-    return (_clang_isInvalidDeclaration ??= _dylib.lookupFunction<
-        _c_clang_isInvalidDeclaration,
-        _dart_clang_isInvalidDeclaration>('clang_isInvalidDeclaration'))(
+    return (_clang_isInvalidDeclaration ??=
+        _lookup<ffi.NativeFunction<_c_clang_isInvalidDeclaration>>(
+                'clang_isInvalidDeclaration')
+            .asFunction<_dart_clang_isInvalidDeclaration>())(
       arg0,
     );
   }
@@ -1538,8 +1606,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isReference ??=
-        _dylib.lookupFunction<_c_clang_isReference, _dart_clang_isReference>(
-            'clang_isReference'))(
+        _lookup<ffi.NativeFunction<_c_clang_isReference>>('clang_isReference')
+            .asFunction<_dart_clang_isReference>())(
       arg0,
     );
   }
@@ -1551,8 +1619,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isExpression ??=
-        _dylib.lookupFunction<_c_clang_isExpression, _dart_clang_isExpression>(
-            'clang_isExpression'))(
+        _lookup<ffi.NativeFunction<_c_clang_isExpression>>('clang_isExpression')
+            .asFunction<_dart_clang_isExpression>())(
       arg0,
     );
   }
@@ -1564,8 +1632,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isStatement ??=
-        _dylib.lookupFunction<_c_clang_isStatement, _dart_clang_isStatement>(
-            'clang_isStatement'))(
+        _lookup<ffi.NativeFunction<_c_clang_isStatement>>('clang_isStatement')
+            .asFunction<_dart_clang_isStatement>())(
       arg0,
     );
   }
@@ -1577,8 +1645,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isAttribute ??=
-        _dylib.lookupFunction<_c_clang_isAttribute, _dart_clang_isAttribute>(
-            'clang_isAttribute'))(
+        _lookup<ffi.NativeFunction<_c_clang_isAttribute>>('clang_isAttribute')
+            .asFunction<_dart_clang_isAttribute>())(
       arg0,
     );
   }
@@ -1589,9 +1657,10 @@ class LibClang {
   int clang_Cursor_hasAttrs(
     CXCursor C,
   ) {
-    return (_clang_Cursor_hasAttrs ??= _dylib.lookupFunction<
-        _c_clang_Cursor_hasAttrs,
-        _dart_clang_Cursor_hasAttrs>('clang_Cursor_hasAttrs'))(
+    return (_clang_Cursor_hasAttrs ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_hasAttrs>>(
+                'clang_Cursor_hasAttrs')
+            .asFunction<_dart_clang_Cursor_hasAttrs>())(
       C,
     );
   }
@@ -1603,8 +1672,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isInvalid ??=
-        _dylib.lookupFunction<_c_clang_isInvalid, _dart_clang_isInvalid>(
-            'clang_isInvalid'))(
+        _lookup<ffi.NativeFunction<_c_clang_isInvalid>>('clang_isInvalid')
+            .asFunction<_dart_clang_isInvalid>())(
       arg0,
     );
   }
@@ -1615,9 +1684,10 @@ class LibClang {
   int clang_isTranslationUnit(
     int arg0,
   ) {
-    return (_clang_isTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_isTranslationUnit,
-        _dart_clang_isTranslationUnit>('clang_isTranslationUnit'))(
+    return (_clang_isTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_isTranslationUnit>>(
+                'clang_isTranslationUnit')
+            .asFunction<_dart_clang_isTranslationUnit>())(
       arg0,
     );
   }
@@ -1629,9 +1699,10 @@ class LibClang {
   int clang_isPreprocessing(
     int arg0,
   ) {
-    return (_clang_isPreprocessing ??= _dylib.lookupFunction<
-        _c_clang_isPreprocessing,
-        _dart_clang_isPreprocessing>('clang_isPreprocessing'))(
+    return (_clang_isPreprocessing ??=
+        _lookup<ffi.NativeFunction<_c_clang_isPreprocessing>>(
+                'clang_isPreprocessing')
+            .asFunction<_dart_clang_isPreprocessing>())(
       arg0,
     );
   }
@@ -1644,8 +1715,8 @@ class LibClang {
     int arg0,
   ) {
     return (_clang_isUnexposed ??=
-        _dylib.lookupFunction<_c_clang_isUnexposed, _dart_clang_isUnexposed>(
-            'clang_isUnexposed'))(
+        _lookup<ffi.NativeFunction<_c_clang_isUnexposed>>('clang_isUnexposed')
+            .asFunction<_dart_clang_isUnexposed>())(
       arg0,
     );
   }
@@ -1656,9 +1727,10 @@ class LibClang {
   int clang_getCursorLinkage(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorLinkage ??= _dylib.lookupFunction<
-        _c_clang_getCursorLinkage,
-        _dart_clang_getCursorLinkage>('clang_getCursorLinkage'))(
+    return (_clang_getCursorLinkage ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLinkage>>(
+                'clang_getCursorLinkage')
+            .asFunction<_dart_clang_getCursorLinkage>())(
       cursor,
     );
   }
@@ -1669,9 +1741,10 @@ class LibClang {
   int clang_getCursorVisibility(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorVisibility ??= _dylib.lookupFunction<
-        _c_clang_getCursorVisibility,
-        _dart_clang_getCursorVisibility>('clang_getCursorVisibility'))(
+    return (_clang_getCursorVisibility ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorVisibility>>(
+                'clang_getCursorVisibility')
+            .asFunction<_dart_clang_getCursorVisibility>())(
       cursor,
     );
   }
@@ -1683,9 +1756,10 @@ class LibClang {
   int clang_getCursorAvailability(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorAvailability ??= _dylib.lookupFunction<
-        _c_clang_getCursorAvailability,
-        _dart_clang_getCursorAvailability>('clang_getCursorAvailability'))(
+    return (_clang_getCursorAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorAvailability>>(
+                'clang_getCursorAvailability')
+            .asFunction<_dart_clang_getCursorAvailability>())(
       cursor,
     );
   }
@@ -1703,10 +1777,10 @@ class LibClang {
     ffi.Pointer<CXPlatformAvailability> availability,
     int availability_size,
   ) {
-    return (_clang_getCursorPlatformAvailability ??= _dylib.lookupFunction<
-            _c_clang_getCursorPlatformAvailability,
-            _dart_clang_getCursorPlatformAvailability>(
-        'clang_getCursorPlatformAvailability'))(
+    return (_clang_getCursorPlatformAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorPlatformAvailability>>(
+                'clang_getCursorPlatformAvailability')
+            .asFunction<_dart_clang_getCursorPlatformAvailability>())(
       cursor,
       always_deprecated,
       deprecated_message,
@@ -1724,10 +1798,10 @@ class LibClang {
   void clang_disposeCXPlatformAvailability(
     ffi.Pointer<CXPlatformAvailability> availability,
   ) {
-    return (_clang_disposeCXPlatformAvailability ??= _dylib.lookupFunction<
-            _c_clang_disposeCXPlatformAvailability,
-            _dart_clang_disposeCXPlatformAvailability>(
-        'clang_disposeCXPlatformAvailability'))(
+    return (_clang_disposeCXPlatformAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCXPlatformAvailability>>(
+                'clang_disposeCXPlatformAvailability')
+            .asFunction<_dart_clang_disposeCXPlatformAvailability>())(
       availability,
     );
   }
@@ -1739,9 +1813,10 @@ class LibClang {
   int clang_getCursorLanguage(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorLanguage ??= _dylib.lookupFunction<
-        _c_clang_getCursorLanguage,
-        _dart_clang_getCursorLanguage>('clang_getCursorLanguage'))(
+    return (_clang_getCursorLanguage ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLanguage>>(
+                'clang_getCursorLanguage')
+            .asFunction<_dart_clang_getCursorLanguage>())(
       cursor,
     );
   }
@@ -1753,9 +1828,10 @@ class LibClang {
   int clang_getCursorTLSKind(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorTLSKind ??= _dylib.lookupFunction<
-        _c_clang_getCursorTLSKind,
-        _dart_clang_getCursorTLSKind>('clang_getCursorTLSKind'))(
+    return (_clang_getCursorTLSKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorTLSKind>>(
+                'clang_getCursorTLSKind')
+            .asFunction<_dart_clang_getCursorTLSKind>())(
       cursor,
     );
   }
@@ -1766,10 +1842,10 @@ class LibClang {
   ffi.Pointer<CXTranslationUnitImpl> clang_Cursor_getTranslationUnit(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getTranslationUnit ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTranslationUnit,
-            _dart_clang_Cursor_getTranslationUnit>(
-        'clang_Cursor_getTranslationUnit'))(
+    return (_clang_Cursor_getTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTranslationUnit>>(
+                'clang_Cursor_getTranslationUnit')
+            .asFunction<_dart_clang_Cursor_getTranslationUnit>())(
       arg0,
     );
   }
@@ -1778,9 +1854,10 @@ class LibClang {
 
   /// Creates an empty CXCursorSet.
   ffi.Pointer<CXCursorSetImpl> clang_createCXCursorSet() {
-    return (_clang_createCXCursorSet ??= _dylib.lookupFunction<
-        _c_clang_createCXCursorSet,
-        _dart_clang_createCXCursorSet>('clang_createCXCursorSet'))();
+    return (_clang_createCXCursorSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_createCXCursorSet>>(
+                'clang_createCXCursorSet')
+            .asFunction<_dart_clang_createCXCursorSet>())();
   }
 
   _dart_clang_createCXCursorSet? _clang_createCXCursorSet;
@@ -1789,9 +1866,10 @@ class LibClang {
   void clang_disposeCXCursorSet(
     ffi.Pointer<CXCursorSetImpl> cset,
   ) {
-    return (_clang_disposeCXCursorSet ??= _dylib.lookupFunction<
-        _c_clang_disposeCXCursorSet,
-        _dart_clang_disposeCXCursorSet>('clang_disposeCXCursorSet'))(
+    return (_clang_disposeCXCursorSet ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCXCursorSet>>(
+                'clang_disposeCXCursorSet')
+            .asFunction<_dart_clang_disposeCXCursorSet>())(
       cset,
     );
   }
@@ -1803,9 +1881,10 @@ class LibClang {
     ffi.Pointer<CXCursorSetImpl> cset,
     CXCursor cursor,
   ) {
-    return (_clang_CXCursorSet_contains ??= _dylib.lookupFunction<
-        _c_clang_CXCursorSet_contains,
-        _dart_clang_CXCursorSet_contains>('clang_CXCursorSet_contains'))(
+    return (_clang_CXCursorSet_contains ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXCursorSet_contains>>(
+                'clang_CXCursorSet_contains')
+            .asFunction<_dart_clang_CXCursorSet_contains>())(
       cset,
       cursor,
     );
@@ -1818,9 +1897,10 @@ class LibClang {
     ffi.Pointer<CXCursorSetImpl> cset,
     CXCursor cursor,
   ) {
-    return (_clang_CXCursorSet_insert ??= _dylib.lookupFunction<
-        _c_clang_CXCursorSet_insert,
-        _dart_clang_CXCursorSet_insert>('clang_CXCursorSet_insert'))(
+    return (_clang_CXCursorSet_insert ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXCursorSet_insert>>(
+                'clang_CXCursorSet_insert')
+            .asFunction<_dart_clang_CXCursorSet_insert>())(
       cset,
       cursor,
     );
@@ -1832,9 +1912,10 @@ class LibClang {
   CXCursor clang_getCursorSemanticParent(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorSemanticParent ??= _dylib.lookupFunction<
-        _c_clang_getCursorSemanticParent,
-        _dart_clang_getCursorSemanticParent>('clang_getCursorSemanticParent'))(
+    return (_clang_getCursorSemanticParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorSemanticParent>>(
+                'clang_getCursorSemanticParent')
+            .asFunction<_dart_clang_getCursorSemanticParent>())(
       cursor,
     );
   }
@@ -1845,9 +1926,10 @@ class LibClang {
   CXCursor clang_getCursorLexicalParent(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorLexicalParent ??= _dylib.lookupFunction<
-        _c_clang_getCursorLexicalParent,
-        _dart_clang_getCursorLexicalParent>('clang_getCursorLexicalParent'))(
+    return (_clang_getCursorLexicalParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLexicalParent>>(
+                'clang_getCursorLexicalParent')
+            .asFunction<_dart_clang_getCursorLexicalParent>())(
       cursor,
     );
   }
@@ -1860,9 +1942,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<CXCursor>> overridden,
     ffi.Pointer<ffi.Uint32> num_overridden,
   ) {
-    return (_clang_getOverriddenCursors ??= _dylib.lookupFunction<
-        _c_clang_getOverriddenCursors,
-        _dart_clang_getOverriddenCursors>('clang_getOverriddenCursors'))(
+    return (_clang_getOverriddenCursors ??=
+        _lookup<ffi.NativeFunction<_c_clang_getOverriddenCursors>>(
+                'clang_getOverriddenCursors')
+            .asFunction<_dart_clang_getOverriddenCursors>())(
       cursor,
       overridden,
       num_overridden,
@@ -1876,10 +1959,10 @@ class LibClang {
   void clang_disposeOverriddenCursors(
     ffi.Pointer<CXCursor> overridden,
   ) {
-    return (_clang_disposeOverriddenCursors ??= _dylib.lookupFunction<
-            _c_clang_disposeOverriddenCursors,
-            _dart_clang_disposeOverriddenCursors>(
-        'clang_disposeOverriddenCursors'))(
+    return (_clang_disposeOverriddenCursors ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeOverriddenCursors>>(
+                'clang_disposeOverriddenCursors')
+            .asFunction<_dart_clang_disposeOverriddenCursors>())(
       overridden,
     );
   }
@@ -1891,9 +1974,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getIncludedFile(
     CXCursor cursor,
   ) {
-    return (_clang_getIncludedFile ??= _dylib.lookupFunction<
-        _c_clang_getIncludedFile,
-        _dart_clang_getIncludedFile>('clang_getIncludedFile'))(
+    return (_clang_getIncludedFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_getIncludedFile>>(
+                'clang_getIncludedFile')
+            .asFunction<_dart_clang_getIncludedFile>())(
       cursor,
     );
   }
@@ -1907,8 +1991,8 @@ class LibClang {
     CXSourceLocation arg1,
   ) {
     return (_clang_getCursor ??=
-        _dylib.lookupFunction<_c_clang_getCursor, _dart_clang_getCursor>(
-            'clang_getCursor'))(
+        _lookup<ffi.NativeFunction<_c_clang_getCursor>>('clang_getCursor')
+            .asFunction<_dart_clang_getCursor>())(
       arg0,
       arg1,
     );
@@ -1921,9 +2005,10 @@ class LibClang {
   CXSourceLocation clang_getCursorLocation(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorLocation ??= _dylib.lookupFunction<
-        _c_clang_getCursorLocation,
-        _dart_clang_getCursorLocation>('clang_getCursorLocation'))(
+    return (_clang_getCursorLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorLocation>>(
+                'clang_getCursorLocation')
+            .asFunction<_dart_clang_getCursorLocation>())(
       arg0,
     );
   }
@@ -1935,9 +2020,10 @@ class LibClang {
   CXSourceRange clang_getCursorExtent(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorExtent ??= _dylib.lookupFunction<
-        _c_clang_getCursorExtent,
-        _dart_clang_getCursorExtent>('clang_getCursorExtent'))(
+    return (_clang_getCursorExtent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorExtent>>(
+                'clang_getCursorExtent')
+            .asFunction<_dart_clang_getCursorExtent>())(
       arg0,
     );
   }
@@ -1948,9 +2034,10 @@ class LibClang {
   CXType clang_getCursorType(
     CXCursor C,
   ) {
-    return (_clang_getCursorType ??= _dylib.lookupFunction<
-        _c_clang_getCursorType,
-        _dart_clang_getCursorType>('clang_getCursorType'))(
+    return (_clang_getCursorType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorType>>(
+                'clang_getCursorType')
+            .asFunction<_dart_clang_getCursorType>())(
       C,
     );
   }
@@ -1962,9 +2049,10 @@ class LibClang {
   CXString clang_getTypeSpelling(
     CXType CT,
   ) {
-    return (_clang_getTypeSpelling ??= _dylib.lookupFunction<
-        _c_clang_getTypeSpelling,
-        _dart_clang_getTypeSpelling>('clang_getTypeSpelling'))(
+    return (_clang_getTypeSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypeSpelling>>(
+                'clang_getTypeSpelling')
+            .asFunction<_dart_clang_getTypeSpelling>())(
       CT,
     );
   }
@@ -1975,10 +2063,10 @@ class LibClang {
   CXType clang_getTypedefDeclUnderlyingType(
     CXCursor C,
   ) {
-    return (_clang_getTypedefDeclUnderlyingType ??= _dylib.lookupFunction<
-            _c_clang_getTypedefDeclUnderlyingType,
-            _dart_clang_getTypedefDeclUnderlyingType>(
-        'clang_getTypedefDeclUnderlyingType'))(
+    return (_clang_getTypedefDeclUnderlyingType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypedefDeclUnderlyingType>>(
+                'clang_getTypedefDeclUnderlyingType')
+            .asFunction<_dart_clang_getTypedefDeclUnderlyingType>())(
       C,
     );
   }
@@ -1989,9 +2077,10 @@ class LibClang {
   CXType clang_getEnumDeclIntegerType(
     CXCursor C,
   ) {
-    return (_clang_getEnumDeclIntegerType ??= _dylib.lookupFunction<
-        _c_clang_getEnumDeclIntegerType,
-        _dart_clang_getEnumDeclIntegerType>('clang_getEnumDeclIntegerType'))(
+    return (_clang_getEnumDeclIntegerType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getEnumDeclIntegerType>>(
+                'clang_getEnumDeclIntegerType')
+            .asFunction<_dart_clang_getEnumDeclIntegerType>())(
       C,
     );
   }
@@ -2003,10 +2092,10 @@ class LibClang {
   int clang_getEnumConstantDeclValue(
     CXCursor C,
   ) {
-    return (_clang_getEnumConstantDeclValue ??= _dylib.lookupFunction<
-            _c_clang_getEnumConstantDeclValue,
-            _dart_clang_getEnumConstantDeclValue>(
-        'clang_getEnumConstantDeclValue'))(
+    return (_clang_getEnumConstantDeclValue ??=
+        _lookup<ffi.NativeFunction<_c_clang_getEnumConstantDeclValue>>(
+                'clang_getEnumConstantDeclValue')
+            .asFunction<_dart_clang_getEnumConstantDeclValue>())(
       C,
     );
   }
@@ -2018,10 +2107,10 @@ class LibClang {
   int clang_getEnumConstantDeclUnsignedValue(
     CXCursor C,
   ) {
-    return (_clang_getEnumConstantDeclUnsignedValue ??= _dylib.lookupFunction<
-            _c_clang_getEnumConstantDeclUnsignedValue,
-            _dart_clang_getEnumConstantDeclUnsignedValue>(
-        'clang_getEnumConstantDeclUnsignedValue'))(
+    return (_clang_getEnumConstantDeclUnsignedValue ??=
+        _lookup<ffi.NativeFunction<_c_clang_getEnumConstantDeclUnsignedValue>>(
+                'clang_getEnumConstantDeclUnsignedValue')
+            .asFunction<_dart_clang_getEnumConstantDeclUnsignedValue>())(
       C,
     );
   }
@@ -2033,9 +2122,10 @@ class LibClang {
   int clang_getFieldDeclBitWidth(
     CXCursor C,
   ) {
-    return (_clang_getFieldDeclBitWidth ??= _dylib.lookupFunction<
-        _c_clang_getFieldDeclBitWidth,
-        _dart_clang_getFieldDeclBitWidth>('clang_getFieldDeclBitWidth'))(
+    return (_clang_getFieldDeclBitWidth ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFieldDeclBitWidth>>(
+                'clang_getFieldDeclBitWidth')
+            .asFunction<_dart_clang_getFieldDeclBitWidth>())(
       C,
     );
   }
@@ -2047,9 +2137,10 @@ class LibClang {
   int clang_Cursor_getNumArguments(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getNumArguments ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getNumArguments,
-        _dart_clang_Cursor_getNumArguments>('clang_Cursor_getNumArguments'))(
+    return (_clang_Cursor_getNumArguments ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getNumArguments>>(
+                'clang_Cursor_getNumArguments')
+            .asFunction<_dart_clang_Cursor_getNumArguments>())(
       C,
     );
   }
@@ -2061,9 +2152,10 @@ class LibClang {
     CXCursor C,
     int i,
   ) {
-    return (_clang_Cursor_getArgument ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getArgument,
-        _dart_clang_Cursor_getArgument>('clang_Cursor_getArgument'))(
+    return (_clang_Cursor_getArgument ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getArgument>>(
+                'clang_Cursor_getArgument')
+            .asFunction<_dart_clang_Cursor_getArgument>())(
       C,
       i,
     );
@@ -2076,10 +2168,10 @@ class LibClang {
   int clang_Cursor_getNumTemplateArguments(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getNumTemplateArguments ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getNumTemplateArguments,
-            _dart_clang_Cursor_getNumTemplateArguments>(
-        'clang_Cursor_getNumTemplateArguments'))(
+    return (_clang_Cursor_getNumTemplateArguments ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getNumTemplateArguments>>(
+                'clang_Cursor_getNumTemplateArguments')
+            .asFunction<_dart_clang_Cursor_getNumTemplateArguments>())(
       C,
     );
   }
@@ -2092,10 +2184,10 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentKind ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTemplateArgumentKind,
-            _dart_clang_Cursor_getTemplateArgumentKind>(
-        'clang_Cursor_getTemplateArgumentKind'))(
+    return (_clang_Cursor_getTemplateArgumentKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTemplateArgumentKind>>(
+                'clang_Cursor_getTemplateArgumentKind')
+            .asFunction<_dart_clang_Cursor_getTemplateArgumentKind>())(
       C,
       I,
     );
@@ -2110,10 +2202,10 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentType ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTemplateArgumentType,
-            _dart_clang_Cursor_getTemplateArgumentType>(
-        'clang_Cursor_getTemplateArgumentType'))(
+    return (_clang_Cursor_getTemplateArgumentType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTemplateArgumentType>>(
+                'clang_Cursor_getTemplateArgumentType')
+            .asFunction<_dart_clang_Cursor_getTemplateArgumentType>())(
       C,
       I,
     );
@@ -2128,10 +2220,10 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentValue ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getTemplateArgumentValue,
-            _dart_clang_Cursor_getTemplateArgumentValue>(
-        'clang_Cursor_getTemplateArgumentValue'))(
+    return (_clang_Cursor_getTemplateArgumentValue ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getTemplateArgumentValue>>(
+                'clang_Cursor_getTemplateArgumentValue')
+            .asFunction<_dart_clang_Cursor_getTemplateArgumentValue>())(
       C,
       I,
     );
@@ -2146,10 +2238,11 @@ class LibClang {
     CXCursor C,
     int I,
   ) {
-    return (_clang_Cursor_getTemplateArgumentUnsignedValue ??=
-        _dylib.lookupFunction<_c_clang_Cursor_getTemplateArgumentUnsignedValue,
-                _dart_clang_Cursor_getTemplateArgumentUnsignedValue>(
-            'clang_Cursor_getTemplateArgumentUnsignedValue'))(
+    return (_clang_Cursor_getTemplateArgumentUnsignedValue ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_Cursor_getTemplateArgumentUnsignedValue>>(
+            'clang_Cursor_getTemplateArgumentUnsignedValue')
+        .asFunction<_dart_clang_Cursor_getTemplateArgumentUnsignedValue>())(
       C,
       I,
     );
@@ -2164,8 +2257,8 @@ class LibClang {
     CXType B,
   ) {
     return (_clang_equalTypes ??=
-        _dylib.lookupFunction<_c_clang_equalTypes, _dart_clang_equalTypes>(
-            'clang_equalTypes'))(
+        _lookup<ffi.NativeFunction<_c_clang_equalTypes>>('clang_equalTypes')
+            .asFunction<_dart_clang_equalTypes>())(
       A,
       B,
     );
@@ -2177,9 +2270,10 @@ class LibClang {
   CXType clang_getCanonicalType(
     CXType T,
   ) {
-    return (_clang_getCanonicalType ??= _dylib.lookupFunction<
-        _c_clang_getCanonicalType,
-        _dart_clang_getCanonicalType>('clang_getCanonicalType'))(
+    return (_clang_getCanonicalType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCanonicalType>>(
+                'clang_getCanonicalType')
+            .asFunction<_dart_clang_getCanonicalType>())(
       T,
     );
   }
@@ -2191,9 +2285,10 @@ class LibClang {
   int clang_isConstQualifiedType(
     CXType T,
   ) {
-    return (_clang_isConstQualifiedType ??= _dylib.lookupFunction<
-        _c_clang_isConstQualifiedType,
-        _dart_clang_isConstQualifiedType>('clang_isConstQualifiedType'))(
+    return (_clang_isConstQualifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_isConstQualifiedType>>(
+                'clang_isConstQualifiedType')
+            .asFunction<_dart_clang_isConstQualifiedType>())(
       T,
     );
   }
@@ -2204,10 +2299,10 @@ class LibClang {
   int clang_Cursor_isMacroFunctionLike(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isMacroFunctionLike ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isMacroFunctionLike,
-            _dart_clang_Cursor_isMacroFunctionLike>(
-        'clang_Cursor_isMacroFunctionLike'))(
+    return (_clang_Cursor_isMacroFunctionLike ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isMacroFunctionLike>>(
+                'clang_Cursor_isMacroFunctionLike')
+            .asFunction<_dart_clang_Cursor_isMacroFunctionLike>())(
       C,
     );
   }
@@ -2218,9 +2313,10 @@ class LibClang {
   int clang_Cursor_isMacroBuiltin(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isMacroBuiltin ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isMacroBuiltin,
-        _dart_clang_Cursor_isMacroBuiltin>('clang_Cursor_isMacroBuiltin'))(
+    return (_clang_Cursor_isMacroBuiltin ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isMacroBuiltin>>(
+                'clang_Cursor_isMacroBuiltin')
+            .asFunction<_dart_clang_Cursor_isMacroBuiltin>())(
       C,
     );
   }
@@ -2232,10 +2328,10 @@ class LibClang {
   int clang_Cursor_isFunctionInlined(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isFunctionInlined ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isFunctionInlined,
-            _dart_clang_Cursor_isFunctionInlined>(
-        'clang_Cursor_isFunctionInlined'))(
+    return (_clang_Cursor_isFunctionInlined ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isFunctionInlined>>(
+                'clang_Cursor_isFunctionInlined')
+            .asFunction<_dart_clang_Cursor_isFunctionInlined>())(
       C,
     );
   }
@@ -2248,9 +2344,10 @@ class LibClang {
   int clang_isVolatileQualifiedType(
     CXType T,
   ) {
-    return (_clang_isVolatileQualifiedType ??= _dylib.lookupFunction<
-        _c_clang_isVolatileQualifiedType,
-        _dart_clang_isVolatileQualifiedType>('clang_isVolatileQualifiedType'))(
+    return (_clang_isVolatileQualifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_isVolatileQualifiedType>>(
+                'clang_isVolatileQualifiedType')
+            .asFunction<_dart_clang_isVolatileQualifiedType>())(
       T,
     );
   }
@@ -2263,9 +2360,10 @@ class LibClang {
   int clang_isRestrictQualifiedType(
     CXType T,
   ) {
-    return (_clang_isRestrictQualifiedType ??= _dylib.lookupFunction<
-        _c_clang_isRestrictQualifiedType,
-        _dart_clang_isRestrictQualifiedType>('clang_isRestrictQualifiedType'))(
+    return (_clang_isRestrictQualifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_isRestrictQualifiedType>>(
+                'clang_isRestrictQualifiedType')
+            .asFunction<_dart_clang_isRestrictQualifiedType>())(
       T,
     );
   }
@@ -2276,9 +2374,10 @@ class LibClang {
   int clang_getAddressSpace(
     CXType T,
   ) {
-    return (_clang_getAddressSpace ??= _dylib.lookupFunction<
-        _c_clang_getAddressSpace,
-        _dart_clang_getAddressSpace>('clang_getAddressSpace'))(
+    return (_clang_getAddressSpace ??=
+        _lookup<ffi.NativeFunction<_c_clang_getAddressSpace>>(
+                'clang_getAddressSpace')
+            .asFunction<_dart_clang_getAddressSpace>())(
       T,
     );
   }
@@ -2289,9 +2388,10 @@ class LibClang {
   CXString clang_getTypedefName(
     CXType CT,
   ) {
-    return (_clang_getTypedefName ??= _dylib.lookupFunction<
-        _c_clang_getTypedefName,
-        _dart_clang_getTypedefName>('clang_getTypedefName'))(
+    return (_clang_getTypedefName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypedefName>>(
+                'clang_getTypedefName')
+            .asFunction<_dart_clang_getTypedefName>())(
       CT,
     );
   }
@@ -2302,9 +2402,10 @@ class LibClang {
   CXType clang_getPointeeType(
     CXType T,
   ) {
-    return (_clang_getPointeeType ??= _dylib.lookupFunction<
-        _c_clang_getPointeeType,
-        _dart_clang_getPointeeType>('clang_getPointeeType'))(
+    return (_clang_getPointeeType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getPointeeType>>(
+                'clang_getPointeeType')
+            .asFunction<_dart_clang_getPointeeType>())(
       T,
     );
   }
@@ -2315,9 +2416,10 @@ class LibClang {
   CXCursor clang_getTypeDeclaration(
     CXType T,
   ) {
-    return (_clang_getTypeDeclaration ??= _dylib.lookupFunction<
-        _c_clang_getTypeDeclaration,
-        _dart_clang_getTypeDeclaration>('clang_getTypeDeclaration'))(
+    return (_clang_getTypeDeclaration ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypeDeclaration>>(
+                'clang_getTypeDeclaration')
+            .asFunction<_dart_clang_getTypeDeclaration>())(
       T,
     );
   }
@@ -2328,9 +2430,10 @@ class LibClang {
   CXString clang_getDeclObjCTypeEncoding(
     CXCursor C,
   ) {
-    return (_clang_getDeclObjCTypeEncoding ??= _dylib.lookupFunction<
-        _c_clang_getDeclObjCTypeEncoding,
-        _dart_clang_getDeclObjCTypeEncoding>('clang_getDeclObjCTypeEncoding'))(
+    return (_clang_getDeclObjCTypeEncoding ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDeclObjCTypeEncoding>>(
+                'clang_getDeclObjCTypeEncoding')
+            .asFunction<_dart_clang_getDeclObjCTypeEncoding>())(
       C,
     );
   }
@@ -2341,9 +2444,10 @@ class LibClang {
   CXString clang_Type_getObjCEncoding(
     CXType type,
   ) {
-    return (_clang_Type_getObjCEncoding ??= _dylib.lookupFunction<
-        _c_clang_Type_getObjCEncoding,
-        _dart_clang_Type_getObjCEncoding>('clang_Type_getObjCEncoding'))(
+    return (_clang_Type_getObjCEncoding ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCEncoding>>(
+                'clang_Type_getObjCEncoding')
+            .asFunction<_dart_clang_Type_getObjCEncoding>())(
       type,
     );
   }
@@ -2354,9 +2458,10 @@ class LibClang {
   CXString clang_getTypeKindSpelling(
     int K,
   ) {
-    return (_clang_getTypeKindSpelling ??= _dylib.lookupFunction<
-        _c_clang_getTypeKindSpelling,
-        _dart_clang_getTypeKindSpelling>('clang_getTypeKindSpelling'))(
+    return (_clang_getTypeKindSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTypeKindSpelling>>(
+                'clang_getTypeKindSpelling')
+            .asFunction<_dart_clang_getTypeKindSpelling>())(
       K,
     );
   }
@@ -2367,10 +2472,10 @@ class LibClang {
   int clang_getFunctionTypeCallingConv(
     CXType T,
   ) {
-    return (_clang_getFunctionTypeCallingConv ??= _dylib.lookupFunction<
-            _c_clang_getFunctionTypeCallingConv,
-            _dart_clang_getFunctionTypeCallingConv>(
-        'clang_getFunctionTypeCallingConv'))(
+    return (_clang_getFunctionTypeCallingConv ??=
+        _lookup<ffi.NativeFunction<_c_clang_getFunctionTypeCallingConv>>(
+                'clang_getFunctionTypeCallingConv')
+            .asFunction<_dart_clang_getFunctionTypeCallingConv>())(
       T,
     );
   }
@@ -2381,9 +2486,10 @@ class LibClang {
   CXType clang_getResultType(
     CXType T,
   ) {
-    return (_clang_getResultType ??= _dylib.lookupFunction<
-        _c_clang_getResultType,
-        _dart_clang_getResultType>('clang_getResultType'))(
+    return (_clang_getResultType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getResultType>>(
+                'clang_getResultType')
+            .asFunction<_dart_clang_getResultType>())(
       T,
     );
   }
@@ -2395,10 +2501,10 @@ class LibClang {
   int clang_getExceptionSpecificationType(
     CXType T,
   ) {
-    return (_clang_getExceptionSpecificationType ??= _dylib.lookupFunction<
-            _c_clang_getExceptionSpecificationType,
-            _dart_clang_getExceptionSpecificationType>(
-        'clang_getExceptionSpecificationType'))(
+    return (_clang_getExceptionSpecificationType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getExceptionSpecificationType>>(
+                'clang_getExceptionSpecificationType')
+            .asFunction<_dart_clang_getExceptionSpecificationType>())(
       T,
     );
   }
@@ -2411,9 +2517,10 @@ class LibClang {
   int clang_getNumArgTypes(
     CXType T,
   ) {
-    return (_clang_getNumArgTypes ??= _dylib.lookupFunction<
-        _c_clang_getNumArgTypes,
-        _dart_clang_getNumArgTypes>('clang_getNumArgTypes'))(
+    return (_clang_getNumArgTypes ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumArgTypes>>(
+                'clang_getNumArgTypes')
+            .asFunction<_dart_clang_getNumArgTypes>())(
       T,
     );
   }
@@ -2426,8 +2533,8 @@ class LibClang {
     int i,
   ) {
     return (_clang_getArgType ??=
-        _dylib.lookupFunction<_c_clang_getArgType, _dart_clang_getArgType>(
-            'clang_getArgType'))(
+        _lookup<ffi.NativeFunction<_c_clang_getArgType>>('clang_getArgType')
+            .asFunction<_dart_clang_getArgType>())(
       T,
       i,
     );
@@ -2439,10 +2546,10 @@ class LibClang {
   CXType clang_Type_getObjCObjectBaseType(
     CXType T,
   ) {
-    return (_clang_Type_getObjCObjectBaseType ??= _dylib.lookupFunction<
-            _c_clang_Type_getObjCObjectBaseType,
-            _dart_clang_Type_getObjCObjectBaseType>(
-        'clang_Type_getObjCObjectBaseType'))(
+    return (_clang_Type_getObjCObjectBaseType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCObjectBaseType>>(
+                'clang_Type_getObjCObjectBaseType')
+            .asFunction<_dart_clang_Type_getObjCObjectBaseType>())(
       T,
     );
   }
@@ -2454,10 +2561,10 @@ class LibClang {
   int clang_Type_getNumObjCProtocolRefs(
     CXType T,
   ) {
-    return (_clang_Type_getNumObjCProtocolRefs ??= _dylib.lookupFunction<
-            _c_clang_Type_getNumObjCProtocolRefs,
-            _dart_clang_Type_getNumObjCProtocolRefs>(
-        'clang_Type_getNumObjCProtocolRefs'))(
+    return (_clang_Type_getNumObjCProtocolRefs ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNumObjCProtocolRefs>>(
+                'clang_Type_getNumObjCProtocolRefs')
+            .asFunction<_dart_clang_Type_getNumObjCProtocolRefs>())(
       T,
     );
   }
@@ -2469,10 +2576,10 @@ class LibClang {
     CXType T,
     int i,
   ) {
-    return (_clang_Type_getObjCProtocolDecl ??= _dylib.lookupFunction<
-            _c_clang_Type_getObjCProtocolDecl,
-            _dart_clang_Type_getObjCProtocolDecl>(
-        'clang_Type_getObjCProtocolDecl'))(
+    return (_clang_Type_getObjCProtocolDecl ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCProtocolDecl>>(
+                'clang_Type_getObjCProtocolDecl')
+            .asFunction<_dart_clang_Type_getObjCProtocolDecl>())(
       T,
       i,
     );
@@ -2484,9 +2591,10 @@ class LibClang {
   int clang_Type_getNumObjCTypeArgs(
     CXType T,
   ) {
-    return (_clang_Type_getNumObjCTypeArgs ??= _dylib.lookupFunction<
-        _c_clang_Type_getNumObjCTypeArgs,
-        _dart_clang_Type_getNumObjCTypeArgs>('clang_Type_getNumObjCTypeArgs'))(
+    return (_clang_Type_getNumObjCTypeArgs ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNumObjCTypeArgs>>(
+                'clang_Type_getNumObjCTypeArgs')
+            .asFunction<_dart_clang_Type_getNumObjCTypeArgs>())(
       T,
     );
   }
@@ -2498,9 +2606,10 @@ class LibClang {
     CXType T,
     int i,
   ) {
-    return (_clang_Type_getObjCTypeArg ??= _dylib.lookupFunction<
-        _c_clang_Type_getObjCTypeArg,
-        _dart_clang_Type_getObjCTypeArg>('clang_Type_getObjCTypeArg'))(
+    return (_clang_Type_getObjCTypeArg ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getObjCTypeArg>>(
+                'clang_Type_getObjCTypeArg')
+            .asFunction<_dart_clang_Type_getObjCTypeArg>())(
       T,
       i,
     );
@@ -2512,9 +2621,10 @@ class LibClang {
   int clang_isFunctionTypeVariadic(
     CXType T,
   ) {
-    return (_clang_isFunctionTypeVariadic ??= _dylib.lookupFunction<
-        _c_clang_isFunctionTypeVariadic,
-        _dart_clang_isFunctionTypeVariadic>('clang_isFunctionTypeVariadic'))(
+    return (_clang_isFunctionTypeVariadic ??=
+        _lookup<ffi.NativeFunction<_c_clang_isFunctionTypeVariadic>>(
+                'clang_isFunctionTypeVariadic')
+            .asFunction<_dart_clang_isFunctionTypeVariadic>())(
       T,
     );
   }
@@ -2525,9 +2635,10 @@ class LibClang {
   CXType clang_getCursorResultType(
     CXCursor C,
   ) {
-    return (_clang_getCursorResultType ??= _dylib.lookupFunction<
-        _c_clang_getCursorResultType,
-        _dart_clang_getCursorResultType>('clang_getCursorResultType'))(
+    return (_clang_getCursorResultType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorResultType>>(
+                'clang_getCursorResultType')
+            .asFunction<_dart_clang_getCursorResultType>())(
       C,
     );
   }
@@ -2539,10 +2650,11 @@ class LibClang {
   int clang_getCursorExceptionSpecificationType(
     CXCursor C,
   ) {
-    return (_clang_getCursorExceptionSpecificationType ??=
-        _dylib.lookupFunction<_c_clang_getCursorExceptionSpecificationType,
-                _dart_clang_getCursorExceptionSpecificationType>(
-            'clang_getCursorExceptionSpecificationType'))(
+    return (_clang_getCursorExceptionSpecificationType ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_getCursorExceptionSpecificationType>>(
+            'clang_getCursorExceptionSpecificationType')
+        .asFunction<_dart_clang_getCursorExceptionSpecificationType>())(
       C,
     );
   }
@@ -2555,8 +2667,8 @@ class LibClang {
     CXType T,
   ) {
     return (_clang_isPODType ??=
-        _dylib.lookupFunction<_c_clang_isPODType, _dart_clang_isPODType>(
-            'clang_isPODType'))(
+        _lookup<ffi.NativeFunction<_c_clang_isPODType>>('clang_isPODType')
+            .asFunction<_dart_clang_isPODType>())(
       T,
     );
   }
@@ -2567,9 +2679,10 @@ class LibClang {
   CXType clang_getElementType(
     CXType T,
   ) {
-    return (_clang_getElementType ??= _dylib.lookupFunction<
-        _c_clang_getElementType,
-        _dart_clang_getElementType>('clang_getElementType'))(
+    return (_clang_getElementType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getElementType>>(
+                'clang_getElementType')
+            .asFunction<_dart_clang_getElementType>())(
       T,
     );
   }
@@ -2580,9 +2693,10 @@ class LibClang {
   int clang_getNumElements(
     CXType T,
   ) {
-    return (_clang_getNumElements ??= _dylib.lookupFunction<
-        _c_clang_getNumElements,
-        _dart_clang_getNumElements>('clang_getNumElements'))(
+    return (_clang_getNumElements ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumElements>>(
+                'clang_getNumElements')
+            .asFunction<_dart_clang_getNumElements>())(
       T,
     );
   }
@@ -2593,9 +2707,10 @@ class LibClang {
   CXType clang_getArrayElementType(
     CXType T,
   ) {
-    return (_clang_getArrayElementType ??= _dylib.lookupFunction<
-        _c_clang_getArrayElementType,
-        _dart_clang_getArrayElementType>('clang_getArrayElementType'))(
+    return (_clang_getArrayElementType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getArrayElementType>>(
+                'clang_getArrayElementType')
+            .asFunction<_dart_clang_getArrayElementType>())(
       T,
     );
   }
@@ -2607,8 +2722,8 @@ class LibClang {
     CXType T,
   ) {
     return (_clang_getArraySize ??=
-        _dylib.lookupFunction<_c_clang_getArraySize, _dart_clang_getArraySize>(
-            'clang_getArraySize'))(
+        _lookup<ffi.NativeFunction<_c_clang_getArraySize>>('clang_getArraySize')
+            .asFunction<_dart_clang_getArraySize>())(
       T,
     );
   }
@@ -2619,9 +2734,10 @@ class LibClang {
   CXType clang_Type_getNamedType(
     CXType T,
   ) {
-    return (_clang_Type_getNamedType ??= _dylib.lookupFunction<
-        _c_clang_Type_getNamedType,
-        _dart_clang_Type_getNamedType>('clang_Type_getNamedType'))(
+    return (_clang_Type_getNamedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNamedType>>(
+                'clang_Type_getNamedType')
+            .asFunction<_dart_clang_Type_getNamedType>())(
       T,
     );
   }
@@ -2632,10 +2748,10 @@ class LibClang {
   int clang_Type_isTransparentTagTypedef(
     CXType T,
   ) {
-    return (_clang_Type_isTransparentTagTypedef ??= _dylib.lookupFunction<
-            _c_clang_Type_isTransparentTagTypedef,
-            _dart_clang_Type_isTransparentTagTypedef>(
-        'clang_Type_isTransparentTagTypedef'))(
+    return (_clang_Type_isTransparentTagTypedef ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_isTransparentTagTypedef>>(
+                'clang_Type_isTransparentTagTypedef')
+            .asFunction<_dart_clang_Type_isTransparentTagTypedef>())(
       T,
     );
   }
@@ -2646,9 +2762,10 @@ class LibClang {
   int clang_Type_getNullability(
     CXType T,
   ) {
-    return (_clang_Type_getNullability ??= _dylib.lookupFunction<
-        _c_clang_Type_getNullability,
-        _dart_clang_Type_getNullability>('clang_Type_getNullability'))(
+    return (_clang_Type_getNullability ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNullability>>(
+                'clang_Type_getNullability')
+            .asFunction<_dart_clang_Type_getNullability>())(
       T,
     );
   }
@@ -2659,9 +2776,10 @@ class LibClang {
   int clang_Type_getAlignOf(
     CXType T,
   ) {
-    return (_clang_Type_getAlignOf ??= _dylib.lookupFunction<
-        _c_clang_Type_getAlignOf,
-        _dart_clang_Type_getAlignOf>('clang_Type_getAlignOf'))(
+    return (_clang_Type_getAlignOf ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getAlignOf>>(
+                'clang_Type_getAlignOf')
+            .asFunction<_dart_clang_Type_getAlignOf>())(
       T,
     );
   }
@@ -2672,9 +2790,10 @@ class LibClang {
   CXType clang_Type_getClassType(
     CXType T,
   ) {
-    return (_clang_Type_getClassType ??= _dylib.lookupFunction<
-        _c_clang_Type_getClassType,
-        _dart_clang_Type_getClassType>('clang_Type_getClassType'))(
+    return (_clang_Type_getClassType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getClassType>>(
+                'clang_Type_getClassType')
+            .asFunction<_dart_clang_Type_getClassType>())(
       T,
     );
   }
@@ -2685,9 +2804,10 @@ class LibClang {
   int clang_Type_getSizeOf(
     CXType T,
   ) {
-    return (_clang_Type_getSizeOf ??= _dylib.lookupFunction<
-        _c_clang_Type_getSizeOf,
-        _dart_clang_Type_getSizeOf>('clang_Type_getSizeOf'))(
+    return (_clang_Type_getSizeOf ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getSizeOf>>(
+                'clang_Type_getSizeOf')
+            .asFunction<_dart_clang_Type_getSizeOf>())(
       T,
     );
   }
@@ -2700,9 +2820,10 @@ class LibClang {
     CXType T,
     ffi.Pointer<ffi.Int8> S,
   ) {
-    return (_clang_Type_getOffsetOf ??= _dylib.lookupFunction<
-        _c_clang_Type_getOffsetOf,
-        _dart_clang_Type_getOffsetOf>('clang_Type_getOffsetOf'))(
+    return (_clang_Type_getOffsetOf ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getOffsetOf>>(
+                'clang_Type_getOffsetOf')
+            .asFunction<_dart_clang_Type_getOffsetOf>())(
       T,
       S,
     );
@@ -2714,9 +2835,10 @@ class LibClang {
   CXType clang_Type_getModifiedType(
     CXType T,
   ) {
-    return (_clang_Type_getModifiedType ??= _dylib.lookupFunction<
-        _c_clang_Type_getModifiedType,
-        _dart_clang_Type_getModifiedType>('clang_Type_getModifiedType'))(
+    return (_clang_Type_getModifiedType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getModifiedType>>(
+                'clang_Type_getModifiedType')
+            .asFunction<_dart_clang_Type_getModifiedType>())(
       T,
     );
   }
@@ -2727,9 +2849,10 @@ class LibClang {
   int clang_Cursor_getOffsetOfField(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getOffsetOfField ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getOffsetOfField,
-        _dart_clang_Cursor_getOffsetOfField>('clang_Cursor_getOffsetOfField'))(
+    return (_clang_Cursor_getOffsetOfField ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getOffsetOfField>>(
+                'clang_Cursor_getOffsetOfField')
+            .asFunction<_dart_clang_Cursor_getOffsetOfField>())(
       C,
     );
   }
@@ -2741,9 +2864,10 @@ class LibClang {
   int clang_Cursor_isAnonymous(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isAnonymous ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isAnonymous,
-        _dart_clang_Cursor_isAnonymous>('clang_Cursor_isAnonymous'))(
+    return (_clang_Cursor_isAnonymous ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isAnonymous>>(
+                'clang_Cursor_isAnonymous')
+            .asFunction<_dart_clang_Cursor_isAnonymous>())(
       C,
     );
   }
@@ -2755,10 +2879,10 @@ class LibClang {
   int clang_Cursor_isAnonymousRecordDecl(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isAnonymousRecordDecl ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isAnonymousRecordDecl,
-            _dart_clang_Cursor_isAnonymousRecordDecl>(
-        'clang_Cursor_isAnonymousRecordDecl'))(
+    return (_clang_Cursor_isAnonymousRecordDecl ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isAnonymousRecordDecl>>(
+                'clang_Cursor_isAnonymousRecordDecl')
+            .asFunction<_dart_clang_Cursor_isAnonymousRecordDecl>())(
       C,
     );
   }
@@ -2770,10 +2894,10 @@ class LibClang {
   int clang_Cursor_isInlineNamespace(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isInlineNamespace ??= _dylib.lookupFunction<
-            _c_clang_Cursor_isInlineNamespace,
-            _dart_clang_Cursor_isInlineNamespace>(
-        'clang_Cursor_isInlineNamespace'))(
+    return (_clang_Cursor_isInlineNamespace ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isInlineNamespace>>(
+                'clang_Cursor_isInlineNamespace')
+            .asFunction<_dart_clang_Cursor_isInlineNamespace>())(
       C,
     );
   }
@@ -2785,10 +2909,10 @@ class LibClang {
   int clang_Type_getNumTemplateArguments(
     CXType T,
   ) {
-    return (_clang_Type_getNumTemplateArguments ??= _dylib.lookupFunction<
-            _c_clang_Type_getNumTemplateArguments,
-            _dart_clang_Type_getNumTemplateArguments>(
-        'clang_Type_getNumTemplateArguments'))(
+    return (_clang_Type_getNumTemplateArguments ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getNumTemplateArguments>>(
+                'clang_Type_getNumTemplateArguments')
+            .asFunction<_dart_clang_Type_getNumTemplateArguments>())(
       T,
     );
   }
@@ -2801,10 +2925,10 @@ class LibClang {
     CXType T,
     int i,
   ) {
-    return (_clang_Type_getTemplateArgumentAsType ??= _dylib.lookupFunction<
-            _c_clang_Type_getTemplateArgumentAsType,
-            _dart_clang_Type_getTemplateArgumentAsType>(
-        'clang_Type_getTemplateArgumentAsType'))(
+    return (_clang_Type_getTemplateArgumentAsType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getTemplateArgumentAsType>>(
+                'clang_Type_getTemplateArgumentAsType')
+            .asFunction<_dart_clang_Type_getTemplateArgumentAsType>())(
       T,
       i,
     );
@@ -2817,9 +2941,10 @@ class LibClang {
   int clang_Type_getCXXRefQualifier(
     CXType T,
   ) {
-    return (_clang_Type_getCXXRefQualifier ??= _dylib.lookupFunction<
-        _c_clang_Type_getCXXRefQualifier,
-        _dart_clang_Type_getCXXRefQualifier>('clang_Type_getCXXRefQualifier'))(
+    return (_clang_Type_getCXXRefQualifier ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_getCXXRefQualifier>>(
+                'clang_Type_getCXXRefQualifier')
+            .asFunction<_dart_clang_Type_getCXXRefQualifier>())(
       T,
     );
   }
@@ -2831,9 +2956,10 @@ class LibClang {
   int clang_Cursor_isBitField(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isBitField ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isBitField,
-        _dart_clang_Cursor_isBitField>('clang_Cursor_isBitField'))(
+    return (_clang_Cursor_isBitField ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isBitField>>(
+                'clang_Cursor_isBitField')
+            .asFunction<_dart_clang_Cursor_isBitField>())(
       C,
     );
   }
@@ -2845,9 +2971,10 @@ class LibClang {
   int clang_isVirtualBase(
     CXCursor arg0,
   ) {
-    return (_clang_isVirtualBase ??= _dylib.lookupFunction<
-        _c_clang_isVirtualBase,
-        _dart_clang_isVirtualBase>('clang_isVirtualBase'))(
+    return (_clang_isVirtualBase ??=
+        _lookup<ffi.NativeFunction<_c_clang_isVirtualBase>>(
+                'clang_isVirtualBase')
+            .asFunction<_dart_clang_isVirtualBase>())(
       arg0,
     );
   }
@@ -2858,9 +2985,10 @@ class LibClang {
   int clang_getCXXAccessSpecifier(
     CXCursor arg0,
   ) {
-    return (_clang_getCXXAccessSpecifier ??= _dylib.lookupFunction<
-        _c_clang_getCXXAccessSpecifier,
-        _dart_clang_getCXXAccessSpecifier>('clang_getCXXAccessSpecifier'))(
+    return (_clang_getCXXAccessSpecifier ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCXXAccessSpecifier>>(
+                'clang_getCXXAccessSpecifier')
+            .asFunction<_dart_clang_getCXXAccessSpecifier>())(
       arg0,
     );
   }
@@ -2871,9 +2999,10 @@ class LibClang {
   int clang_Cursor_getStorageClass(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getStorageClass ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getStorageClass,
-        _dart_clang_Cursor_getStorageClass>('clang_Cursor_getStorageClass'))(
+    return (_clang_Cursor_getStorageClass ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getStorageClass>>(
+                'clang_Cursor_getStorageClass')
+            .asFunction<_dart_clang_Cursor_getStorageClass>())(
       arg0,
     );
   }
@@ -2885,9 +3014,10 @@ class LibClang {
   int clang_getNumOverloadedDecls(
     CXCursor cursor,
   ) {
-    return (_clang_getNumOverloadedDecls ??= _dylib.lookupFunction<
-        _c_clang_getNumOverloadedDecls,
-        _dart_clang_getNumOverloadedDecls>('clang_getNumOverloadedDecls'))(
+    return (_clang_getNumOverloadedDecls ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumOverloadedDecls>>(
+                'clang_getNumOverloadedDecls')
+            .asFunction<_dart_clang_getNumOverloadedDecls>())(
       cursor,
     );
   }
@@ -2900,9 +3030,10 @@ class LibClang {
     CXCursor cursor,
     int index,
   ) {
-    return (_clang_getOverloadedDecl ??= _dylib.lookupFunction<
-        _c_clang_getOverloadedDecl,
-        _dart_clang_getOverloadedDecl>('clang_getOverloadedDecl'))(
+    return (_clang_getOverloadedDecl ??=
+        _lookup<ffi.NativeFunction<_c_clang_getOverloadedDecl>>(
+                'clang_getOverloadedDecl')
+            .asFunction<_dart_clang_getOverloadedDecl>())(
       cursor,
       index,
     );
@@ -2915,10 +3046,10 @@ class LibClang {
   CXType clang_getIBOutletCollectionType(
     CXCursor arg0,
   ) {
-    return (_clang_getIBOutletCollectionType ??= _dylib.lookupFunction<
-            _c_clang_getIBOutletCollectionType,
-            _dart_clang_getIBOutletCollectionType>(
-        'clang_getIBOutletCollectionType'))(
+    return (_clang_getIBOutletCollectionType ??=
+        _lookup<ffi.NativeFunction<_c_clang_getIBOutletCollectionType>>(
+                'clang_getIBOutletCollectionType')
+            .asFunction<_dart_clang_getIBOutletCollectionType>())(
       arg0,
     );
   }
@@ -2931,9 +3062,10 @@ class LibClang {
     ffi.Pointer<ffi.NativeFunction<CXCursorVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
-    return (_clang_visitChildren ??= _dylib.lookupFunction<
-        _c_clang_visitChildren,
-        _dart_clang_visitChildren>('clang_visitChildren'))(
+    return (_clang_visitChildren ??=
+        _lookup<ffi.NativeFunction<_c_clang_visitChildren>>(
+                'clang_visitChildren')
+            .asFunction<_dart_clang_visitChildren>())(
       parent,
       visitor,
       client_data,
@@ -2948,8 +3080,8 @@ class LibClang {
     CXCursor arg0,
   ) {
     return (_clang_getCursorUSR ??=
-        _dylib.lookupFunction<_c_clang_getCursorUSR, _dart_clang_getCursorUSR>(
-            'clang_getCursorUSR'))(
+        _lookup<ffi.NativeFunction<_c_clang_getCursorUSR>>('clang_getCursorUSR')
+            .asFunction<_dart_clang_getCursorUSR>())(
       arg0,
     );
   }
@@ -2960,9 +3092,10 @@ class LibClang {
   CXString clang_constructUSR_ObjCClass(
     ffi.Pointer<ffi.Int8> class_name,
   ) {
-    return (_clang_constructUSR_ObjCClass ??= _dylib.lookupFunction<
-        _c_clang_constructUSR_ObjCClass,
-        _dart_clang_constructUSR_ObjCClass>('clang_constructUSR_ObjCClass'))(
+    return (_clang_constructUSR_ObjCClass ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCClass>>(
+                'clang_constructUSR_ObjCClass')
+            .asFunction<_dart_clang_constructUSR_ObjCClass>())(
       class_name,
     );
   }
@@ -2974,10 +3107,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> class_name,
     ffi.Pointer<ffi.Int8> category_name,
   ) {
-    return (_clang_constructUSR_ObjCCategory ??= _dylib.lookupFunction<
-            _c_clang_constructUSR_ObjCCategory,
-            _dart_clang_constructUSR_ObjCCategory>(
-        'clang_constructUSR_ObjCCategory'))(
+    return (_clang_constructUSR_ObjCCategory ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCCategory>>(
+                'clang_constructUSR_ObjCCategory')
+            .asFunction<_dart_clang_constructUSR_ObjCCategory>())(
       class_name,
       category_name,
     );
@@ -2989,10 +3122,10 @@ class LibClang {
   CXString clang_constructUSR_ObjCProtocol(
     ffi.Pointer<ffi.Int8> protocol_name,
   ) {
-    return (_clang_constructUSR_ObjCProtocol ??= _dylib.lookupFunction<
-            _c_clang_constructUSR_ObjCProtocol,
-            _dart_clang_constructUSR_ObjCProtocol>(
-        'clang_constructUSR_ObjCProtocol'))(
+    return (_clang_constructUSR_ObjCProtocol ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCProtocol>>(
+                'clang_constructUSR_ObjCProtocol')
+            .asFunction<_dart_clang_constructUSR_ObjCProtocol>())(
       protocol_name,
     );
   }
@@ -3005,9 +3138,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> name,
     CXString classUSR,
   ) {
-    return (_clang_constructUSR_ObjCIvar ??= _dylib.lookupFunction<
-        _c_clang_constructUSR_ObjCIvar,
-        _dart_clang_constructUSR_ObjCIvar>('clang_constructUSR_ObjCIvar'))(
+    return (_clang_constructUSR_ObjCIvar ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCIvar>>(
+                'clang_constructUSR_ObjCIvar')
+            .asFunction<_dart_clang_constructUSR_ObjCIvar>())(
       name,
       classUSR,
     );
@@ -3022,9 +3156,10 @@ class LibClang {
     int isInstanceMethod,
     CXString classUSR,
   ) {
-    return (_clang_constructUSR_ObjCMethod ??= _dylib.lookupFunction<
-        _c_clang_constructUSR_ObjCMethod,
-        _dart_clang_constructUSR_ObjCMethod>('clang_constructUSR_ObjCMethod'))(
+    return (_clang_constructUSR_ObjCMethod ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCMethod>>(
+                'clang_constructUSR_ObjCMethod')
+            .asFunction<_dart_clang_constructUSR_ObjCMethod>())(
       name,
       isInstanceMethod,
       classUSR,
@@ -3039,10 +3174,10 @@ class LibClang {
     ffi.Pointer<ffi.Int8> property,
     CXString classUSR,
   ) {
-    return (_clang_constructUSR_ObjCProperty ??= _dylib.lookupFunction<
-            _c_clang_constructUSR_ObjCProperty,
-            _dart_clang_constructUSR_ObjCProperty>(
-        'clang_constructUSR_ObjCProperty'))(
+    return (_clang_constructUSR_ObjCProperty ??=
+        _lookup<ffi.NativeFunction<_c_clang_constructUSR_ObjCProperty>>(
+                'clang_constructUSR_ObjCProperty')
+            .asFunction<_dart_clang_constructUSR_ObjCProperty>())(
       property,
       classUSR,
     );
@@ -3054,9 +3189,10 @@ class LibClang {
   CXString clang_getCursorSpelling(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorSpelling ??= _dylib.lookupFunction<
-        _c_clang_getCursorSpelling,
-        _dart_clang_getCursorSpelling>('clang_getCursorSpelling'))(
+    return (_clang_getCursorSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorSpelling>>(
+                'clang_getCursorSpelling')
+            .asFunction<_dart_clang_getCursorSpelling>())(
       arg0,
     );
   }
@@ -3072,10 +3208,10 @@ class LibClang {
     int pieceIndex,
     int options,
   ) {
-    return (_clang_Cursor_getSpellingNameRange ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getSpellingNameRange,
-            _dart_clang_Cursor_getSpellingNameRange>(
-        'clang_Cursor_getSpellingNameRange'))(
+    return (_clang_Cursor_getSpellingNameRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getSpellingNameRange>>(
+                'clang_Cursor_getSpellingNameRange')
+            .asFunction<_dart_clang_Cursor_getSpellingNameRange>())(
       arg0,
       pieceIndex,
       options,
@@ -3089,10 +3225,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Policy,
     int Property,
   ) {
-    return (_clang_PrintingPolicy_getProperty ??= _dylib.lookupFunction<
-            _c_clang_PrintingPolicy_getProperty,
-            _dart_clang_PrintingPolicy_getProperty>(
-        'clang_PrintingPolicy_getProperty'))(
+    return (_clang_PrintingPolicy_getProperty ??=
+        _lookup<ffi.NativeFunction<_c_clang_PrintingPolicy_getProperty>>(
+                'clang_PrintingPolicy_getProperty')
+            .asFunction<_dart_clang_PrintingPolicy_getProperty>())(
       Policy,
       Property,
     );
@@ -3106,10 +3242,10 @@ class LibClang {
     int Property,
     int Value,
   ) {
-    return (_clang_PrintingPolicy_setProperty ??= _dylib.lookupFunction<
-            _c_clang_PrintingPolicy_setProperty,
-            _dart_clang_PrintingPolicy_setProperty>(
-        'clang_PrintingPolicy_setProperty'))(
+    return (_clang_PrintingPolicy_setProperty ??=
+        _lookup<ffi.NativeFunction<_c_clang_PrintingPolicy_setProperty>>(
+                'clang_PrintingPolicy_setProperty')
+            .asFunction<_dart_clang_PrintingPolicy_setProperty>())(
       Policy,
       Property,
       Value,
@@ -3122,9 +3258,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getCursorPrintingPolicy(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorPrintingPolicy ??= _dylib.lookupFunction<
-        _c_clang_getCursorPrintingPolicy,
-        _dart_clang_getCursorPrintingPolicy>('clang_getCursorPrintingPolicy'))(
+    return (_clang_getCursorPrintingPolicy ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorPrintingPolicy>>(
+                'clang_getCursorPrintingPolicy')
+            .asFunction<_dart_clang_getCursorPrintingPolicy>())(
       arg0,
     );
   }
@@ -3135,9 +3272,10 @@ class LibClang {
   void clang_PrintingPolicy_dispose(
     ffi.Pointer<ffi.Void> Policy,
   ) {
-    return (_clang_PrintingPolicy_dispose ??= _dylib.lookupFunction<
-        _c_clang_PrintingPolicy_dispose,
-        _dart_clang_PrintingPolicy_dispose>('clang_PrintingPolicy_dispose'))(
+    return (_clang_PrintingPolicy_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_PrintingPolicy_dispose>>(
+                'clang_PrintingPolicy_dispose')
+            .asFunction<_dart_clang_PrintingPolicy_dispose>())(
       Policy,
     );
   }
@@ -3149,9 +3287,10 @@ class LibClang {
     CXCursor Cursor,
     ffi.Pointer<ffi.Void> Policy,
   ) {
-    return (_clang_getCursorPrettyPrinted ??= _dylib.lookupFunction<
-        _c_clang_getCursorPrettyPrinted,
-        _dart_clang_getCursorPrettyPrinted>('clang_getCursorPrettyPrinted'))(
+    return (_clang_getCursorPrettyPrinted ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorPrettyPrinted>>(
+                'clang_getCursorPrettyPrinted')
+            .asFunction<_dart_clang_getCursorPrettyPrinted>())(
       Cursor,
       Policy,
     );
@@ -3163,9 +3302,10 @@ class LibClang {
   CXString clang_getCursorDisplayName(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorDisplayName ??= _dylib.lookupFunction<
-        _c_clang_getCursorDisplayName,
-        _dart_clang_getCursorDisplayName>('clang_getCursorDisplayName'))(
+    return (_clang_getCursorDisplayName ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorDisplayName>>(
+                'clang_getCursorDisplayName')
+            .asFunction<_dart_clang_getCursorDisplayName>())(
       arg0,
     );
   }
@@ -3177,9 +3317,10 @@ class LibClang {
   CXCursor clang_getCursorReferenced(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorReferenced ??= _dylib.lookupFunction<
-        _c_clang_getCursorReferenced,
-        _dart_clang_getCursorReferenced>('clang_getCursorReferenced'))(
+    return (_clang_getCursorReferenced ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorReferenced>>(
+                'clang_getCursorReferenced')
+            .asFunction<_dart_clang_getCursorReferenced>())(
       arg0,
     );
   }
@@ -3191,9 +3332,10 @@ class LibClang {
   CXCursor clang_getCursorDefinition(
     CXCursor arg0,
   ) {
-    return (_clang_getCursorDefinition ??= _dylib.lookupFunction<
-        _c_clang_getCursorDefinition,
-        _dart_clang_getCursorDefinition>('clang_getCursorDefinition'))(
+    return (_clang_getCursorDefinition ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorDefinition>>(
+                'clang_getCursorDefinition')
+            .asFunction<_dart_clang_getCursorDefinition>())(
       arg0,
     );
   }
@@ -3205,9 +3347,10 @@ class LibClang {
   int clang_isCursorDefinition(
     CXCursor arg0,
   ) {
-    return (_clang_isCursorDefinition ??= _dylib.lookupFunction<
-        _c_clang_isCursorDefinition,
-        _dart_clang_isCursorDefinition>('clang_isCursorDefinition'))(
+    return (_clang_isCursorDefinition ??=
+        _lookup<ffi.NativeFunction<_c_clang_isCursorDefinition>>(
+                'clang_isCursorDefinition')
+            .asFunction<_dart_clang_isCursorDefinition>())(
       arg0,
     );
   }
@@ -3218,9 +3361,10 @@ class LibClang {
   CXCursor clang_getCanonicalCursor(
     CXCursor arg0,
   ) {
-    return (_clang_getCanonicalCursor ??= _dylib.lookupFunction<
-        _c_clang_getCanonicalCursor,
-        _dart_clang_getCanonicalCursor>('clang_getCanonicalCursor'))(
+    return (_clang_getCanonicalCursor ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCanonicalCursor>>(
+                'clang_getCanonicalCursor')
+            .asFunction<_dart_clang_getCanonicalCursor>())(
       arg0,
     );
   }
@@ -3232,10 +3376,10 @@ class LibClang {
   int clang_Cursor_getObjCSelectorIndex(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getObjCSelectorIndex ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCSelectorIndex,
-            _dart_clang_Cursor_getObjCSelectorIndex>(
-        'clang_Cursor_getObjCSelectorIndex'))(
+    return (_clang_Cursor_getObjCSelectorIndex ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCSelectorIndex>>(
+                'clang_Cursor_getObjCSelectorIndex')
+            .asFunction<_dart_clang_Cursor_getObjCSelectorIndex>())(
       arg0,
     );
   }
@@ -3247,9 +3391,10 @@ class LibClang {
   int clang_Cursor_isDynamicCall(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isDynamicCall ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isDynamicCall,
-        _dart_clang_Cursor_isDynamicCall>('clang_Cursor_isDynamicCall'))(
+    return (_clang_Cursor_isDynamicCall ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isDynamicCall>>(
+                'clang_Cursor_isDynamicCall')
+            .asFunction<_dart_clang_Cursor_isDynamicCall>())(
       C,
     );
   }
@@ -3261,9 +3406,10 @@ class LibClang {
   CXType clang_Cursor_getReceiverType(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getReceiverType ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getReceiverType,
-        _dart_clang_Cursor_getReceiverType>('clang_Cursor_getReceiverType'))(
+    return (_clang_Cursor_getReceiverType ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getReceiverType>>(
+                'clang_Cursor_getReceiverType')
+            .asFunction<_dart_clang_Cursor_getReceiverType>())(
       C,
     );
   }
@@ -3277,10 +3423,10 @@ class LibClang {
     CXCursor C,
     int reserved,
   ) {
-    return (_clang_Cursor_getObjCPropertyAttributes ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCPropertyAttributes,
-            _dart_clang_Cursor_getObjCPropertyAttributes>(
-        'clang_Cursor_getObjCPropertyAttributes'))(
+    return (_clang_Cursor_getObjCPropertyAttributes ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCPropertyAttributes>>(
+                'clang_Cursor_getObjCPropertyAttributes')
+            .asFunction<_dart_clang_Cursor_getObjCPropertyAttributes>())(
       C,
       reserved,
     );
@@ -3294,10 +3440,10 @@ class LibClang {
   CXString clang_Cursor_getObjCPropertyGetterName(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getObjCPropertyGetterName ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCPropertyGetterName,
-            _dart_clang_Cursor_getObjCPropertyGetterName>(
-        'clang_Cursor_getObjCPropertyGetterName'))(
+    return (_clang_Cursor_getObjCPropertyGetterName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCPropertyGetterName>>(
+                'clang_Cursor_getObjCPropertyGetterName')
+            .asFunction<_dart_clang_Cursor_getObjCPropertyGetterName>())(
       C,
     );
   }
@@ -3310,10 +3456,10 @@ class LibClang {
   CXString clang_Cursor_getObjCPropertySetterName(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getObjCPropertySetterName ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCPropertySetterName,
-            _dart_clang_Cursor_getObjCPropertySetterName>(
-        'clang_Cursor_getObjCPropertySetterName'))(
+    return (_clang_Cursor_getObjCPropertySetterName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCPropertySetterName>>(
+                'clang_Cursor_getObjCPropertySetterName')
+            .asFunction<_dart_clang_Cursor_getObjCPropertySetterName>())(
       C,
     );
   }
@@ -3328,10 +3474,10 @@ class LibClang {
   int clang_Cursor_getObjCDeclQualifiers(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getObjCDeclQualifiers ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getObjCDeclQualifiers,
-            _dart_clang_Cursor_getObjCDeclQualifiers>(
-        'clang_Cursor_getObjCDeclQualifiers'))(
+    return (_clang_Cursor_getObjCDeclQualifiers ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCDeclQualifiers>>(
+                'clang_Cursor_getObjCDeclQualifiers')
+            .asFunction<_dart_clang_Cursor_getObjCDeclQualifiers>())(
       C,
     );
   }
@@ -3345,9 +3491,10 @@ class LibClang {
   int clang_Cursor_isObjCOptional(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isObjCOptional ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isObjCOptional,
-        _dart_clang_Cursor_isObjCOptional>('clang_Cursor_isObjCOptional'))(
+    return (_clang_Cursor_isObjCOptional ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isObjCOptional>>(
+                'clang_Cursor_isObjCOptional')
+            .asFunction<_dart_clang_Cursor_isObjCOptional>())(
       C,
     );
   }
@@ -3358,9 +3505,10 @@ class LibClang {
   int clang_Cursor_isVariadic(
     CXCursor C,
   ) {
-    return (_clang_Cursor_isVariadic ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isVariadic,
-        _dart_clang_Cursor_isVariadic>('clang_Cursor_isVariadic'))(
+    return (_clang_Cursor_isVariadic ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isVariadic>>(
+                'clang_Cursor_isVariadic')
+            .asFunction<_dart_clang_Cursor_isVariadic>())(
       C,
     );
   }
@@ -3375,9 +3523,10 @@ class LibClang {
     ffi.Pointer<CXString> definedIn,
     ffi.Pointer<ffi.Uint32> isGenerated,
   ) {
-    return (_clang_Cursor_isExternalSymbol ??= _dylib.lookupFunction<
-        _c_clang_Cursor_isExternalSymbol,
-        _dart_clang_Cursor_isExternalSymbol>('clang_Cursor_isExternalSymbol'))(
+    return (_clang_Cursor_isExternalSymbol ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_isExternalSymbol>>(
+                'clang_Cursor_isExternalSymbol')
+            .asFunction<_dart_clang_Cursor_isExternalSymbol>())(
       C,
       language,
       definedIn,
@@ -3393,9 +3542,10 @@ class LibClang {
   CXSourceRange clang_Cursor_getCommentRange(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getCommentRange ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getCommentRange,
-        _dart_clang_Cursor_getCommentRange>('clang_Cursor_getCommentRange'))(
+    return (_clang_Cursor_getCommentRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getCommentRange>>(
+                'clang_Cursor_getCommentRange')
+            .asFunction<_dart_clang_Cursor_getCommentRange>())(
       C,
     );
   }
@@ -3407,10 +3557,10 @@ class LibClang {
   CXString clang_Cursor_getRawCommentText(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getRawCommentText ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getRawCommentText,
-            _dart_clang_Cursor_getRawCommentText>(
-        'clang_Cursor_getRawCommentText'))(
+    return (_clang_Cursor_getRawCommentText ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getRawCommentText>>(
+                'clang_Cursor_getRawCommentText')
+            .asFunction<_dart_clang_Cursor_getRawCommentText>())(
       C,
     );
   }
@@ -3422,10 +3572,10 @@ class LibClang {
   CXString clang_Cursor_getBriefCommentText(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getBriefCommentText ??= _dylib.lookupFunction<
-            _c_clang_Cursor_getBriefCommentText,
-            _dart_clang_Cursor_getBriefCommentText>(
-        'clang_Cursor_getBriefCommentText'))(
+    return (_clang_Cursor_getBriefCommentText ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getBriefCommentText>>(
+                'clang_Cursor_getBriefCommentText')
+            .asFunction<_dart_clang_Cursor_getBriefCommentText>())(
       C,
     );
   }
@@ -3436,9 +3586,10 @@ class LibClang {
   CXString clang_Cursor_getMangling(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getMangling ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getMangling,
-        _dart_clang_Cursor_getMangling>('clang_Cursor_getMangling'))(
+    return (_clang_Cursor_getMangling ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getMangling>>(
+                'clang_Cursor_getMangling')
+            .asFunction<_dart_clang_Cursor_getMangling>())(
       arg0,
     );
   }
@@ -3450,9 +3601,10 @@ class LibClang {
   ffi.Pointer<CXStringSet> clang_Cursor_getCXXManglings(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getCXXManglings ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getCXXManglings,
-        _dart_clang_Cursor_getCXXManglings>('clang_Cursor_getCXXManglings'))(
+    return (_clang_Cursor_getCXXManglings ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getCXXManglings>>(
+                'clang_Cursor_getCXXManglings')
+            .asFunction<_dart_clang_Cursor_getCXXManglings>())(
       arg0,
     );
   }
@@ -3464,9 +3616,10 @@ class LibClang {
   ffi.Pointer<CXStringSet> clang_Cursor_getObjCManglings(
     CXCursor arg0,
   ) {
-    return (_clang_Cursor_getObjCManglings ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getObjCManglings,
-        _dart_clang_Cursor_getObjCManglings>('clang_Cursor_getObjCManglings'))(
+    return (_clang_Cursor_getObjCManglings ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getObjCManglings>>(
+                'clang_Cursor_getObjCManglings')
+            .asFunction<_dart_clang_Cursor_getObjCManglings>())(
       arg0,
     );
   }
@@ -3477,9 +3630,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Cursor_getModule(
     CXCursor C,
   ) {
-    return (_clang_Cursor_getModule ??= _dylib.lookupFunction<
-        _c_clang_Cursor_getModule,
-        _dart_clang_Cursor_getModule>('clang_Cursor_getModule'))(
+    return (_clang_Cursor_getModule ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_getModule>>(
+                'clang_Cursor_getModule')
+            .asFunction<_dart_clang_Cursor_getModule>())(
       C,
     );
   }
@@ -3492,9 +3646,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     ffi.Pointer<ffi.Void> arg1,
   ) {
-    return (_clang_getModuleForFile ??= _dylib.lookupFunction<
-        _c_clang_getModuleForFile,
-        _dart_clang_getModuleForFile>('clang_getModuleForFile'))(
+    return (_clang_getModuleForFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_getModuleForFile>>(
+                'clang_getModuleForFile')
+            .asFunction<_dart_clang_getModuleForFile>())(
       arg0,
       arg1,
     );
@@ -3506,9 +3661,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Module_getASTFile(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getASTFile ??= _dylib.lookupFunction<
-        _c_clang_Module_getASTFile,
-        _dart_clang_Module_getASTFile>('clang_Module_getASTFile'))(
+    return (_clang_Module_getASTFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getASTFile>>(
+                'clang_Module_getASTFile')
+            .asFunction<_dart_clang_Module_getASTFile>())(
       Module,
     );
   }
@@ -3520,9 +3676,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Module_getParent(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getParent ??= _dylib.lookupFunction<
-        _c_clang_Module_getParent,
-        _dart_clang_Module_getParent>('clang_Module_getParent'))(
+    return (_clang_Module_getParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getParent>>(
+                'clang_Module_getParent')
+            .asFunction<_dart_clang_Module_getParent>())(
       Module,
     );
   }
@@ -3534,9 +3691,10 @@ class LibClang {
   CXString clang_Module_getName(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getName ??= _dylib.lookupFunction<
-        _c_clang_Module_getName,
-        _dart_clang_Module_getName>('clang_Module_getName'))(
+    return (_clang_Module_getName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getName>>(
+                'clang_Module_getName')
+            .asFunction<_dart_clang_Module_getName>())(
       Module,
     );
   }
@@ -3547,9 +3705,10 @@ class LibClang {
   CXString clang_Module_getFullName(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getFullName ??= _dylib.lookupFunction<
-        _c_clang_Module_getFullName,
-        _dart_clang_Module_getFullName>('clang_Module_getFullName'))(
+    return (_clang_Module_getFullName ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getFullName>>(
+                'clang_Module_getFullName')
+            .asFunction<_dart_clang_Module_getFullName>())(
       Module,
     );
   }
@@ -3560,9 +3719,10 @@ class LibClang {
   int clang_Module_isSystem(
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_isSystem ??= _dylib.lookupFunction<
-        _c_clang_Module_isSystem,
-        _dart_clang_Module_isSystem>('clang_Module_isSystem'))(
+    return (_clang_Module_isSystem ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_isSystem>>(
+                'clang_Module_isSystem')
+            .asFunction<_dart_clang_Module_isSystem>())(
       Module,
     );
   }
@@ -3574,10 +3734,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     ffi.Pointer<ffi.Void> Module,
   ) {
-    return (_clang_Module_getNumTopLevelHeaders ??= _dylib.lookupFunction<
-            _c_clang_Module_getNumTopLevelHeaders,
-            _dart_clang_Module_getNumTopLevelHeaders>(
-        'clang_Module_getNumTopLevelHeaders'))(
+    return (_clang_Module_getNumTopLevelHeaders ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getNumTopLevelHeaders>>(
+                'clang_Module_getNumTopLevelHeaders')
+            .asFunction<_dart_clang_Module_getNumTopLevelHeaders>())(
       arg0,
       Module,
     );
@@ -3591,10 +3751,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> Module,
     int Index,
   ) {
-    return (_clang_Module_getTopLevelHeader ??= _dylib.lookupFunction<
-            _c_clang_Module_getTopLevelHeader,
-            _dart_clang_Module_getTopLevelHeader>(
-        'clang_Module_getTopLevelHeader'))(
+    return (_clang_Module_getTopLevelHeader ??=
+        _lookup<ffi.NativeFunction<_c_clang_Module_getTopLevelHeader>>(
+                'clang_Module_getTopLevelHeader')
+            .asFunction<_dart_clang_Module_getTopLevelHeader>())(
       arg0,
       Module,
       Index,
@@ -3607,10 +3767,11 @@ class LibClang {
   int clang_CXXConstructor_isConvertingConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isConvertingConstructor ??=
-        _dylib.lookupFunction<_c_clang_CXXConstructor_isConvertingConstructor,
-                _dart_clang_CXXConstructor_isConvertingConstructor>(
-            'clang_CXXConstructor_isConvertingConstructor'))(
+    return (_clang_CXXConstructor_isConvertingConstructor ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_CXXConstructor_isConvertingConstructor>>(
+            'clang_CXXConstructor_isConvertingConstructor')
+        .asFunction<_dart_clang_CXXConstructor_isConvertingConstructor>())(
       C,
     );
   }
@@ -3622,10 +3783,10 @@ class LibClang {
   int clang_CXXConstructor_isCopyConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isCopyConstructor ??= _dylib.lookupFunction<
-            _c_clang_CXXConstructor_isCopyConstructor,
-            _dart_clang_CXXConstructor_isCopyConstructor>(
-        'clang_CXXConstructor_isCopyConstructor'))(
+    return (_clang_CXXConstructor_isCopyConstructor ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXConstructor_isCopyConstructor>>(
+                'clang_CXXConstructor_isCopyConstructor')
+            .asFunction<_dart_clang_CXXConstructor_isCopyConstructor>())(
       C,
     );
   }
@@ -3637,10 +3798,11 @@ class LibClang {
   int clang_CXXConstructor_isDefaultConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isDefaultConstructor ??=
-        _dylib.lookupFunction<_c_clang_CXXConstructor_isDefaultConstructor,
-                _dart_clang_CXXConstructor_isDefaultConstructor>(
-            'clang_CXXConstructor_isDefaultConstructor'))(
+    return (_clang_CXXConstructor_isDefaultConstructor ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_CXXConstructor_isDefaultConstructor>>(
+            'clang_CXXConstructor_isDefaultConstructor')
+        .asFunction<_dart_clang_CXXConstructor_isDefaultConstructor>())(
       C,
     );
   }
@@ -3652,10 +3814,10 @@ class LibClang {
   int clang_CXXConstructor_isMoveConstructor(
     CXCursor C,
   ) {
-    return (_clang_CXXConstructor_isMoveConstructor ??= _dylib.lookupFunction<
-            _c_clang_CXXConstructor_isMoveConstructor,
-            _dart_clang_CXXConstructor_isMoveConstructor>(
-        'clang_CXXConstructor_isMoveConstructor'))(
+    return (_clang_CXXConstructor_isMoveConstructor ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXConstructor_isMoveConstructor>>(
+                'clang_CXXConstructor_isMoveConstructor')
+            .asFunction<_dart_clang_CXXConstructor_isMoveConstructor>())(
       C,
     );
   }
@@ -3667,9 +3829,10 @@ class LibClang {
   int clang_CXXField_isMutable(
     CXCursor C,
   ) {
-    return (_clang_CXXField_isMutable ??= _dylib.lookupFunction<
-        _c_clang_CXXField_isMutable,
-        _dart_clang_CXXField_isMutable>('clang_CXXField_isMutable'))(
+    return (_clang_CXXField_isMutable ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXField_isMutable>>(
+                'clang_CXXField_isMutable')
+            .asFunction<_dart_clang_CXXField_isMutable>())(
       C,
     );
   }
@@ -3680,9 +3843,10 @@ class LibClang {
   int clang_CXXMethod_isDefaulted(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isDefaulted ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isDefaulted,
-        _dart_clang_CXXMethod_isDefaulted>('clang_CXXMethod_isDefaulted'))(
+    return (_clang_CXXMethod_isDefaulted ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isDefaulted>>(
+                'clang_CXXMethod_isDefaulted')
+            .asFunction<_dart_clang_CXXMethod_isDefaulted>())(
       C,
     );
   }
@@ -3694,9 +3858,10 @@ class LibClang {
   int clang_CXXMethod_isPureVirtual(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isPureVirtual ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isPureVirtual,
-        _dart_clang_CXXMethod_isPureVirtual>('clang_CXXMethod_isPureVirtual'))(
+    return (_clang_CXXMethod_isPureVirtual ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isPureVirtual>>(
+                'clang_CXXMethod_isPureVirtual')
+            .asFunction<_dart_clang_CXXMethod_isPureVirtual>())(
       C,
     );
   }
@@ -3708,9 +3873,10 @@ class LibClang {
   int clang_CXXMethod_isStatic(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isStatic ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isStatic,
-        _dart_clang_CXXMethod_isStatic>('clang_CXXMethod_isStatic'))(
+    return (_clang_CXXMethod_isStatic ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isStatic>>(
+                'clang_CXXMethod_isStatic')
+            .asFunction<_dart_clang_CXXMethod_isStatic>())(
       C,
     );
   }
@@ -3723,9 +3889,10 @@ class LibClang {
   int clang_CXXMethod_isVirtual(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isVirtual ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isVirtual,
-        _dart_clang_CXXMethod_isVirtual>('clang_CXXMethod_isVirtual'))(
+    return (_clang_CXXMethod_isVirtual ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isVirtual>>(
+                'clang_CXXMethod_isVirtual')
+            .asFunction<_dart_clang_CXXMethod_isVirtual>())(
       C,
     );
   }
@@ -3737,9 +3904,10 @@ class LibClang {
   int clang_CXXRecord_isAbstract(
     CXCursor C,
   ) {
-    return (_clang_CXXRecord_isAbstract ??= _dylib.lookupFunction<
-        _c_clang_CXXRecord_isAbstract,
-        _dart_clang_CXXRecord_isAbstract>('clang_CXXRecord_isAbstract'))(
+    return (_clang_CXXRecord_isAbstract ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXRecord_isAbstract>>(
+                'clang_CXXRecord_isAbstract')
+            .asFunction<_dart_clang_CXXRecord_isAbstract>())(
       C,
     );
   }
@@ -3750,9 +3918,10 @@ class LibClang {
   int clang_EnumDecl_isScoped(
     CXCursor C,
   ) {
-    return (_clang_EnumDecl_isScoped ??= _dylib.lookupFunction<
-        _c_clang_EnumDecl_isScoped,
-        _dart_clang_EnumDecl_isScoped>('clang_EnumDecl_isScoped'))(
+    return (_clang_EnumDecl_isScoped ??=
+        _lookup<ffi.NativeFunction<_c_clang_EnumDecl_isScoped>>(
+                'clang_EnumDecl_isScoped')
+            .asFunction<_dart_clang_EnumDecl_isScoped>())(
       C,
     );
   }
@@ -3764,9 +3933,10 @@ class LibClang {
   int clang_CXXMethod_isConst(
     CXCursor C,
   ) {
-    return (_clang_CXXMethod_isConst ??= _dylib.lookupFunction<
-        _c_clang_CXXMethod_isConst,
-        _dart_clang_CXXMethod_isConst>('clang_CXXMethod_isConst'))(
+    return (_clang_CXXMethod_isConst ??=
+        _lookup<ffi.NativeFunction<_c_clang_CXXMethod_isConst>>(
+                'clang_CXXMethod_isConst')
+            .asFunction<_dart_clang_CXXMethod_isConst>())(
       C,
     );
   }
@@ -3778,9 +3948,10 @@ class LibClang {
   int clang_getTemplateCursorKind(
     CXCursor C,
   ) {
-    return (_clang_getTemplateCursorKind ??= _dylib.lookupFunction<
-        _c_clang_getTemplateCursorKind,
-        _dart_clang_getTemplateCursorKind>('clang_getTemplateCursorKind'))(
+    return (_clang_getTemplateCursorKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTemplateCursorKind>>(
+                'clang_getTemplateCursorKind')
+            .asFunction<_dart_clang_getTemplateCursorKind>())(
       C,
     );
   }
@@ -3793,10 +3964,10 @@ class LibClang {
   CXCursor clang_getSpecializedCursorTemplate(
     CXCursor C,
   ) {
-    return (_clang_getSpecializedCursorTemplate ??= _dylib.lookupFunction<
-            _c_clang_getSpecializedCursorTemplate,
-            _dart_clang_getSpecializedCursorTemplate>(
-        'clang_getSpecializedCursorTemplate'))(
+    return (_clang_getSpecializedCursorTemplate ??=
+        _lookup<ffi.NativeFunction<_c_clang_getSpecializedCursorTemplate>>(
+                'clang_getSpecializedCursorTemplate')
+            .asFunction<_dart_clang_getSpecializedCursorTemplate>())(
       C,
     );
   }
@@ -3810,10 +3981,10 @@ class LibClang {
     int NameFlags,
     int PieceIndex,
   ) {
-    return (_clang_getCursorReferenceNameRange ??= _dylib.lookupFunction<
-            _c_clang_getCursorReferenceNameRange,
-            _dart_clang_getCursorReferenceNameRange>(
-        'clang_getCursorReferenceNameRange'))(
+    return (_clang_getCursorReferenceNameRange ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorReferenceNameRange>>(
+                'clang_getCursorReferenceNameRange')
+            .asFunction<_dart_clang_getCursorReferenceNameRange>())(
       C,
       NameFlags,
       PieceIndex,
@@ -3828,8 +3999,8 @@ class LibClang {
     CXSourceLocation Location,
   ) {
     return (_clang_getToken ??=
-        _dylib.lookupFunction<_c_clang_getToken, _dart_clang_getToken>(
-            'clang_getToken'))(
+        _lookup<ffi.NativeFunction<_c_clang_getToken>>('clang_getToken')
+            .asFunction<_dart_clang_getToken>())(
       TU,
       Location,
     );
@@ -3842,8 +4013,8 @@ class LibClang {
     CXToken arg0,
   ) {
     return (_clang_getTokenKind ??=
-        _dylib.lookupFunction<_c_clang_getTokenKind, _dart_clang_getTokenKind>(
-            'clang_getTokenKind'))(
+        _lookup<ffi.NativeFunction<_c_clang_getTokenKind>>('clang_getTokenKind')
+            .asFunction<_dart_clang_getTokenKind>())(
       arg0,
     );
   }
@@ -3855,9 +4026,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     CXToken arg1,
   ) {
-    return (_clang_getTokenSpelling ??= _dylib.lookupFunction<
-        _c_clang_getTokenSpelling,
-        _dart_clang_getTokenSpelling>('clang_getTokenSpelling'))(
+    return (_clang_getTokenSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTokenSpelling>>(
+                'clang_getTokenSpelling')
+            .asFunction<_dart_clang_getTokenSpelling>())(
       arg0,
       arg1,
     );
@@ -3870,9 +4042,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     CXToken arg1,
   ) {
-    return (_clang_getTokenLocation ??= _dylib.lookupFunction<
-        _c_clang_getTokenLocation,
-        _dart_clang_getTokenLocation>('clang_getTokenLocation'))(
+    return (_clang_getTokenLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTokenLocation>>(
+                'clang_getTokenLocation')
+            .asFunction<_dart_clang_getTokenLocation>())(
       arg0,
       arg1,
     );
@@ -3885,9 +4058,10 @@ class LibClang {
     ffi.Pointer<CXTranslationUnitImpl> arg0,
     CXToken arg1,
   ) {
-    return (_clang_getTokenExtent ??= _dylib.lookupFunction<
-        _c_clang_getTokenExtent,
-        _dart_clang_getTokenExtent>('clang_getTokenExtent'))(
+    return (_clang_getTokenExtent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getTokenExtent>>(
+                'clang_getTokenExtent')
+            .asFunction<_dart_clang_getTokenExtent>())(
       arg0,
       arg1,
     );
@@ -3904,8 +4078,8 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> NumTokens,
   ) {
     return (_clang_tokenize ??=
-        _dylib.lookupFunction<_c_clang_tokenize, _dart_clang_tokenize>(
-            'clang_tokenize'))(
+        _lookup<ffi.NativeFunction<_c_clang_tokenize>>('clang_tokenize')
+            .asFunction<_dart_clang_tokenize>())(
       TU,
       Range,
       Tokens,
@@ -3923,9 +4097,10 @@ class LibClang {
     int NumTokens,
     ffi.Pointer<CXCursor> Cursors,
   ) {
-    return (_clang_annotateTokens ??= _dylib.lookupFunction<
-        _c_clang_annotateTokens,
-        _dart_clang_annotateTokens>('clang_annotateTokens'))(
+    return (_clang_annotateTokens ??=
+        _lookup<ffi.NativeFunction<_c_clang_annotateTokens>>(
+                'clang_annotateTokens')
+            .asFunction<_dart_clang_annotateTokens>())(
       TU,
       Tokens,
       NumTokens,
@@ -3941,9 +4116,10 @@ class LibClang {
     ffi.Pointer<CXToken> Tokens,
     int NumTokens,
   ) {
-    return (_clang_disposeTokens ??= _dylib.lookupFunction<
-        _c_clang_disposeTokens,
-        _dart_clang_disposeTokens>('clang_disposeTokens'))(
+    return (_clang_disposeTokens ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeTokens>>(
+                'clang_disposeTokens')
+            .asFunction<_dart_clang_disposeTokens>())(
       TU,
       Tokens,
       NumTokens,
@@ -3957,9 +4133,10 @@ class LibClang {
   CXString clang_getCursorKindSpelling(
     int Kind,
   ) {
-    return (_clang_getCursorKindSpelling ??= _dylib.lookupFunction<
-        _c_clang_getCursorKindSpelling,
-        _dart_clang_getCursorKindSpelling>('clang_getCursorKindSpelling'))(
+    return (_clang_getCursorKindSpelling ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorKindSpelling>>(
+                'clang_getCursorKindSpelling')
+            .asFunction<_dart_clang_getCursorKindSpelling>())(
       Kind,
     );
   }
@@ -3975,10 +4152,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> endLine,
     ffi.Pointer<ffi.Uint32> endColumn,
   ) {
-    return (_clang_getDefinitionSpellingAndExtent ??= _dylib.lookupFunction<
-            _c_clang_getDefinitionSpellingAndExtent,
-            _dart_clang_getDefinitionSpellingAndExtent>(
-        'clang_getDefinitionSpellingAndExtent'))(
+    return (_clang_getDefinitionSpellingAndExtent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getDefinitionSpellingAndExtent>>(
+                'clang_getDefinitionSpellingAndExtent')
+            .asFunction<_dart_clang_getDefinitionSpellingAndExtent>())(
       arg0,
       startBuf,
       endBuf,
@@ -3993,9 +4170,10 @@ class LibClang {
       _clang_getDefinitionSpellingAndExtent;
 
   void clang_enableStackTraces() {
-    return (_clang_enableStackTraces ??= _dylib.lookupFunction<
-        _c_clang_enableStackTraces,
-        _dart_clang_enableStackTraces>('clang_enableStackTraces'))();
+    return (_clang_enableStackTraces ??=
+        _lookup<ffi.NativeFunction<_c_clang_enableStackTraces>>(
+                'clang_enableStackTraces')
+            .asFunction<_dart_clang_enableStackTraces>())();
   }
 
   _dart_clang_enableStackTraces? _clang_enableStackTraces;
@@ -4005,9 +4183,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> user_data,
     int stack_size,
   ) {
-    return (_clang_executeOnThread ??= _dylib.lookupFunction<
-        _c_clang_executeOnThread,
-        _dart_clang_executeOnThread>('clang_executeOnThread'))(
+    return (_clang_executeOnThread ??=
+        _lookup<ffi.NativeFunction<_c_clang_executeOnThread>>(
+                'clang_executeOnThread')
+            .asFunction<_dart_clang_executeOnThread>())(
       fn,
       user_data,
       stack_size,
@@ -4021,9 +4200,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int chunk_number,
   ) {
-    return (_clang_getCompletionChunkKind ??= _dylib.lookupFunction<
-        _c_clang_getCompletionChunkKind,
-        _dart_clang_getCompletionChunkKind>('clang_getCompletionChunkKind'))(
+    return (_clang_getCompletionChunkKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionChunkKind>>(
+                'clang_getCompletionChunkKind')
+            .asFunction<_dart_clang_getCompletionChunkKind>())(
       completion_string,
       chunk_number,
     );
@@ -4037,9 +4217,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int chunk_number,
   ) {
-    return (_clang_getCompletionChunkText ??= _dylib.lookupFunction<
-        _c_clang_getCompletionChunkText,
-        _dart_clang_getCompletionChunkText>('clang_getCompletionChunkText'))(
+    return (_clang_getCompletionChunkText ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionChunkText>>(
+                'clang_getCompletionChunkText')
+            .asFunction<_dart_clang_getCompletionChunkText>())(
       completion_string,
       chunk_number,
     );
@@ -4053,10 +4234,11 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int chunk_number,
   ) {
-    return (_clang_getCompletionChunkCompletionString ??= _dylib.lookupFunction<
-            _c_clang_getCompletionChunkCompletionString,
-            _dart_clang_getCompletionChunkCompletionString>(
-        'clang_getCompletionChunkCompletionString'))(
+    return (_clang_getCompletionChunkCompletionString ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_getCompletionChunkCompletionString>>(
+            'clang_getCompletionChunkCompletionString')
+        .asFunction<_dart_clang_getCompletionChunkCompletionString>())(
       completion_string,
       chunk_number,
     );
@@ -4069,9 +4251,10 @@ class LibClang {
   int clang_getNumCompletionChunks(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getNumCompletionChunks ??= _dylib.lookupFunction<
-        _c_clang_getNumCompletionChunks,
-        _dart_clang_getNumCompletionChunks>('clang_getNumCompletionChunks'))(
+    return (_clang_getNumCompletionChunks ??=
+        _lookup<ffi.NativeFunction<_c_clang_getNumCompletionChunks>>(
+                'clang_getNumCompletionChunks')
+            .asFunction<_dart_clang_getNumCompletionChunks>())(
       completion_string,
     );
   }
@@ -4082,9 +4265,10 @@ class LibClang {
   int clang_getCompletionPriority(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionPriority ??= _dylib.lookupFunction<
-        _c_clang_getCompletionPriority,
-        _dart_clang_getCompletionPriority>('clang_getCompletionPriority'))(
+    return (_clang_getCompletionPriority ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionPriority>>(
+                'clang_getCompletionPriority')
+            .asFunction<_dart_clang_getCompletionPriority>())(
       completion_string,
     );
   }
@@ -4096,10 +4280,10 @@ class LibClang {
   int clang_getCompletionAvailability(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionAvailability ??= _dylib.lookupFunction<
-            _c_clang_getCompletionAvailability,
-            _dart_clang_getCompletionAvailability>(
-        'clang_getCompletionAvailability'))(
+    return (_clang_getCompletionAvailability ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionAvailability>>(
+                'clang_getCompletionAvailability')
+            .asFunction<_dart_clang_getCompletionAvailability>())(
       completion_string,
     );
   }
@@ -4111,10 +4295,10 @@ class LibClang {
   int clang_getCompletionNumAnnotations(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionNumAnnotations ??= _dylib.lookupFunction<
-            _c_clang_getCompletionNumAnnotations,
-            _dart_clang_getCompletionNumAnnotations>(
-        'clang_getCompletionNumAnnotations'))(
+    return (_clang_getCompletionNumAnnotations ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionNumAnnotations>>(
+                'clang_getCompletionNumAnnotations')
+            .asFunction<_dart_clang_getCompletionNumAnnotations>())(
       completion_string,
     );
   }
@@ -4126,9 +4310,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     int annotation_number,
   ) {
-    return (_clang_getCompletionAnnotation ??= _dylib.lookupFunction<
-        _c_clang_getCompletionAnnotation,
-        _dart_clang_getCompletionAnnotation>('clang_getCompletionAnnotation'))(
+    return (_clang_getCompletionAnnotation ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionAnnotation>>(
+                'clang_getCompletionAnnotation')
+            .asFunction<_dart_clang_getCompletionAnnotation>())(
       completion_string,
       annotation_number,
     );
@@ -4141,9 +4326,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> completion_string,
     ffi.Pointer<ffi.Int32> kind,
   ) {
-    return (_clang_getCompletionParent ??= _dylib.lookupFunction<
-        _c_clang_getCompletionParent,
-        _dart_clang_getCompletionParent>('clang_getCompletionParent'))(
+    return (_clang_getCompletionParent ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionParent>>(
+                'clang_getCompletionParent')
+            .asFunction<_dart_clang_getCompletionParent>())(
       completion_string,
       kind,
     );
@@ -4156,10 +4342,10 @@ class LibClang {
   CXString clang_getCompletionBriefComment(
     ffi.Pointer<ffi.Void> completion_string,
   ) {
-    return (_clang_getCompletionBriefComment ??= _dylib.lookupFunction<
-            _c_clang_getCompletionBriefComment,
-            _dart_clang_getCompletionBriefComment>(
-        'clang_getCompletionBriefComment'))(
+    return (_clang_getCompletionBriefComment ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionBriefComment>>(
+                'clang_getCompletionBriefComment')
+            .asFunction<_dart_clang_getCompletionBriefComment>())(
       completion_string,
     );
   }
@@ -4171,10 +4357,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getCursorCompletionString(
     CXCursor cursor,
   ) {
-    return (_clang_getCursorCompletionString ??= _dylib.lookupFunction<
-            _c_clang_getCursorCompletionString,
-            _dart_clang_getCursorCompletionString>(
-        'clang_getCursorCompletionString'))(
+    return (_clang_getCursorCompletionString ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCursorCompletionString>>(
+                'clang_getCursorCompletionString')
+            .asFunction<_dart_clang_getCursorCompletionString>())(
       cursor,
     );
   }
@@ -4186,9 +4372,10 @@ class LibClang {
     ffi.Pointer<CXCodeCompleteResults> results,
     int completion_index,
   ) {
-    return (_clang_getCompletionNumFixIts ??= _dylib.lookupFunction<
-        _c_clang_getCompletionNumFixIts,
-        _dart_clang_getCompletionNumFixIts>('clang_getCompletionNumFixIts'))(
+    return (_clang_getCompletionNumFixIts ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionNumFixIts>>(
+                'clang_getCompletionNumFixIts')
+            .asFunction<_dart_clang_getCompletionNumFixIts>())(
       results,
       completion_index,
     );
@@ -4204,9 +4391,10 @@ class LibClang {
     int fixit_index,
     ffi.Pointer<CXSourceRange> replacement_range,
   ) {
-    return (_clang_getCompletionFixIt ??= _dylib.lookupFunction<
-        _c_clang_getCompletionFixIt,
-        _dart_clang_getCompletionFixIt>('clang_getCompletionFixIt'))(
+    return (_clang_getCompletionFixIt ??=
+        _lookup<ffi.NativeFunction<_c_clang_getCompletionFixIt>>(
+                'clang_getCompletionFixIt')
+            .asFunction<_dart_clang_getCompletionFixIt>())(
       results,
       completion_index,
       fixit_index,
@@ -4219,10 +4407,10 @@ class LibClang {
   /// Returns a default set of code-completion options that can be passed to
   /// clang_codeCompleteAt().
   int clang_defaultCodeCompleteOptions() {
-    return (_clang_defaultCodeCompleteOptions ??= _dylib.lookupFunction<
-            _c_clang_defaultCodeCompleteOptions,
-            _dart_clang_defaultCodeCompleteOptions>(
-        'clang_defaultCodeCompleteOptions'))();
+    return (_clang_defaultCodeCompleteOptions ??=
+        _lookup<ffi.NativeFunction<_c_clang_defaultCodeCompleteOptions>>(
+                'clang_defaultCodeCompleteOptions')
+            .asFunction<_dart_clang_defaultCodeCompleteOptions>())();
   }
 
   _dart_clang_defaultCodeCompleteOptions? _clang_defaultCodeCompleteOptions;
@@ -4237,9 +4425,10 @@ class LibClang {
     int num_unsaved_files,
     int options,
   ) {
-    return (_clang_codeCompleteAt ??= _dylib.lookupFunction<
-        _c_clang_codeCompleteAt,
-        _dart_clang_codeCompleteAt>('clang_codeCompleteAt'))(
+    return (_clang_codeCompleteAt ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteAt>>(
+                'clang_codeCompleteAt')
+            .asFunction<_dart_clang_codeCompleteAt>())(
       TU,
       complete_filename,
       complete_line,
@@ -4257,10 +4446,10 @@ class LibClang {
     ffi.Pointer<CXCompletionResult> Results,
     int NumResults,
   ) {
-    return (_clang_sortCodeCompletionResults ??= _dylib.lookupFunction<
-            _c_clang_sortCodeCompletionResults,
-            _dart_clang_sortCodeCompletionResults>(
-        'clang_sortCodeCompletionResults'))(
+    return (_clang_sortCodeCompletionResults ??=
+        _lookup<ffi.NativeFunction<_c_clang_sortCodeCompletionResults>>(
+                'clang_sortCodeCompletionResults')
+            .asFunction<_dart_clang_sortCodeCompletionResults>())(
       Results,
       NumResults,
     );
@@ -4272,10 +4461,10 @@ class LibClang {
   void clang_disposeCodeCompleteResults(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_disposeCodeCompleteResults ??= _dylib.lookupFunction<
-            _c_clang_disposeCodeCompleteResults,
-            _dart_clang_disposeCodeCompleteResults>(
-        'clang_disposeCodeCompleteResults'))(
+    return (_clang_disposeCodeCompleteResults ??=
+        _lookup<ffi.NativeFunction<_c_clang_disposeCodeCompleteResults>>(
+                'clang_disposeCodeCompleteResults')
+            .asFunction<_dart_clang_disposeCodeCompleteResults>())(
       Results,
     );
   }
@@ -4287,10 +4476,10 @@ class LibClang {
   int clang_codeCompleteGetNumDiagnostics(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetNumDiagnostics ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetNumDiagnostics,
-            _dart_clang_codeCompleteGetNumDiagnostics>(
-        'clang_codeCompleteGetNumDiagnostics'))(
+    return (_clang_codeCompleteGetNumDiagnostics ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetNumDiagnostics>>(
+                'clang_codeCompleteGetNumDiagnostics')
+            .asFunction<_dart_clang_codeCompleteGetNumDiagnostics>())(
       Results,
     );
   }
@@ -4303,10 +4492,10 @@ class LibClang {
     ffi.Pointer<CXCodeCompleteResults> Results,
     int Index,
   ) {
-    return (_clang_codeCompleteGetDiagnostic ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetDiagnostic,
-            _dart_clang_codeCompleteGetDiagnostic>(
-        'clang_codeCompleteGetDiagnostic'))(
+    return (_clang_codeCompleteGetDiagnostic ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetDiagnostic>>(
+                'clang_codeCompleteGetDiagnostic')
+            .asFunction<_dart_clang_codeCompleteGetDiagnostic>())(
       Results,
       Index,
     );
@@ -4319,9 +4508,10 @@ class LibClang {
   int clang_codeCompleteGetContexts(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetContexts ??= _dylib.lookupFunction<
-        _c_clang_codeCompleteGetContexts,
-        _dart_clang_codeCompleteGetContexts>('clang_codeCompleteGetContexts'))(
+    return (_clang_codeCompleteGetContexts ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetContexts>>(
+                'clang_codeCompleteGetContexts')
+            .asFunction<_dart_clang_codeCompleteGetContexts>())(
       Results,
     );
   }
@@ -4336,10 +4526,10 @@ class LibClang {
     ffi.Pointer<CXCodeCompleteResults> Results,
     ffi.Pointer<ffi.Uint32> IsIncomplete,
   ) {
-    return (_clang_codeCompleteGetContainerKind ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetContainerKind,
-            _dart_clang_codeCompleteGetContainerKind>(
-        'clang_codeCompleteGetContainerKind'))(
+    return (_clang_codeCompleteGetContainerKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetContainerKind>>(
+                'clang_codeCompleteGetContainerKind')
+            .asFunction<_dart_clang_codeCompleteGetContainerKind>())(
       Results,
       IsIncomplete,
     );
@@ -4353,10 +4543,10 @@ class LibClang {
   CXString clang_codeCompleteGetContainerUSR(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetContainerUSR ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetContainerUSR,
-            _dart_clang_codeCompleteGetContainerUSR>(
-        'clang_codeCompleteGetContainerUSR'))(
+    return (_clang_codeCompleteGetContainerUSR ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetContainerUSR>>(
+                'clang_codeCompleteGetContainerUSR')
+            .asFunction<_dart_clang_codeCompleteGetContainerUSR>())(
       Results,
     );
   }
@@ -4370,10 +4560,10 @@ class LibClang {
   CXString clang_codeCompleteGetObjCSelector(
     ffi.Pointer<CXCodeCompleteResults> Results,
   ) {
-    return (_clang_codeCompleteGetObjCSelector ??= _dylib.lookupFunction<
-            _c_clang_codeCompleteGetObjCSelector,
-            _dart_clang_codeCompleteGetObjCSelector>(
-        'clang_codeCompleteGetObjCSelector'))(
+    return (_clang_codeCompleteGetObjCSelector ??=
+        _lookup<ffi.NativeFunction<_c_clang_codeCompleteGetObjCSelector>>(
+                'clang_codeCompleteGetObjCSelector')
+            .asFunction<_dart_clang_codeCompleteGetObjCSelector>())(
       Results,
     );
   }
@@ -4383,9 +4573,10 @@ class LibClang {
   /// Return a version string, suitable for showing to a user, but not intended
   /// to be parsed (the format is not guaranteed to be stable).
   CXString clang_getClangVersion() {
-    return (_clang_getClangVersion ??= _dylib.lookupFunction<
-        _c_clang_getClangVersion,
-        _dart_clang_getClangVersion>('clang_getClangVersion'))();
+    return (_clang_getClangVersion ??=
+        _lookup<ffi.NativeFunction<_c_clang_getClangVersion>>(
+                'clang_getClangVersion')
+            .asFunction<_dart_clang_getClangVersion>())();
   }
 
   _dart_clang_getClangVersion? _clang_getClangVersion;
@@ -4394,9 +4585,10 @@ class LibClang {
   void clang_toggleCrashRecovery(
     int isEnabled,
   ) {
-    return (_clang_toggleCrashRecovery ??= _dylib.lookupFunction<
-        _c_clang_toggleCrashRecovery,
-        _dart_clang_toggleCrashRecovery>('clang_toggleCrashRecovery'))(
+    return (_clang_toggleCrashRecovery ??=
+        _lookup<ffi.NativeFunction<_c_clang_toggleCrashRecovery>>(
+                'clang_toggleCrashRecovery')
+            .asFunction<_dart_clang_toggleCrashRecovery>())(
       isEnabled,
     );
   }
@@ -4412,9 +4604,10 @@ class LibClang {
     ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
-    return (_clang_getInclusions ??= _dylib.lookupFunction<
-        _c_clang_getInclusions,
-        _dart_clang_getInclusions>('clang_getInclusions'))(
+    return (_clang_getInclusions ??=
+        _lookup<ffi.NativeFunction<_c_clang_getInclusions>>(
+                'clang_getInclusions')
+            .asFunction<_dart_clang_getInclusions>())(
       tu,
       visitor,
       client_data,
@@ -4429,9 +4622,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_Cursor_Evaluate(
     CXCursor C,
   ) {
-    return (_clang_Cursor_Evaluate ??= _dylib.lookupFunction<
-        _c_clang_Cursor_Evaluate,
-        _dart_clang_Cursor_Evaluate>('clang_Cursor_Evaluate'))(
+    return (_clang_Cursor_Evaluate ??=
+        _lookup<ffi.NativeFunction<_c_clang_Cursor_Evaluate>>(
+                'clang_Cursor_Evaluate')
+            .asFunction<_dart_clang_Cursor_Evaluate>())(
       C,
     );
   }
@@ -4442,9 +4636,10 @@ class LibClang {
   int clang_EvalResult_getKind(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getKind ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getKind,
-        _dart_clang_EvalResult_getKind>('clang_EvalResult_getKind'))(
+    return (_clang_EvalResult_getKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getKind>>(
+                'clang_EvalResult_getKind')
+            .asFunction<_dart_clang_EvalResult_getKind>())(
       E,
     );
   }
@@ -4455,9 +4650,10 @@ class LibClang {
   int clang_EvalResult_getAsInt(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsInt ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getAsInt,
-        _dart_clang_EvalResult_getAsInt>('clang_EvalResult_getAsInt'))(
+    return (_clang_EvalResult_getAsInt ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsInt>>(
+                'clang_EvalResult_getAsInt')
+            .asFunction<_dart_clang_EvalResult_getAsInt>())(
       E,
     );
   }
@@ -4470,10 +4666,10 @@ class LibClang {
   int clang_EvalResult_getAsLongLong(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsLongLong ??= _dylib.lookupFunction<
-            _c_clang_EvalResult_getAsLongLong,
-            _dart_clang_EvalResult_getAsLongLong>(
-        'clang_EvalResult_getAsLongLong'))(
+    return (_clang_EvalResult_getAsLongLong ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsLongLong>>(
+                'clang_EvalResult_getAsLongLong')
+            .asFunction<_dart_clang_EvalResult_getAsLongLong>())(
       E,
     );
   }
@@ -4485,10 +4681,10 @@ class LibClang {
   int clang_EvalResult_isUnsignedInt(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_isUnsignedInt ??= _dylib.lookupFunction<
-            _c_clang_EvalResult_isUnsignedInt,
-            _dart_clang_EvalResult_isUnsignedInt>(
-        'clang_EvalResult_isUnsignedInt'))(
+    return (_clang_EvalResult_isUnsignedInt ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_isUnsignedInt>>(
+                'clang_EvalResult_isUnsignedInt')
+            .asFunction<_dart_clang_EvalResult_isUnsignedInt>())(
       E,
     );
   }
@@ -4500,10 +4696,10 @@ class LibClang {
   int clang_EvalResult_getAsUnsigned(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsUnsigned ??= _dylib.lookupFunction<
-            _c_clang_EvalResult_getAsUnsigned,
-            _dart_clang_EvalResult_getAsUnsigned>(
-        'clang_EvalResult_getAsUnsigned'))(
+    return (_clang_EvalResult_getAsUnsigned ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsUnsigned>>(
+                'clang_EvalResult_getAsUnsigned')
+            .asFunction<_dart_clang_EvalResult_getAsUnsigned>())(
       E,
     );
   }
@@ -4514,9 +4710,10 @@ class LibClang {
   double clang_EvalResult_getAsDouble(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsDouble ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getAsDouble,
-        _dart_clang_EvalResult_getAsDouble>('clang_EvalResult_getAsDouble'))(
+    return (_clang_EvalResult_getAsDouble ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsDouble>>(
+                'clang_EvalResult_getAsDouble')
+            .asFunction<_dart_clang_EvalResult_getAsDouble>())(
       E,
     );
   }
@@ -4530,9 +4727,10 @@ class LibClang {
   ffi.Pointer<ffi.Int8> clang_EvalResult_getAsStr(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_getAsStr ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_getAsStr,
-        _dart_clang_EvalResult_getAsStr>('clang_EvalResult_getAsStr'))(
+    return (_clang_EvalResult_getAsStr ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_getAsStr>>(
+                'clang_EvalResult_getAsStr')
+            .asFunction<_dart_clang_EvalResult_getAsStr>())(
       E,
     );
   }
@@ -4543,9 +4741,10 @@ class LibClang {
   void clang_EvalResult_dispose(
     ffi.Pointer<ffi.Void> E,
   ) {
-    return (_clang_EvalResult_dispose ??= _dylib.lookupFunction<
-        _c_clang_EvalResult_dispose,
-        _dart_clang_EvalResult_dispose>('clang_EvalResult_dispose'))(
+    return (_clang_EvalResult_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_EvalResult_dispose>>(
+                'clang_EvalResult_dispose')
+            .asFunction<_dart_clang_EvalResult_dispose>())(
       E,
     );
   }
@@ -4556,9 +4755,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_getRemappings(
     ffi.Pointer<ffi.Int8> path,
   ) {
-    return (_clang_getRemappings ??= _dylib.lookupFunction<
-        _c_clang_getRemappings,
-        _dart_clang_getRemappings>('clang_getRemappings'))(
+    return (_clang_getRemappings ??=
+        _lookup<ffi.NativeFunction<_c_clang_getRemappings>>(
+                'clang_getRemappings')
+            .asFunction<_dart_clang_getRemappings>())(
       path,
     );
   }
@@ -4570,10 +4770,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> filePaths,
     int numFiles,
   ) {
-    return (_clang_getRemappingsFromFileList ??= _dylib.lookupFunction<
-            _c_clang_getRemappingsFromFileList,
-            _dart_clang_getRemappingsFromFileList>(
-        'clang_getRemappingsFromFileList'))(
+    return (_clang_getRemappingsFromFileList ??=
+        _lookup<ffi.NativeFunction<_c_clang_getRemappingsFromFileList>>(
+                'clang_getRemappingsFromFileList')
+            .asFunction<_dart_clang_getRemappingsFromFileList>())(
       filePaths,
       numFiles,
     );
@@ -4585,9 +4785,10 @@ class LibClang {
   int clang_remap_getNumFiles(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_remap_getNumFiles ??= _dylib.lookupFunction<
-        _c_clang_remap_getNumFiles,
-        _dart_clang_remap_getNumFiles>('clang_remap_getNumFiles'))(
+    return (_clang_remap_getNumFiles ??=
+        _lookup<ffi.NativeFunction<_c_clang_remap_getNumFiles>>(
+                'clang_remap_getNumFiles')
+            .asFunction<_dart_clang_remap_getNumFiles>())(
       arg0,
     );
   }
@@ -4601,9 +4802,10 @@ class LibClang {
     ffi.Pointer<CXString> original,
     ffi.Pointer<CXString> transformed,
   ) {
-    return (_clang_remap_getFilenames ??= _dylib.lookupFunction<
-        _c_clang_remap_getFilenames,
-        _dart_clang_remap_getFilenames>('clang_remap_getFilenames'))(
+    return (_clang_remap_getFilenames ??=
+        _lookup<ffi.NativeFunction<_c_clang_remap_getFilenames>>(
+                'clang_remap_getFilenames')
+            .asFunction<_dart_clang_remap_getFilenames>())(
       arg0,
       index,
       original,
@@ -4617,9 +4819,10 @@ class LibClang {
   void clang_remap_dispose(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_remap_dispose ??= _dylib.lookupFunction<
-        _c_clang_remap_dispose,
-        _dart_clang_remap_dispose>('clang_remap_dispose'))(
+    return (_clang_remap_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_remap_dispose>>(
+                'clang_remap_dispose')
+            .asFunction<_dart_clang_remap_dispose>())(
       arg0,
     );
   }
@@ -4632,9 +4835,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     CXCursorAndRangeVisitor visitor,
   ) {
-    return (_clang_findReferencesInFile ??= _dylib.lookupFunction<
-        _c_clang_findReferencesInFile,
-        _dart_clang_findReferencesInFile>('clang_findReferencesInFile'))(
+    return (_clang_findReferencesInFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_findReferencesInFile>>(
+                'clang_findReferencesInFile')
+            .asFunction<_dart_clang_findReferencesInFile>())(
       cursor,
       file,
       visitor,
@@ -4649,9 +4853,10 @@ class LibClang {
     ffi.Pointer<ffi.Void> file,
     CXCursorAndRangeVisitor visitor,
   ) {
-    return (_clang_findIncludesInFile ??= _dylib.lookupFunction<
-        _c_clang_findIncludesInFile,
-        _dart_clang_findIncludesInFile>('clang_findIncludesInFile'))(
+    return (_clang_findIncludesInFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_findIncludesInFile>>(
+                'clang_findIncludesInFile')
+            .asFunction<_dart_clang_findIncludesInFile>())(
       TU,
       file,
       visitor,
@@ -4663,10 +4868,10 @@ class LibClang {
   int clang_index_isEntityObjCContainerKind(
     int arg0,
   ) {
-    return (_clang_index_isEntityObjCContainerKind ??= _dylib.lookupFunction<
-            _c_clang_index_isEntityObjCContainerKind,
-            _dart_clang_index_isEntityObjCContainerKind>(
-        'clang_index_isEntityObjCContainerKind'))(
+    return (_clang_index_isEntityObjCContainerKind ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_isEntityObjCContainerKind>>(
+                'clang_index_isEntityObjCContainerKind')
+            .asFunction<_dart_clang_index_isEntityObjCContainerKind>())(
       arg0,
     );
   }
@@ -4677,10 +4882,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCContainerDeclInfo> clang_index_getObjCContainerDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCContainerDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCContainerDeclInfo,
-            _dart_clang_index_getObjCContainerDeclInfo>(
-        'clang_index_getObjCContainerDeclInfo'))(
+    return (_clang_index_getObjCContainerDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCContainerDeclInfo>>(
+                'clang_index_getObjCContainerDeclInfo')
+            .asFunction<_dart_clang_index_getObjCContainerDeclInfo>())(
       arg0,
     );
   }
@@ -4691,10 +4896,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCInterfaceDeclInfo> clang_index_getObjCInterfaceDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCInterfaceDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCInterfaceDeclInfo,
-            _dart_clang_index_getObjCInterfaceDeclInfo>(
-        'clang_index_getObjCInterfaceDeclInfo'))(
+    return (_clang_index_getObjCInterfaceDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCInterfaceDeclInfo>>(
+                'clang_index_getObjCInterfaceDeclInfo')
+            .asFunction<_dart_clang_index_getObjCInterfaceDeclInfo>())(
       arg0,
     );
   }
@@ -4705,10 +4910,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCCategoryDeclInfo> clang_index_getObjCCategoryDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCCategoryDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCCategoryDeclInfo,
-            _dart_clang_index_getObjCCategoryDeclInfo>(
-        'clang_index_getObjCCategoryDeclInfo'))(
+    return (_clang_index_getObjCCategoryDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCCategoryDeclInfo>>(
+                'clang_index_getObjCCategoryDeclInfo')
+            .asFunction<_dart_clang_index_getObjCCategoryDeclInfo>())(
       arg0,
     );
   }
@@ -4720,10 +4925,10 @@ class LibClang {
       clang_index_getObjCProtocolRefListInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCProtocolRefListInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCProtocolRefListInfo,
-            _dart_clang_index_getObjCProtocolRefListInfo>(
-        'clang_index_getObjCProtocolRefListInfo'))(
+    return (_clang_index_getObjCProtocolRefListInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCProtocolRefListInfo>>(
+                'clang_index_getObjCProtocolRefListInfo')
+            .asFunction<_dart_clang_index_getObjCProtocolRefListInfo>())(
       arg0,
     );
   }
@@ -4734,10 +4939,10 @@ class LibClang {
   ffi.Pointer<CXIdxObjCPropertyDeclInfo> clang_index_getObjCPropertyDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getObjCPropertyDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getObjCPropertyDeclInfo,
-            _dart_clang_index_getObjCPropertyDeclInfo>(
-        'clang_index_getObjCPropertyDeclInfo'))(
+    return (_clang_index_getObjCPropertyDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getObjCPropertyDeclInfo>>(
+                'clang_index_getObjCPropertyDeclInfo')
+            .asFunction<_dart_clang_index_getObjCPropertyDeclInfo>())(
       arg0,
     );
   }
@@ -4749,10 +4954,11 @@ class LibClang {
       clang_index_getIBOutletCollectionAttrInfo(
     ffi.Pointer<CXIdxAttrInfo> arg0,
   ) {
-    return (_clang_index_getIBOutletCollectionAttrInfo ??=
-        _dylib.lookupFunction<_c_clang_index_getIBOutletCollectionAttrInfo,
-                _dart_clang_index_getIBOutletCollectionAttrInfo>(
-            'clang_index_getIBOutletCollectionAttrInfo'))(
+    return (_clang_index_getIBOutletCollectionAttrInfo ??= _lookup<
+                ffi.NativeFunction<
+                    _c_clang_index_getIBOutletCollectionAttrInfo>>(
+            'clang_index_getIBOutletCollectionAttrInfo')
+        .asFunction<_dart_clang_index_getIBOutletCollectionAttrInfo>())(
       arg0,
     );
   }
@@ -4763,10 +4969,10 @@ class LibClang {
   ffi.Pointer<CXIdxCXXClassDeclInfo> clang_index_getCXXClassDeclInfo(
     ffi.Pointer<CXIdxDeclInfo> arg0,
   ) {
-    return (_clang_index_getCXXClassDeclInfo ??= _dylib.lookupFunction<
-            _c_clang_index_getCXXClassDeclInfo,
-            _dart_clang_index_getCXXClassDeclInfo>(
-        'clang_index_getCXXClassDeclInfo'))(
+    return (_clang_index_getCXXClassDeclInfo ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getCXXClassDeclInfo>>(
+                'clang_index_getCXXClassDeclInfo')
+            .asFunction<_dart_clang_index_getCXXClassDeclInfo>())(
       arg0,
     );
   }
@@ -4777,10 +4983,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_index_getClientContainer(
     ffi.Pointer<CXIdxContainerInfo> arg0,
   ) {
-    return (_clang_index_getClientContainer ??= _dylib.lookupFunction<
-            _c_clang_index_getClientContainer,
-            _dart_clang_index_getClientContainer>(
-        'clang_index_getClientContainer'))(
+    return (_clang_index_getClientContainer ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getClientContainer>>(
+                'clang_index_getClientContainer')
+            .asFunction<_dart_clang_index_getClientContainer>())(
       arg0,
     );
   }
@@ -4792,10 +4998,10 @@ class LibClang {
     ffi.Pointer<CXIdxContainerInfo> arg0,
     ffi.Pointer<ffi.Void> arg1,
   ) {
-    return (_clang_index_setClientContainer ??= _dylib.lookupFunction<
-            _c_clang_index_setClientContainer,
-            _dart_clang_index_setClientContainer>(
-        'clang_index_setClientContainer'))(
+    return (_clang_index_setClientContainer ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_setClientContainer>>(
+                'clang_index_setClientContainer')
+            .asFunction<_dart_clang_index_setClientContainer>())(
       arg0,
       arg1,
     );
@@ -4807,9 +5013,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_index_getClientEntity(
     ffi.Pointer<CXIdxEntityInfo> arg0,
   ) {
-    return (_clang_index_getClientEntity ??= _dylib.lookupFunction<
-        _c_clang_index_getClientEntity,
-        _dart_clang_index_getClientEntity>('clang_index_getClientEntity'))(
+    return (_clang_index_getClientEntity ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_getClientEntity>>(
+                'clang_index_getClientEntity')
+            .asFunction<_dart_clang_index_getClientEntity>())(
       arg0,
     );
   }
@@ -4821,9 +5028,10 @@ class LibClang {
     ffi.Pointer<CXIdxEntityInfo> arg0,
     ffi.Pointer<ffi.Void> arg1,
   ) {
-    return (_clang_index_setClientEntity ??= _dylib.lookupFunction<
-        _c_clang_index_setClientEntity,
-        _dart_clang_index_setClientEntity>('clang_index_setClientEntity'))(
+    return (_clang_index_setClientEntity ??=
+        _lookup<ffi.NativeFunction<_c_clang_index_setClientEntity>>(
+                'clang_index_setClientEntity')
+            .asFunction<_dart_clang_index_setClientEntity>())(
       arg0,
       arg1,
     );
@@ -4836,9 +5044,10 @@ class LibClang {
   ffi.Pointer<ffi.Void> clang_IndexAction_create(
     ffi.Pointer<ffi.Void> CIdx,
   ) {
-    return (_clang_IndexAction_create ??= _dylib.lookupFunction<
-        _c_clang_IndexAction_create,
-        _dart_clang_IndexAction_create>('clang_IndexAction_create'))(
+    return (_clang_IndexAction_create ??=
+        _lookup<ffi.NativeFunction<_c_clang_IndexAction_create>>(
+                'clang_IndexAction_create')
+            .asFunction<_dart_clang_IndexAction_create>())(
       CIdx,
     );
   }
@@ -4849,9 +5058,10 @@ class LibClang {
   void clang_IndexAction_dispose(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_clang_IndexAction_dispose ??= _dylib.lookupFunction<
-        _c_clang_IndexAction_dispose,
-        _dart_clang_IndexAction_dispose>('clang_IndexAction_dispose'))(
+    return (_clang_IndexAction_dispose ??=
+        _lookup<ffi.NativeFunction<_c_clang_IndexAction_dispose>>(
+                'clang_IndexAction_dispose')
+            .asFunction<_dart_clang_IndexAction_dispose>())(
       arg0,
     );
   }
@@ -4874,9 +5084,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
     int TU_options,
   ) {
-    return (_clang_indexSourceFile ??= _dylib.lookupFunction<
-        _c_clang_indexSourceFile,
-        _dart_clang_indexSourceFile>('clang_indexSourceFile'))(
+    return (_clang_indexSourceFile ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexSourceFile>>(
+                'clang_indexSourceFile')
+            .asFunction<_dart_clang_indexSourceFile>())(
       arg0,
       client_data,
       index_callbacks,
@@ -4911,9 +5122,10 @@ class LibClang {
     ffi.Pointer<ffi.Pointer<CXTranslationUnitImpl>> out_TU,
     int TU_options,
   ) {
-    return (_clang_indexSourceFileFullArgv ??= _dylib.lookupFunction<
-        _c_clang_indexSourceFileFullArgv,
-        _dart_clang_indexSourceFileFullArgv>('clang_indexSourceFileFullArgv'))(
+    return (_clang_indexSourceFileFullArgv ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexSourceFileFullArgv>>(
+                'clang_indexSourceFileFullArgv')
+            .asFunction<_dart_clang_indexSourceFileFullArgv>())(
       arg0,
       client_data,
       index_callbacks,
@@ -4941,9 +5153,10 @@ class LibClang {
     int index_options,
     ffi.Pointer<CXTranslationUnitImpl> arg5,
   ) {
-    return (_clang_indexTranslationUnit ??= _dylib.lookupFunction<
-        _c_clang_indexTranslationUnit,
-        _dart_clang_indexTranslationUnit>('clang_indexTranslationUnit'))(
+    return (_clang_indexTranslationUnit ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexTranslationUnit>>(
+                'clang_indexTranslationUnit')
+            .asFunction<_dart_clang_indexTranslationUnit>())(
       arg0,
       client_data,
       index_callbacks,
@@ -4965,10 +5178,10 @@ class LibClang {
     ffi.Pointer<ffi.Uint32> column,
     ffi.Pointer<ffi.Uint32> offset,
   ) {
-    return (_clang_indexLoc_getFileLocation ??= _dylib.lookupFunction<
-            _c_clang_indexLoc_getFileLocation,
-            _dart_clang_indexLoc_getFileLocation>(
-        'clang_indexLoc_getFileLocation'))(
+    return (_clang_indexLoc_getFileLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexLoc_getFileLocation>>(
+                'clang_indexLoc_getFileLocation')
+            .asFunction<_dart_clang_indexLoc_getFileLocation>())(
       loc,
       indexFile,
       file,
@@ -4984,10 +5197,10 @@ class LibClang {
   CXSourceLocation clang_indexLoc_getCXSourceLocation(
     CXIdxLoc loc,
   ) {
-    return (_clang_indexLoc_getCXSourceLocation ??= _dylib.lookupFunction<
-            _c_clang_indexLoc_getCXSourceLocation,
-            _dart_clang_indexLoc_getCXSourceLocation>(
-        'clang_indexLoc_getCXSourceLocation'))(
+    return (_clang_indexLoc_getCXSourceLocation ??=
+        _lookup<ffi.NativeFunction<_c_clang_indexLoc_getCXSourceLocation>>(
+                'clang_indexLoc_getCXSourceLocation')
+            .asFunction<_dart_clang_indexLoc_getCXSourceLocation>())(
       loc,
     );
   }
@@ -5000,9 +5213,10 @@ class LibClang {
     ffi.Pointer<ffi.NativeFunction<CXFieldVisitor>> visitor,
     ffi.Pointer<ffi.Void> client_data,
   ) {
-    return (_clang_Type_visitFields ??= _dylib.lookupFunction<
-        _c_clang_Type_visitFields,
-        _dart_clang_Type_visitFields>('clang_Type_visitFields'))(
+    return (_clang_Type_visitFields ??=
+        _lookup<ffi.NativeFunction<_c_clang_Type_visitFields>>(
+                'clang_Type_visitFields')
+            .asFunction<_dart_clang_Type_visitFields>())(
       T,
       visitor,
       client_data,

--- a/test/large_integration_tests/_expected_sqlite_bindings.dart
+++ b/test/large_integration_tests/_expected_sqlite_bindings.dart
@@ -5,11 +5,18 @@ import 'dart:ffi' as ffi;
 
 /// Bindings to SQLite.
 class SQLite {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  SQLite(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  SQLite(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  SQLite.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   /// CAPI3REF: Run-Time Library Version Numbers
   /// KEYWORDS: sqlite3_version sqlite3_sourceid
@@ -42,7 +49,7 @@ class SQLite {
   ///
   /// See also: [sqlite_version()] and [sqlite_source_id()].
   late final ffi.Pointer<ffi.Pointer<ffi.Int8>> _sqlite3_version =
-      _dylib.lookup<ffi.Pointer<ffi.Int8>>('sqlite3_version');
+      _lookup<ffi.Pointer<ffi.Int8>>('sqlite3_version');
 
   ffi.Pointer<ffi.Int8> get sqlite3_version => _sqlite3_version.value;
 
@@ -51,24 +58,25 @@ class SQLite {
 
   ffi.Pointer<ffi.Int8> sqlite3_libversion() {
     return (_sqlite3_libversion ??=
-        _dylib.lookupFunction<_c_sqlite3_libversion, _dart_sqlite3_libversion>(
-            'sqlite3_libversion'))();
+        _lookup<ffi.NativeFunction<_c_sqlite3_libversion>>('sqlite3_libversion')
+            .asFunction<_dart_sqlite3_libversion>())();
   }
 
   _dart_sqlite3_libversion? _sqlite3_libversion;
 
   ffi.Pointer<ffi.Int8> sqlite3_sourceid() {
     return (_sqlite3_sourceid ??=
-        _dylib.lookupFunction<_c_sqlite3_sourceid, _dart_sqlite3_sourceid>(
-            'sqlite3_sourceid'))();
+        _lookup<ffi.NativeFunction<_c_sqlite3_sourceid>>('sqlite3_sourceid')
+            .asFunction<_dart_sqlite3_sourceid>())();
   }
 
   _dart_sqlite3_sourceid? _sqlite3_sourceid;
 
   int sqlite3_libversion_number() {
-    return (_sqlite3_libversion_number ??= _dylib.lookupFunction<
-        _c_sqlite3_libversion_number,
-        _dart_sqlite3_libversion_number>('sqlite3_libversion_number'))();
+    return (_sqlite3_libversion_number ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_libversion_number>>(
+                'sqlite3_libversion_number')
+            .asFunction<_dart_sqlite3_libversion_number>())();
   }
 
   _dart_sqlite3_libversion_number? _sqlite3_libversion_number;
@@ -76,9 +84,10 @@ class SQLite {
   int sqlite3_compileoption_used(
     ffi.Pointer<ffi.Int8> zOptName,
   ) {
-    return (_sqlite3_compileoption_used ??= _dylib.lookupFunction<
-        _c_sqlite3_compileoption_used,
-        _dart_sqlite3_compileoption_used>('sqlite3_compileoption_used'))(
+    return (_sqlite3_compileoption_used ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_compileoption_used>>(
+                'sqlite3_compileoption_used')
+            .asFunction<_dart_sqlite3_compileoption_used>())(
       zOptName,
     );
   }
@@ -88,9 +97,10 @@ class SQLite {
   ffi.Pointer<ffi.Int8> sqlite3_compileoption_get(
     int N,
   ) {
-    return (_sqlite3_compileoption_get ??= _dylib.lookupFunction<
-        _c_sqlite3_compileoption_get,
-        _dart_sqlite3_compileoption_get>('sqlite3_compileoption_get'))(
+    return (_sqlite3_compileoption_get ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_compileoption_get>>(
+                'sqlite3_compileoption_get')
+            .asFunction<_dart_sqlite3_compileoption_get>())(
       N,
     );
   }
@@ -133,8 +143,8 @@ class SQLite {
   /// See the [threading mode] documentation for additional information.
   int sqlite3_threadsafe() {
     return (_sqlite3_threadsafe ??=
-        _dylib.lookupFunction<_c_sqlite3_threadsafe, _dart_sqlite3_threadsafe>(
-            'sqlite3_threadsafe'))();
+        _lookup<ffi.NativeFunction<_c_sqlite3_threadsafe>>('sqlite3_threadsafe')
+            .asFunction<_dart_sqlite3_threadsafe>())();
   }
 
   _dart_sqlite3_threadsafe? _sqlite3_threadsafe;
@@ -179,8 +189,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_close ??=
-        _dylib.lookupFunction<_c_sqlite3_close, _dart_sqlite3_close>(
-            'sqlite3_close'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_close>>('sqlite3_close')
+            .asFunction<_dart_sqlite3_close>())(
       arg0,
     );
   }
@@ -191,8 +201,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_close_v2 ??=
-        _dylib.lookupFunction<_c_sqlite3_close_v2, _dart_sqlite3_close_v2>(
-            'sqlite3_close_v2'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_close_v2>>('sqlite3_close_v2')
+            .asFunction<_dart_sqlite3_close_v2>())(
       arg0,
     );
   }
@@ -266,8 +276,9 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg3,
     ffi.Pointer<ffi.Pointer<ffi.Int8>> errmsg,
   ) {
-    return (_sqlite3_exec ??= _dylib
-        .lookupFunction<_c_sqlite3_exec, _dart_sqlite3_exec>('sqlite3_exec'))(
+    return (_sqlite3_exec ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_exec>>('sqlite3_exec')
+            .asFunction<_dart_sqlite3_exec>())(
       arg0,
       sql,
       callback,
@@ -353,32 +364,32 @@ class SQLite {
   /// failure.
   int sqlite3_initialize() {
     return (_sqlite3_initialize ??=
-        _dylib.lookupFunction<_c_sqlite3_initialize, _dart_sqlite3_initialize>(
-            'sqlite3_initialize'))();
+        _lookup<ffi.NativeFunction<_c_sqlite3_initialize>>('sqlite3_initialize')
+            .asFunction<_dart_sqlite3_initialize>())();
   }
 
   _dart_sqlite3_initialize? _sqlite3_initialize;
 
   int sqlite3_shutdown() {
     return (_sqlite3_shutdown ??=
-        _dylib.lookupFunction<_c_sqlite3_shutdown, _dart_sqlite3_shutdown>(
-            'sqlite3_shutdown'))();
+        _lookup<ffi.NativeFunction<_c_sqlite3_shutdown>>('sqlite3_shutdown')
+            .asFunction<_dart_sqlite3_shutdown>())();
   }
 
   _dart_sqlite3_shutdown? _sqlite3_shutdown;
 
   int sqlite3_os_init() {
     return (_sqlite3_os_init ??=
-        _dylib.lookupFunction<_c_sqlite3_os_init, _dart_sqlite3_os_init>(
-            'sqlite3_os_init'))();
+        _lookup<ffi.NativeFunction<_c_sqlite3_os_init>>('sqlite3_os_init')
+            .asFunction<_dart_sqlite3_os_init>())();
   }
 
   _dart_sqlite3_os_init? _sqlite3_os_init;
 
   int sqlite3_os_end() {
     return (_sqlite3_os_end ??=
-        _dylib.lookupFunction<_c_sqlite3_os_end, _dart_sqlite3_os_end>(
-            'sqlite3_os_end'))();
+        _lookup<ffi.NativeFunction<_c_sqlite3_os_end>>('sqlite3_os_end')
+            .asFunction<_dart_sqlite3_os_end>())();
   }
 
   _dart_sqlite3_os_end? _sqlite3_os_end;
@@ -416,8 +427,8 @@ class SQLite {
     int arg0,
   ) {
     return (_sqlite3_config ??=
-        _dylib.lookupFunction<_c_sqlite3_config, _dart_sqlite3_config>(
-            'sqlite3_config'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_config>>('sqlite3_config')
+            .asFunction<_dart_sqlite3_config>())(
       arg0,
     );
   }
@@ -444,8 +455,8 @@ class SQLite {
     int op,
   ) {
     return (_sqlite3_db_config ??=
-        _dylib.lookupFunction<_c_sqlite3_db_config, _dart_sqlite3_db_config>(
-            'sqlite3_db_config'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_config>>('sqlite3_db_config')
+            .asFunction<_dart_sqlite3_db_config>())(
       arg0,
       op,
     );
@@ -463,9 +474,10 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
     int onoff,
   ) {
-    return (_sqlite3_extended_result_codes ??= _dylib.lookupFunction<
-        _c_sqlite3_extended_result_codes,
-        _dart_sqlite3_extended_result_codes>('sqlite3_extended_result_codes'))(
+    return (_sqlite3_extended_result_codes ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_extended_result_codes>>(
+                'sqlite3_extended_result_codes')
+            .asFunction<_dart_sqlite3_extended_result_codes>())(
       arg0,
       onoff,
     );
@@ -534,9 +546,10 @@ class SQLite {
   int sqlite3_last_insert_rowid(
     ffi.Pointer<sqlite3> arg0,
   ) {
-    return (_sqlite3_last_insert_rowid ??= _dylib.lookupFunction<
-        _c_sqlite3_last_insert_rowid,
-        _dart_sqlite3_last_insert_rowid>('sqlite3_last_insert_rowid'))(
+    return (_sqlite3_last_insert_rowid ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_last_insert_rowid>>(
+                'sqlite3_last_insert_rowid')
+            .asFunction<_dart_sqlite3_last_insert_rowid>())(
       arg0,
     );
   }
@@ -553,9 +566,10 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
     int arg1,
   ) {
-    return (_sqlite3_set_last_insert_rowid ??= _dylib.lookupFunction<
-        _c_sqlite3_set_last_insert_rowid,
-        _dart_sqlite3_set_last_insert_rowid>('sqlite3_set_last_insert_rowid'))(
+    return (_sqlite3_set_last_insert_rowid ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_set_last_insert_rowid>>(
+                'sqlite3_set_last_insert_rowid')
+            .asFunction<_dart_sqlite3_set_last_insert_rowid>())(
       arg0,
       arg1,
     );
@@ -621,8 +635,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_changes ??=
-        _dylib.lookupFunction<_c_sqlite3_changes, _dart_sqlite3_changes>(
-            'sqlite3_changes'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_changes>>('sqlite3_changes')
+            .asFunction<_dart_sqlite3_changes>())(
       arg0,
     );
   }
@@ -665,9 +679,10 @@ class SQLite {
   int sqlite3_total_changes(
     ffi.Pointer<sqlite3> arg0,
   ) {
-    return (_sqlite3_total_changes ??= _dylib.lookupFunction<
-        _c_sqlite3_total_changes,
-        _dart_sqlite3_total_changes>('sqlite3_total_changes'))(
+    return (_sqlite3_total_changes ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_total_changes>>(
+                'sqlite3_total_changes')
+            .asFunction<_dart_sqlite3_total_changes>())(
       arg0,
     );
   }
@@ -711,8 +726,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_interrupt ??=
-        _dylib.lookupFunction<_c_sqlite3_interrupt, _dart_sqlite3_interrupt>(
-            'sqlite3_interrupt'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_interrupt>>('sqlite3_interrupt')
+            .asFunction<_dart_sqlite3_interrupt>())(
       arg0,
     );
   }
@@ -754,8 +769,8 @@ class SQLite {
     ffi.Pointer<ffi.Int8> sql,
   ) {
     return (_sqlite3_complete ??=
-        _dylib.lookupFunction<_c_sqlite3_complete, _dart_sqlite3_complete>(
-            'sqlite3_complete'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_complete>>('sqlite3_complete')
+            .asFunction<_dart_sqlite3_complete>())(
       sql,
     );
   }
@@ -766,8 +781,8 @@ class SQLite {
     ffi.Pointer<ffi.Void> sql,
   ) {
     return (_sqlite3_complete16 ??=
-        _dylib.lookupFunction<_c_sqlite3_complete16, _dart_sqlite3_complete16>(
-            'sqlite3_complete16'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_complete16>>('sqlite3_complete16')
+            .asFunction<_dart_sqlite3_complete16>())(
       sql,
     );
   }
@@ -836,9 +851,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_20>> arg1,
     ffi.Pointer<ffi.Void> arg2,
   ) {
-    return (_sqlite3_busy_handler ??= _dylib.lookupFunction<
-        _c_sqlite3_busy_handler,
-        _dart_sqlite3_busy_handler>('sqlite3_busy_handler'))(
+    return (_sqlite3_busy_handler ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_busy_handler>>(
+                'sqlite3_busy_handler')
+            .asFunction<_dart_sqlite3_busy_handler>())(
       arg0,
       arg1,
       arg2,
@@ -870,9 +886,10 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
     int ms,
   ) {
-    return (_sqlite3_busy_timeout ??= _dylib.lookupFunction<
-        _c_sqlite3_busy_timeout,
-        _dart_sqlite3_busy_timeout>('sqlite3_busy_timeout'))(
+    return (_sqlite3_busy_timeout ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_busy_timeout>>(
+                'sqlite3_busy_timeout')
+            .asFunction<_dart_sqlite3_busy_timeout>())(
       arg0,
       ms,
     );
@@ -960,8 +977,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> pzErrmsg,
   ) {
     return (_sqlite3_get_table ??=
-        _dylib.lookupFunction<_c_sqlite3_get_table, _dart_sqlite3_get_table>(
-            'sqlite3_get_table'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_get_table>>('sqlite3_get_table')
+            .asFunction<_dart_sqlite3_get_table>())(
       db,
       zSql,
       pazResult,
@@ -977,8 +994,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> result,
   ) {
     return (_sqlite3_free_table ??=
-        _dylib.lookupFunction<_c_sqlite3_free_table, _dart_sqlite3_free_table>(
-            'sqlite3_free_table'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_free_table>>('sqlite3_free_table')
+            .asFunction<_dart_sqlite3_free_table>())(
       result,
     );
   }
@@ -1027,8 +1044,8 @@ class SQLite {
     ffi.Pointer<ffi.Int8> arg0,
   ) {
     return (_sqlite3_mprintf ??=
-        _dylib.lookupFunction<_c_sqlite3_mprintf, _dart_sqlite3_mprintf>(
-            'sqlite3_mprintf'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_mprintf>>('sqlite3_mprintf')
+            .asFunction<_dart_sqlite3_mprintf>())(
       arg0,
     );
   }
@@ -1041,8 +1058,8 @@ class SQLite {
     ffi.Pointer<ffi.Int8> arg2,
   ) {
     return (_sqlite3_snprintf ??=
-        _dylib.lookupFunction<_c_sqlite3_snprintf, _dart_sqlite3_snprintf>(
-            'sqlite3_snprintf'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_snprintf>>('sqlite3_snprintf')
+            .asFunction<_dart_sqlite3_snprintf>())(
       arg0,
       arg1,
       arg2,
@@ -1128,8 +1145,8 @@ class SQLite {
     int arg0,
   ) {
     return (_sqlite3_malloc ??=
-        _dylib.lookupFunction<_c_sqlite3_malloc, _dart_sqlite3_malloc>(
-            'sqlite3_malloc'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_malloc>>('sqlite3_malloc')
+            .asFunction<_dart_sqlite3_malloc>())(
       arg0,
     );
   }
@@ -1140,8 +1157,8 @@ class SQLite {
     int arg0,
   ) {
     return (_sqlite3_malloc64 ??=
-        _dylib.lookupFunction<_c_sqlite3_malloc64, _dart_sqlite3_malloc64>(
-            'sqlite3_malloc64'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_malloc64>>('sqlite3_malloc64')
+            .asFunction<_dart_sqlite3_malloc64>())(
       arg0,
     );
   }
@@ -1153,8 +1170,8 @@ class SQLite {
     int arg1,
   ) {
     return (_sqlite3_realloc ??=
-        _dylib.lookupFunction<_c_sqlite3_realloc, _dart_sqlite3_realloc>(
-            'sqlite3_realloc'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_realloc>>('sqlite3_realloc')
+            .asFunction<_dart_sqlite3_realloc>())(
       arg0,
       arg1,
     );
@@ -1167,8 +1184,8 @@ class SQLite {
     int arg1,
   ) {
     return (_sqlite3_realloc64 ??=
-        _dylib.lookupFunction<_c_sqlite3_realloc64, _dart_sqlite3_realloc64>(
-            'sqlite3_realloc64'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_realloc64>>('sqlite3_realloc64')
+            .asFunction<_dart_sqlite3_realloc64>())(
       arg0,
       arg1,
     );
@@ -1179,8 +1196,9 @@ class SQLite {
   void sqlite3_free(
     ffi.Pointer<ffi.Void> arg0,
   ) {
-    return (_sqlite3_free ??= _dylib
-        .lookupFunction<_c_sqlite3_free, _dart_sqlite3_free>('sqlite3_free'))(
+    return (_sqlite3_free ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_free>>('sqlite3_free')
+            .asFunction<_dart_sqlite3_free>())(
       arg0,
     );
   }
@@ -1191,8 +1209,8 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg0,
   ) {
     return (_sqlite3_msize ??=
-        _dylib.lookupFunction<_c_sqlite3_msize, _dart_sqlite3_msize>(
-            'sqlite3_msize'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_msize>>('sqlite3_msize')
+            .asFunction<_dart_sqlite3_msize>())(
       arg0,
     );
   }
@@ -1221,9 +1239,10 @@ class SQLite {
   /// by [sqlite3_memory_highwater(1)] is the high-water mark
   /// prior to the reset.
   int sqlite3_memory_used() {
-    return (_sqlite3_memory_used ??= _dylib.lookupFunction<
-        _c_sqlite3_memory_used,
-        _dart_sqlite3_memory_used>('sqlite3_memory_used'))();
+    return (_sqlite3_memory_used ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_memory_used>>(
+                'sqlite3_memory_used')
+            .asFunction<_dart_sqlite3_memory_used>())();
   }
 
   _dart_sqlite3_memory_used? _sqlite3_memory_used;
@@ -1231,9 +1250,10 @@ class SQLite {
   int sqlite3_memory_highwater(
     int resetFlag,
   ) {
-    return (_sqlite3_memory_highwater ??= _dylib.lookupFunction<
-        _c_sqlite3_memory_highwater,
-        _dart_sqlite3_memory_highwater>('sqlite3_memory_highwater'))(
+    return (_sqlite3_memory_highwater ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_memory_highwater>>(
+                'sqlite3_memory_highwater')
+            .asFunction<_dart_sqlite3_memory_highwater>())(
       resetFlag,
     );
   }
@@ -1264,8 +1284,8 @@ class SQLite {
     ffi.Pointer<ffi.Void> P,
   ) {
     return (_sqlite3_randomness ??=
-        _dylib.lookupFunction<_c_sqlite3_randomness, _dart_sqlite3_randomness>(
-            'sqlite3_randomness'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_randomness>>('sqlite3_randomness')
+            .asFunction<_dart_sqlite3_randomness>())(
       N,
       P,
     );
@@ -1365,9 +1385,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_21>> xAuth,
     ffi.Pointer<ffi.Void> pUserData,
   ) {
-    return (_sqlite3_set_authorizer ??= _dylib.lookupFunction<
-        _c_sqlite3_set_authorizer,
-        _dart_sqlite3_set_authorizer>('sqlite3_set_authorizer'))(
+    return (_sqlite3_set_authorizer ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_set_authorizer>>(
+                'sqlite3_set_authorizer')
+            .asFunction<_dart_sqlite3_set_authorizer>())(
       arg0,
       xAuth,
       pUserData,
@@ -1412,8 +1433,8 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg2,
   ) {
     return (_sqlite3_trace ??=
-        _dylib.lookupFunction<_c_sqlite3_trace, _dart_sqlite3_trace>(
-            'sqlite3_trace'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_trace>>('sqlite3_trace')
+            .asFunction<_dart_sqlite3_trace>())(
       arg0,
       xTrace,
       arg2,
@@ -1428,8 +1449,8 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg2,
   ) {
     return (_sqlite3_profile ??=
-        _dylib.lookupFunction<_c_sqlite3_profile, _dart_sqlite3_profile>(
-            'sqlite3_profile'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_profile>>('sqlite3_profile')
+            .asFunction<_dart_sqlite3_profile>())(
       arg0,
       xProfile,
       arg2,
@@ -1472,8 +1493,8 @@ class SQLite {
     ffi.Pointer<ffi.Void> pCtx,
   ) {
     return (_sqlite3_trace_v2 ??=
-        _dylib.lookupFunction<_c_sqlite3_trace_v2, _dart_sqlite3_trace_v2>(
-            'sqlite3_trace_v2'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_trace_v2>>('sqlite3_trace_v2')
+            .asFunction<_dart_sqlite3_trace_v2>())(
       arg0,
       uMask,
       xCallback,
@@ -1518,9 +1539,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_25>> arg2,
     ffi.Pointer<ffi.Void> arg3,
   ) {
-    return (_sqlite3_progress_handler ??= _dylib.lookupFunction<
-        _c_sqlite3_progress_handler,
-        _dart_sqlite3_progress_handler>('sqlite3_progress_handler'))(
+    return (_sqlite3_progress_handler ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_progress_handler>>(
+                'sqlite3_progress_handler')
+            .asFunction<_dart_sqlite3_progress_handler>())(
       arg0,
       arg1,
       arg2,
@@ -1785,8 +1807,9 @@ class SQLite {
     ffi.Pointer<ffi.Int8> filename,
     ffi.Pointer<ffi.Pointer<sqlite3>> ppDb,
   ) {
-    return (_sqlite3_open ??= _dylib
-        .lookupFunction<_c_sqlite3_open, _dart_sqlite3_open>('sqlite3_open'))(
+    return (_sqlite3_open ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_open>>('sqlite3_open')
+            .asFunction<_dart_sqlite3_open>())(
       filename,
       ppDb,
     );
@@ -1799,8 +1822,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<sqlite3>> ppDb,
   ) {
     return (_sqlite3_open16 ??=
-        _dylib.lookupFunction<_c_sqlite3_open16, _dart_sqlite3_open16>(
-            'sqlite3_open16'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_open16>>('sqlite3_open16')
+            .asFunction<_dart_sqlite3_open16>())(
       filename,
       ppDb,
     );
@@ -1815,8 +1838,8 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zVfs,
   ) {
     return (_sqlite3_open_v2 ??=
-        _dylib.lookupFunction<_c_sqlite3_open_v2, _dart_sqlite3_open_v2>(
-            'sqlite3_open_v2'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_open_v2>>('sqlite3_open_v2')
+            .asFunction<_dart_sqlite3_open_v2>())(
       filename,
       ppDb,
       flags,
@@ -1894,9 +1917,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zFilename,
     ffi.Pointer<ffi.Int8> zParam,
   ) {
-    return (_sqlite3_uri_parameter ??= _dylib.lookupFunction<
-        _c_sqlite3_uri_parameter,
-        _dart_sqlite3_uri_parameter>('sqlite3_uri_parameter'))(
+    return (_sqlite3_uri_parameter ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_uri_parameter>>(
+                'sqlite3_uri_parameter')
+            .asFunction<_dart_sqlite3_uri_parameter>())(
       zFilename,
       zParam,
     );
@@ -1909,9 +1933,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zParam,
     int bDefault,
   ) {
-    return (_sqlite3_uri_boolean ??= _dylib.lookupFunction<
-        _c_sqlite3_uri_boolean,
-        _dart_sqlite3_uri_boolean>('sqlite3_uri_boolean'))(
+    return (_sqlite3_uri_boolean ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_uri_boolean>>(
+                'sqlite3_uri_boolean')
+            .asFunction<_dart_sqlite3_uri_boolean>())(
       zFile,
       zParam,
       bDefault,
@@ -1926,8 +1951,8 @@ class SQLite {
     int arg2,
   ) {
     return (_sqlite3_uri_int64 ??=
-        _dylib.lookupFunction<_c_sqlite3_uri_int64, _dart_sqlite3_uri_int64>(
-            'sqlite3_uri_int64'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_uri_int64>>('sqlite3_uri_int64')
+            .asFunction<_dart_sqlite3_uri_int64>())(
       arg0,
       arg1,
       arg2,
@@ -1941,8 +1966,8 @@ class SQLite {
     int N,
   ) {
     return (_sqlite3_uri_key ??=
-        _dylib.lookupFunction<_c_sqlite3_uri_key, _dart_sqlite3_uri_key>(
-            'sqlite3_uri_key'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_uri_key>>('sqlite3_uri_key')
+            .asFunction<_dart_sqlite3_uri_key>())(
       zFilename,
       N,
     );
@@ -1978,9 +2003,10 @@ class SQLite {
   ffi.Pointer<ffi.Int8> sqlite3_filename_database(
     ffi.Pointer<ffi.Int8> arg0,
   ) {
-    return (_sqlite3_filename_database ??= _dylib.lookupFunction<
-        _c_sqlite3_filename_database,
-        _dart_sqlite3_filename_database>('sqlite3_filename_database'))(
+    return (_sqlite3_filename_database ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_filename_database>>(
+                'sqlite3_filename_database')
+            .asFunction<_dart_sqlite3_filename_database>())(
       arg0,
     );
   }
@@ -1990,9 +2016,10 @@ class SQLite {
   ffi.Pointer<ffi.Int8> sqlite3_filename_journal(
     ffi.Pointer<ffi.Int8> arg0,
   ) {
-    return (_sqlite3_filename_journal ??= _dylib.lookupFunction<
-        _c_sqlite3_filename_journal,
-        _dart_sqlite3_filename_journal>('sqlite3_filename_journal'))(
+    return (_sqlite3_filename_journal ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_filename_journal>>(
+                'sqlite3_filename_journal')
+            .asFunction<_dart_sqlite3_filename_journal>())(
       arg0,
     );
   }
@@ -2002,9 +2029,10 @@ class SQLite {
   ffi.Pointer<ffi.Int8> sqlite3_filename_wal(
     ffi.Pointer<ffi.Int8> arg0,
   ) {
-    return (_sqlite3_filename_wal ??= _dylib.lookupFunction<
-        _c_sqlite3_filename_wal,
-        _dart_sqlite3_filename_wal>('sqlite3_filename_wal'))(
+    return (_sqlite3_filename_wal ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_filename_wal>>(
+                'sqlite3_filename_wal')
+            .asFunction<_dart_sqlite3_filename_wal>())(
       arg0,
     );
   }
@@ -2029,9 +2057,10 @@ class SQLite {
   ffi.Pointer<sqlite3_file> sqlite3_database_file_object(
     ffi.Pointer<ffi.Int8> arg0,
   ) {
-    return (_sqlite3_database_file_object ??= _dylib.lookupFunction<
-        _c_sqlite3_database_file_object,
-        _dart_sqlite3_database_file_object>('sqlite3_database_file_object'))(
+    return (_sqlite3_database_file_object ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_database_file_object>>(
+                'sqlite3_database_file_object')
+            .asFunction<_dart_sqlite3_database_file_object>())(
       arg0,
     );
   }
@@ -2088,9 +2117,10 @@ class SQLite {
     int nParam,
     ffi.Pointer<ffi.Pointer<ffi.Int8>> azParam,
   ) {
-    return (_sqlite3_create_filename ??= _dylib.lookupFunction<
-        _c_sqlite3_create_filename,
-        _dart_sqlite3_create_filename>('sqlite3_create_filename'))(
+    return (_sqlite3_create_filename ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_filename>>(
+                'sqlite3_create_filename')
+            .asFunction<_dart_sqlite3_create_filename>())(
       zDatabase,
       zJournal,
       zWal,
@@ -2104,9 +2134,10 @@ class SQLite {
   void sqlite3_free_filename(
     ffi.Pointer<ffi.Int8> arg0,
   ) {
-    return (_sqlite3_free_filename ??= _dylib.lookupFunction<
-        _c_sqlite3_free_filename,
-        _dart_sqlite3_free_filename>('sqlite3_free_filename'))(
+    return (_sqlite3_free_filename ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_free_filename>>(
+                'sqlite3_free_filename')
+            .asFunction<_dart_sqlite3_free_filename>())(
       arg0,
     );
   }
@@ -2167,8 +2198,8 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
   ) {
     return (_sqlite3_errcode ??=
-        _dylib.lookupFunction<_c_sqlite3_errcode, _dart_sqlite3_errcode>(
-            'sqlite3_errcode'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_errcode>>('sqlite3_errcode')
+            .asFunction<_dart_sqlite3_errcode>())(
       db,
     );
   }
@@ -2178,9 +2209,10 @@ class SQLite {
   int sqlite3_extended_errcode(
     ffi.Pointer<sqlite3> db,
   ) {
-    return (_sqlite3_extended_errcode ??= _dylib.lookupFunction<
-        _c_sqlite3_extended_errcode,
-        _dart_sqlite3_extended_errcode>('sqlite3_extended_errcode'))(
+    return (_sqlite3_extended_errcode ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_extended_errcode>>(
+                'sqlite3_extended_errcode')
+            .asFunction<_dart_sqlite3_extended_errcode>())(
       db,
     );
   }
@@ -2191,8 +2223,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_errmsg ??=
-        _dylib.lookupFunction<_c_sqlite3_errmsg, _dart_sqlite3_errmsg>(
-            'sqlite3_errmsg'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_errmsg>>('sqlite3_errmsg')
+            .asFunction<_dart_sqlite3_errmsg>())(
       arg0,
     );
   }
@@ -2203,8 +2235,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_errmsg16 ??=
-        _dylib.lookupFunction<_c_sqlite3_errmsg16, _dart_sqlite3_errmsg16>(
-            'sqlite3_errmsg16'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_errmsg16>>('sqlite3_errmsg16')
+            .asFunction<_dart_sqlite3_errmsg16>())(
       arg0,
     );
   }
@@ -2215,8 +2247,8 @@ class SQLite {
     int arg0,
   ) {
     return (_sqlite3_errstr ??=
-        _dylib.lookupFunction<_c_sqlite3_errstr, _dart_sqlite3_errstr>(
-            'sqlite3_errstr'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_errstr>>('sqlite3_errstr')
+            .asFunction<_dart_sqlite3_errstr>())(
       arg0,
     );
   }
@@ -2267,8 +2299,8 @@ class SQLite {
     int newVal,
   ) {
     return (_sqlite3_limit ??=
-        _dylib.lookupFunction<_c_sqlite3_limit, _dart_sqlite3_limit>(
-            'sqlite3_limit'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_limit>>('sqlite3_limit')
+            .asFunction<_dart_sqlite3_limit>())(
       arg0,
       id,
       newVal,
@@ -2383,8 +2415,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> pzTail,
   ) {
     return (_sqlite3_prepare ??=
-        _dylib.lookupFunction<_c_sqlite3_prepare, _dart_sqlite3_prepare>(
-            'sqlite3_prepare'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_prepare>>('sqlite3_prepare')
+            .asFunction<_dart_sqlite3_prepare>())(
       db,
       zSql,
       nByte,
@@ -2403,8 +2435,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> pzTail,
   ) {
     return (_sqlite3_prepare_v2 ??=
-        _dylib.lookupFunction<_c_sqlite3_prepare_v2, _dart_sqlite3_prepare_v2>(
-            'sqlite3_prepare_v2'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_prepare_v2>>('sqlite3_prepare_v2')
+            .asFunction<_dart_sqlite3_prepare_v2>())(
       db,
       zSql,
       nByte,
@@ -2424,8 +2456,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> pzTail,
   ) {
     return (_sqlite3_prepare_v3 ??=
-        _dylib.lookupFunction<_c_sqlite3_prepare_v3, _dart_sqlite3_prepare_v3>(
-            'sqlite3_prepare_v3'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_prepare_v3>>('sqlite3_prepare_v3')
+            .asFunction<_dart_sqlite3_prepare_v3>())(
       db,
       zSql,
       nByte,
@@ -2445,8 +2477,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<ffi.Void>> pzTail,
   ) {
     return (_sqlite3_prepare16 ??=
-        _dylib.lookupFunction<_c_sqlite3_prepare16, _dart_sqlite3_prepare16>(
-            'sqlite3_prepare16'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_prepare16>>('sqlite3_prepare16')
+            .asFunction<_dart_sqlite3_prepare16>())(
       db,
       zSql,
       nByte,
@@ -2464,9 +2496,10 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<sqlite3_stmt>> ppStmt,
     ffi.Pointer<ffi.Pointer<ffi.Void>> pzTail,
   ) {
-    return (_sqlite3_prepare16_v2 ??= _dylib.lookupFunction<
-        _c_sqlite3_prepare16_v2,
-        _dart_sqlite3_prepare16_v2>('sqlite3_prepare16_v2'))(
+    return (_sqlite3_prepare16_v2 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_prepare16_v2>>(
+                'sqlite3_prepare16_v2')
+            .asFunction<_dart_sqlite3_prepare16_v2>())(
       db,
       zSql,
       nByte,
@@ -2485,9 +2518,10 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<sqlite3_stmt>> ppStmt,
     ffi.Pointer<ffi.Pointer<ffi.Void>> pzTail,
   ) {
-    return (_sqlite3_prepare16_v3 ??= _dylib.lookupFunction<
-        _c_sqlite3_prepare16_v3,
-        _dart_sqlite3_prepare16_v3>('sqlite3_prepare16_v3'))(
+    return (_sqlite3_prepare16_v3 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_prepare16_v3>>(
+                'sqlite3_prepare16_v3')
+            .asFunction<_dart_sqlite3_prepare16_v3>())(
       db,
       zSql,
       nByte,
@@ -2538,8 +2572,9 @@ class SQLite {
   ffi.Pointer<ffi.Int8> sqlite3_sql(
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
-    return (_sqlite3_sql ??= _dylib
-        .lookupFunction<_c_sqlite3_sql, _dart_sqlite3_sql>('sqlite3_sql'))(
+    return (_sqlite3_sql ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_sql>>('sqlite3_sql')
+            .asFunction<_dart_sqlite3_sql>())(
       pStmt,
     );
   }
@@ -2549,9 +2584,10 @@ class SQLite {
   ffi.Pointer<ffi.Int8> sqlite3_expanded_sql(
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
-    return (_sqlite3_expanded_sql ??= _dylib.lookupFunction<
-        _c_sqlite3_expanded_sql,
-        _dart_sqlite3_expanded_sql>('sqlite3_expanded_sql'))(
+    return (_sqlite3_expanded_sql ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_expanded_sql>>(
+                'sqlite3_expanded_sql')
+            .asFunction<_dart_sqlite3_expanded_sql>())(
       pStmt,
     );
   }
@@ -2561,9 +2597,10 @@ class SQLite {
   ffi.Pointer<ffi.Int8> sqlite3_normalized_sql(
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
-    return (_sqlite3_normalized_sql ??= _dylib.lookupFunction<
-        _c_sqlite3_normalized_sql,
-        _dart_sqlite3_normalized_sql>('sqlite3_normalized_sql'))(
+    return (_sqlite3_normalized_sql ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_normalized_sql>>(
+                'sqlite3_normalized_sql')
+            .asFunction<_dart_sqlite3_normalized_sql>())(
       pStmt,
     );
   }
@@ -2605,9 +2642,10 @@ class SQLite {
   int sqlite3_stmt_readonly(
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
-    return (_sqlite3_stmt_readonly ??= _dylib.lookupFunction<
-        _c_sqlite3_stmt_readonly,
-        _dart_sqlite3_stmt_readonly>('sqlite3_stmt_readonly'))(
+    return (_sqlite3_stmt_readonly ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_stmt_readonly>>(
+                'sqlite3_stmt_readonly')
+            .asFunction<_dart_sqlite3_stmt_readonly>())(
       pStmt,
     );
   }
@@ -2625,9 +2663,10 @@ class SQLite {
   int sqlite3_stmt_isexplain(
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
-    return (_sqlite3_stmt_isexplain ??= _dylib.lookupFunction<
-        _c_sqlite3_stmt_isexplain,
-        _dart_sqlite3_stmt_isexplain>('sqlite3_stmt_isexplain'))(
+    return (_sqlite3_stmt_isexplain ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_stmt_isexplain>>(
+                'sqlite3_stmt_isexplain')
+            .asFunction<_dart_sqlite3_stmt_isexplain>())(
       pStmt,
     );
   }
@@ -2655,8 +2694,8 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
   ) {
     return (_sqlite3_stmt_busy ??=
-        _dylib.lookupFunction<_c_sqlite3_stmt_busy, _dart_sqlite3_stmt_busy>(
-            'sqlite3_stmt_busy'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_stmt_busy>>('sqlite3_stmt_busy')
+            .asFunction<_dart_sqlite3_stmt_busy>())(
       arg0,
     );
   }
@@ -2805,8 +2844,8 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_26>> arg4,
   ) {
     return (_sqlite3_bind_blob ??=
-        _dylib.lookupFunction<_c_sqlite3_bind_blob, _dart_sqlite3_bind_blob>(
-            'sqlite3_bind_blob'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_blob>>('sqlite3_bind_blob')
+            .asFunction<_dart_sqlite3_bind_blob>())(
       arg0,
       arg1,
       arg2,
@@ -2824,9 +2863,10 @@ class SQLite {
     int arg3,
     ffi.Pointer<ffi.NativeFunction<_typedefC_27>> arg4,
   ) {
-    return (_sqlite3_bind_blob64 ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_blob64,
-        _dart_sqlite3_bind_blob64>('sqlite3_bind_blob64'))(
+    return (_sqlite3_bind_blob64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_blob64>>(
+                'sqlite3_bind_blob64')
+            .asFunction<_dart_sqlite3_bind_blob64>())(
       arg0,
       arg1,
       arg2,
@@ -2842,9 +2882,10 @@ class SQLite {
     int arg1,
     double arg2,
   ) {
-    return (_sqlite3_bind_double ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_double,
-        _dart_sqlite3_bind_double>('sqlite3_bind_double'))(
+    return (_sqlite3_bind_double ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_double>>(
+                'sqlite3_bind_double')
+            .asFunction<_dart_sqlite3_bind_double>())(
       arg0,
       arg1,
       arg2,
@@ -2859,8 +2900,8 @@ class SQLite {
     int arg2,
   ) {
     return (_sqlite3_bind_int ??=
-        _dylib.lookupFunction<_c_sqlite3_bind_int, _dart_sqlite3_bind_int>(
-            'sqlite3_bind_int'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_int>>('sqlite3_bind_int')
+            .asFunction<_dart_sqlite3_bind_int>())(
       arg0,
       arg1,
       arg2,
@@ -2875,8 +2916,8 @@ class SQLite {
     int arg2,
   ) {
     return (_sqlite3_bind_int64 ??=
-        _dylib.lookupFunction<_c_sqlite3_bind_int64, _dart_sqlite3_bind_int64>(
-            'sqlite3_bind_int64'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_int64>>('sqlite3_bind_int64')
+            .asFunction<_dart_sqlite3_bind_int64>())(
       arg0,
       arg1,
       arg2,
@@ -2890,8 +2931,8 @@ class SQLite {
     int arg1,
   ) {
     return (_sqlite3_bind_null ??=
-        _dylib.lookupFunction<_c_sqlite3_bind_null, _dart_sqlite3_bind_null>(
-            'sqlite3_bind_null'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_null>>('sqlite3_bind_null')
+            .asFunction<_dart_sqlite3_bind_null>())(
       arg0,
       arg1,
     );
@@ -2907,8 +2948,8 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_28>> arg4,
   ) {
     return (_sqlite3_bind_text ??=
-        _dylib.lookupFunction<_c_sqlite3_bind_text, _dart_sqlite3_bind_text>(
-            'sqlite3_bind_text'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_text>>('sqlite3_bind_text')
+            .asFunction<_dart_sqlite3_bind_text>())(
       arg0,
       arg1,
       arg2,
@@ -2926,9 +2967,10 @@ class SQLite {
     int arg3,
     ffi.Pointer<ffi.NativeFunction<_typedefC_29>> arg4,
   ) {
-    return (_sqlite3_bind_text16 ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_text16,
-        _dart_sqlite3_bind_text16>('sqlite3_bind_text16'))(
+    return (_sqlite3_bind_text16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_text16>>(
+                'sqlite3_bind_text16')
+            .asFunction<_dart_sqlite3_bind_text16>())(
       arg0,
       arg1,
       arg2,
@@ -2947,9 +2989,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_30>> arg4,
     int encoding,
   ) {
-    return (_sqlite3_bind_text64 ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_text64,
-        _dart_sqlite3_bind_text64>('sqlite3_bind_text64'))(
+    return (_sqlite3_bind_text64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_text64>>(
+                'sqlite3_bind_text64')
+            .asFunction<_dart_sqlite3_bind_text64>())(
       arg0,
       arg1,
       arg2,
@@ -2967,8 +3010,8 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg2,
   ) {
     return (_sqlite3_bind_value ??=
-        _dylib.lookupFunction<_c_sqlite3_bind_value, _dart_sqlite3_bind_value>(
-            'sqlite3_bind_value'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_value>>('sqlite3_bind_value')
+            .asFunction<_dart_sqlite3_bind_value>())(
       arg0,
       arg1,
       arg2,
@@ -2984,9 +3027,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> arg3,
     ffi.Pointer<ffi.NativeFunction<_typedefC_31>> arg4,
   ) {
-    return (_sqlite3_bind_pointer ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_pointer,
-        _dart_sqlite3_bind_pointer>('sqlite3_bind_pointer'))(
+    return (_sqlite3_bind_pointer ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_pointer>>(
+                'sqlite3_bind_pointer')
+            .asFunction<_dart_sqlite3_bind_pointer>())(
       arg0,
       arg1,
       arg2,
@@ -3002,9 +3046,10 @@ class SQLite {
     int arg1,
     int n,
   ) {
-    return (_sqlite3_bind_zeroblob ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_zeroblob,
-        _dart_sqlite3_bind_zeroblob>('sqlite3_bind_zeroblob'))(
+    return (_sqlite3_bind_zeroblob ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_zeroblob>>(
+                'sqlite3_bind_zeroblob')
+            .asFunction<_dart_sqlite3_bind_zeroblob>())(
       arg0,
       arg1,
       n,
@@ -3018,9 +3063,10 @@ class SQLite {
     int arg1,
     int arg2,
   ) {
-    return (_sqlite3_bind_zeroblob64 ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_zeroblob64,
-        _dart_sqlite3_bind_zeroblob64>('sqlite3_bind_zeroblob64'))(
+    return (_sqlite3_bind_zeroblob64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_zeroblob64>>(
+                'sqlite3_bind_zeroblob64')
+            .asFunction<_dart_sqlite3_bind_zeroblob64>())(
       arg0,
       arg1,
       arg2,
@@ -3049,9 +3095,10 @@ class SQLite {
   int sqlite3_bind_parameter_count(
     ffi.Pointer<sqlite3_stmt> arg0,
   ) {
-    return (_sqlite3_bind_parameter_count ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_parameter_count,
-        _dart_sqlite3_bind_parameter_count>('sqlite3_bind_parameter_count'))(
+    return (_sqlite3_bind_parameter_count ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_parameter_count>>(
+                'sqlite3_bind_parameter_count')
+            .asFunction<_dart_sqlite3_bind_parameter_count>())(
       arg0,
     );
   }
@@ -3086,9 +3133,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_bind_parameter_name ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_parameter_name,
-        _dart_sqlite3_bind_parameter_name>('sqlite3_bind_parameter_name'))(
+    return (_sqlite3_bind_parameter_name ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_parameter_name>>(
+                'sqlite3_bind_parameter_name')
+            .asFunction<_dart_sqlite3_bind_parameter_name>())(
       arg0,
       arg1,
     );
@@ -3114,9 +3162,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     ffi.Pointer<ffi.Int8> zName,
   ) {
-    return (_sqlite3_bind_parameter_index ??= _dylib.lookupFunction<
-        _c_sqlite3_bind_parameter_index,
-        _dart_sqlite3_bind_parameter_index>('sqlite3_bind_parameter_index'))(
+    return (_sqlite3_bind_parameter_index ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_bind_parameter_index>>(
+                'sqlite3_bind_parameter_index')
+            .asFunction<_dart_sqlite3_bind_parameter_index>())(
       arg0,
       zName,
     );
@@ -3133,9 +3182,10 @@ class SQLite {
   int sqlite3_clear_bindings(
     ffi.Pointer<sqlite3_stmt> arg0,
   ) {
-    return (_sqlite3_clear_bindings ??= _dylib.lookupFunction<
-        _c_sqlite3_clear_bindings,
-        _dart_sqlite3_clear_bindings>('sqlite3_clear_bindings'))(
+    return (_sqlite3_clear_bindings ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_clear_bindings>>(
+                'sqlite3_clear_bindings')
+            .asFunction<_dart_sqlite3_clear_bindings>())(
       arg0,
     );
   }
@@ -3157,9 +3207,10 @@ class SQLite {
   int sqlite3_column_count(
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
-    return (_sqlite3_column_count ??= _dylib.lookupFunction<
-        _c_sqlite3_column_count,
-        _dart_sqlite3_column_count>('sqlite3_column_count'))(
+    return (_sqlite3_column_count ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_count>>(
+                'sqlite3_column_count')
+            .asFunction<_dart_sqlite3_column_count>())(
       pStmt,
     );
   }
@@ -3195,9 +3246,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int N,
   ) {
-    return (_sqlite3_column_name ??= _dylib.lookupFunction<
-        _c_sqlite3_column_name,
-        _dart_sqlite3_column_name>('sqlite3_column_name'))(
+    return (_sqlite3_column_name ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_name>>(
+                'sqlite3_column_name')
+            .asFunction<_dart_sqlite3_column_name>())(
       arg0,
       N,
     );
@@ -3209,9 +3261,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int N,
   ) {
-    return (_sqlite3_column_name16 ??= _dylib.lookupFunction<
-        _c_sqlite3_column_name16,
-        _dart_sqlite3_column_name16>('sqlite3_column_name16'))(
+    return (_sqlite3_column_name16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_name16>>(
+                'sqlite3_column_name16')
+            .asFunction<_dart_sqlite3_column_name16>())(
       arg0,
       N,
     );
@@ -3263,9 +3316,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_database_name ??= _dylib.lookupFunction<
-        _c_sqlite3_column_database_name,
-        _dart_sqlite3_column_database_name>('sqlite3_column_database_name'))(
+    return (_sqlite3_column_database_name ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_database_name>>(
+                'sqlite3_column_database_name')
+            .asFunction<_dart_sqlite3_column_database_name>())(
       arg0,
       arg1,
     );
@@ -3277,10 +3331,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_database_name16 ??= _dylib.lookupFunction<
-            _c_sqlite3_column_database_name16,
-            _dart_sqlite3_column_database_name16>(
-        'sqlite3_column_database_name16'))(
+    return (_sqlite3_column_database_name16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_database_name16>>(
+                'sqlite3_column_database_name16')
+            .asFunction<_dart_sqlite3_column_database_name16>())(
       arg0,
       arg1,
     );
@@ -3292,9 +3346,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_table_name ??= _dylib.lookupFunction<
-        _c_sqlite3_column_table_name,
-        _dart_sqlite3_column_table_name>('sqlite3_column_table_name'))(
+    return (_sqlite3_column_table_name ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_table_name>>(
+                'sqlite3_column_table_name')
+            .asFunction<_dart_sqlite3_column_table_name>())(
       arg0,
       arg1,
     );
@@ -3306,9 +3361,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_table_name16 ??= _dylib.lookupFunction<
-        _c_sqlite3_column_table_name16,
-        _dart_sqlite3_column_table_name16>('sqlite3_column_table_name16'))(
+    return (_sqlite3_column_table_name16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_table_name16>>(
+                'sqlite3_column_table_name16')
+            .asFunction<_dart_sqlite3_column_table_name16>())(
       arg0,
       arg1,
     );
@@ -3320,9 +3376,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_origin_name ??= _dylib.lookupFunction<
-        _c_sqlite3_column_origin_name,
-        _dart_sqlite3_column_origin_name>('sqlite3_column_origin_name'))(
+    return (_sqlite3_column_origin_name ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_origin_name>>(
+                'sqlite3_column_origin_name')
+            .asFunction<_dart_sqlite3_column_origin_name>())(
       arg0,
       arg1,
     );
@@ -3334,9 +3391,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_origin_name16 ??= _dylib.lookupFunction<
-        _c_sqlite3_column_origin_name16,
-        _dart_sqlite3_column_origin_name16>('sqlite3_column_origin_name16'))(
+    return (_sqlite3_column_origin_name16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_origin_name16>>(
+                'sqlite3_column_origin_name16')
+            .asFunction<_dart_sqlite3_column_origin_name16>())(
       arg0,
       arg1,
     );
@@ -3376,9 +3434,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_decltype ??= _dylib.lookupFunction<
-        _c_sqlite3_column_decltype,
-        _dart_sqlite3_column_decltype>('sqlite3_column_decltype'))(
+    return (_sqlite3_column_decltype ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_decltype>>(
+                'sqlite3_column_decltype')
+            .asFunction<_dart_sqlite3_column_decltype>())(
       arg0,
       arg1,
     );
@@ -3390,9 +3449,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int arg1,
   ) {
-    return (_sqlite3_column_decltype16 ??= _dylib.lookupFunction<
-        _c_sqlite3_column_decltype16,
-        _dart_sqlite3_column_decltype16>('sqlite3_column_decltype16'))(
+    return (_sqlite3_column_decltype16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_decltype16>>(
+                'sqlite3_column_decltype16')
+            .asFunction<_dart_sqlite3_column_decltype16>())(
       arg0,
       arg1,
     );
@@ -3483,8 +3543,9 @@ class SQLite {
   int sqlite3_step(
     ffi.Pointer<sqlite3_stmt> arg0,
   ) {
-    return (_sqlite3_step ??= _dylib
-        .lookupFunction<_c_sqlite3_step, _dart_sqlite3_step>('sqlite3_step'))(
+    return (_sqlite3_step ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_step>>('sqlite3_step')
+            .asFunction<_dart_sqlite3_step>())(
       arg0,
     );
   }
@@ -3512,8 +3573,8 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
     return (_sqlite3_data_count ??=
-        _dylib.lookupFunction<_c_sqlite3_data_count, _dart_sqlite3_data_count>(
-            'sqlite3_data_count'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_data_count>>('sqlite3_data_count')
+            .asFunction<_dart_sqlite3_data_count>())(
       pStmt,
     );
   }
@@ -3731,9 +3792,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_blob ??= _dylib.lookupFunction<
-        _c_sqlite3_column_blob,
-        _dart_sqlite3_column_blob>('sqlite3_column_blob'))(
+    return (_sqlite3_column_blob ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_blob>>(
+                'sqlite3_column_blob')
+            .asFunction<_dart_sqlite3_column_blob>())(
       arg0,
       iCol,
     );
@@ -3745,9 +3807,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_double ??= _dylib.lookupFunction<
-        _c_sqlite3_column_double,
-        _dart_sqlite3_column_double>('sqlite3_column_double'))(
+    return (_sqlite3_column_double ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_double>>(
+                'sqlite3_column_double')
+            .asFunction<_dart_sqlite3_column_double>())(
       arg0,
       iCol,
     );
@@ -3760,8 +3823,8 @@ class SQLite {
     int iCol,
   ) {
     return (_sqlite3_column_int ??=
-        _dylib.lookupFunction<_c_sqlite3_column_int, _dart_sqlite3_column_int>(
-            'sqlite3_column_int'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_int>>('sqlite3_column_int')
+            .asFunction<_dart_sqlite3_column_int>())(
       arg0,
       iCol,
     );
@@ -3773,9 +3836,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_int64 ??= _dylib.lookupFunction<
-        _c_sqlite3_column_int64,
-        _dart_sqlite3_column_int64>('sqlite3_column_int64'))(
+    return (_sqlite3_column_int64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_int64>>(
+                'sqlite3_column_int64')
+            .asFunction<_dart_sqlite3_column_int64>())(
       arg0,
       iCol,
     );
@@ -3787,9 +3851,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_text ??= _dylib.lookupFunction<
-        _c_sqlite3_column_text,
-        _dart_sqlite3_column_text>('sqlite3_column_text'))(
+    return (_sqlite3_column_text ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_text>>(
+                'sqlite3_column_text')
+            .asFunction<_dart_sqlite3_column_text>())(
       arg0,
       iCol,
     );
@@ -3801,9 +3866,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_text16 ??= _dylib.lookupFunction<
-        _c_sqlite3_column_text16,
-        _dart_sqlite3_column_text16>('sqlite3_column_text16'))(
+    return (_sqlite3_column_text16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_text16>>(
+                'sqlite3_column_text16')
+            .asFunction<_dart_sqlite3_column_text16>())(
       arg0,
       iCol,
     );
@@ -3815,9 +3881,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_value ??= _dylib.lookupFunction<
-        _c_sqlite3_column_value,
-        _dart_sqlite3_column_value>('sqlite3_column_value'))(
+    return (_sqlite3_column_value ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_value>>(
+                'sqlite3_column_value')
+            .asFunction<_dart_sqlite3_column_value>())(
       arg0,
       iCol,
     );
@@ -3829,9 +3896,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_bytes ??= _dylib.lookupFunction<
-        _c_sqlite3_column_bytes,
-        _dart_sqlite3_column_bytes>('sqlite3_column_bytes'))(
+    return (_sqlite3_column_bytes ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_bytes>>(
+                'sqlite3_column_bytes')
+            .asFunction<_dart_sqlite3_column_bytes>())(
       arg0,
       iCol,
     );
@@ -3843,9 +3911,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_bytes16 ??= _dylib.lookupFunction<
-        _c_sqlite3_column_bytes16,
-        _dart_sqlite3_column_bytes16>('sqlite3_column_bytes16'))(
+    return (_sqlite3_column_bytes16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_bytes16>>(
+                'sqlite3_column_bytes16')
+            .asFunction<_dart_sqlite3_column_bytes16>())(
       arg0,
       iCol,
     );
@@ -3857,9 +3926,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     int iCol,
   ) {
-    return (_sqlite3_column_type ??= _dylib.lookupFunction<
-        _c_sqlite3_column_type,
-        _dart_sqlite3_column_type>('sqlite3_column_type'))(
+    return (_sqlite3_column_type ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_column_type>>(
+                'sqlite3_column_type')
+            .asFunction<_dart_sqlite3_column_type>())(
       arg0,
       iCol,
     );
@@ -3895,8 +3965,8 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
     return (_sqlite3_finalize ??=
-        _dylib.lookupFunction<_c_sqlite3_finalize, _dart_sqlite3_finalize>(
-            'sqlite3_finalize'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_finalize>>('sqlite3_finalize')
+            .asFunction<_dart_sqlite3_finalize>())(
       pStmt,
     );
   }
@@ -3930,8 +4000,8 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
     return (_sqlite3_reset ??=
-        _dylib.lookupFunction<_c_sqlite3_reset, _dart_sqlite3_reset>(
-            'sqlite3_reset'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_reset>>('sqlite3_reset')
+            .asFunction<_dart_sqlite3_reset>())(
       pStmt,
     );
   }
@@ -4071,9 +4141,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_33>> xStep,
     ffi.Pointer<ffi.NativeFunction<_typedefC_34>> xFinal,
   ) {
-    return (_sqlite3_create_function ??= _dylib.lookupFunction<
-        _c_sqlite3_create_function,
-        _dart_sqlite3_create_function>('sqlite3_create_function'))(
+    return (_sqlite3_create_function ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_function>>(
+                'sqlite3_create_function')
+            .asFunction<_dart_sqlite3_create_function>())(
       db,
       zFunctionName,
       nArg,
@@ -4097,9 +4168,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_36>> xStep,
     ffi.Pointer<ffi.NativeFunction<_typedefC_37>> xFinal,
   ) {
-    return (_sqlite3_create_function16 ??= _dylib.lookupFunction<
-        _c_sqlite3_create_function16,
-        _dart_sqlite3_create_function16>('sqlite3_create_function16'))(
+    return (_sqlite3_create_function16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_function16>>(
+                'sqlite3_create_function16')
+            .asFunction<_dart_sqlite3_create_function16>())(
       db,
       zFunctionName,
       nArg,
@@ -4124,9 +4196,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_40>> xFinal,
     ffi.Pointer<ffi.NativeFunction<_typedefC_41>> xDestroy,
   ) {
-    return (_sqlite3_create_function_v2 ??= _dylib.lookupFunction<
-        _c_sqlite3_create_function_v2,
-        _dart_sqlite3_create_function_v2>('sqlite3_create_function_v2'))(
+    return (_sqlite3_create_function_v2 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_function_v2>>(
+                'sqlite3_create_function_v2')
+            .asFunction<_dart_sqlite3_create_function_v2>())(
       db,
       zFunctionName,
       nArg,
@@ -4153,10 +4226,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_45>> xInverse,
     ffi.Pointer<ffi.NativeFunction<_typedefC_46>> xDestroy,
   ) {
-    return (_sqlite3_create_window_function ??= _dylib.lookupFunction<
-            _c_sqlite3_create_window_function,
-            _dart_sqlite3_create_window_function>(
-        'sqlite3_create_window_function'))(
+    return (_sqlite3_create_window_function ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_window_function>>(
+                'sqlite3_create_window_function')
+            .asFunction<_dart_sqlite3_create_window_function>())(
       db,
       zFunctionName,
       nArg,
@@ -4175,9 +4248,10 @@ class SQLite {
   int sqlite3_aggregate_count(
     ffi.Pointer<sqlite3_context> arg0,
   ) {
-    return (_sqlite3_aggregate_count ??= _dylib.lookupFunction<
-        _c_sqlite3_aggregate_count,
-        _dart_sqlite3_aggregate_count>('sqlite3_aggregate_count'))(
+    return (_sqlite3_aggregate_count ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_aggregate_count>>(
+                'sqlite3_aggregate_count')
+            .asFunction<_dart_sqlite3_aggregate_count>())(
       arg0,
     );
   }
@@ -4188,8 +4262,8 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
   ) {
     return (_sqlite3_expired ??=
-        _dylib.lookupFunction<_c_sqlite3_expired, _dart_sqlite3_expired>(
-            'sqlite3_expired'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_expired>>('sqlite3_expired')
+            .asFunction<_dart_sqlite3_expired>())(
       arg0,
     );
   }
@@ -4200,9 +4274,10 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
     ffi.Pointer<sqlite3_stmt> arg1,
   ) {
-    return (_sqlite3_transfer_bindings ??= _dylib.lookupFunction<
-        _c_sqlite3_transfer_bindings,
-        _dart_sqlite3_transfer_bindings>('sqlite3_transfer_bindings'))(
+    return (_sqlite3_transfer_bindings ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_transfer_bindings>>(
+                'sqlite3_transfer_bindings')
+            .asFunction<_dart_sqlite3_transfer_bindings>())(
       arg0,
       arg1,
     );
@@ -4211,17 +4286,19 @@ class SQLite {
   _dart_sqlite3_transfer_bindings? _sqlite3_transfer_bindings;
 
   int sqlite3_global_recover() {
-    return (_sqlite3_global_recover ??= _dylib.lookupFunction<
-        _c_sqlite3_global_recover,
-        _dart_sqlite3_global_recover>('sqlite3_global_recover'))();
+    return (_sqlite3_global_recover ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_global_recover>>(
+                'sqlite3_global_recover')
+            .asFunction<_dart_sqlite3_global_recover>())();
   }
 
   _dart_sqlite3_global_recover? _sqlite3_global_recover;
 
   void sqlite3_thread_cleanup() {
-    return (_sqlite3_thread_cleanup ??= _dylib.lookupFunction<
-        _c_sqlite3_thread_cleanup,
-        _dart_sqlite3_thread_cleanup>('sqlite3_thread_cleanup'))();
+    return (_sqlite3_thread_cleanup ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_thread_cleanup>>(
+                'sqlite3_thread_cleanup')
+            .asFunction<_dart_sqlite3_thread_cleanup>())();
   }
 
   _dart_sqlite3_thread_cleanup? _sqlite3_thread_cleanup;
@@ -4231,9 +4308,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg1,
     int arg2,
   ) {
-    return (_sqlite3_memory_alarm ??= _dylib.lookupFunction<
-        _c_sqlite3_memory_alarm,
-        _dart_sqlite3_memory_alarm>('sqlite3_memory_alarm'))(
+    return (_sqlite3_memory_alarm ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_memory_alarm>>(
+                'sqlite3_memory_alarm')
+            .asFunction<_dart_sqlite3_memory_alarm>())(
       arg0,
       arg1,
       arg2,
@@ -4372,8 +4450,8 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg0,
   ) {
     return (_sqlite3_value_blob ??=
-        _dylib.lookupFunction<_c_sqlite3_value_blob, _dart_sqlite3_value_blob>(
-            'sqlite3_value_blob'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_blob>>('sqlite3_value_blob')
+            .asFunction<_dart_sqlite3_value_blob>())(
       arg0,
     );
   }
@@ -4383,9 +4461,10 @@ class SQLite {
   double sqlite3_value_double(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_double ??= _dylib.lookupFunction<
-        _c_sqlite3_value_double,
-        _dart_sqlite3_value_double>('sqlite3_value_double'))(
+    return (_sqlite3_value_double ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_double>>(
+                'sqlite3_value_double')
+            .asFunction<_dart_sqlite3_value_double>())(
       arg0,
     );
   }
@@ -4396,8 +4475,8 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg0,
   ) {
     return (_sqlite3_value_int ??=
-        _dylib.lookupFunction<_c_sqlite3_value_int, _dart_sqlite3_value_int>(
-            'sqlite3_value_int'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_int>>('sqlite3_value_int')
+            .asFunction<_dart_sqlite3_value_int>())(
       arg0,
     );
   }
@@ -4407,9 +4486,10 @@ class SQLite {
   int sqlite3_value_int64(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_int64 ??= _dylib.lookupFunction<
-        _c_sqlite3_value_int64,
-        _dart_sqlite3_value_int64>('sqlite3_value_int64'))(
+    return (_sqlite3_value_int64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_int64>>(
+                'sqlite3_value_int64')
+            .asFunction<_dart_sqlite3_value_int64>())(
       arg0,
     );
   }
@@ -4420,9 +4500,10 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg0,
     ffi.Pointer<ffi.Int8> arg1,
   ) {
-    return (_sqlite3_value_pointer ??= _dylib.lookupFunction<
-        _c_sqlite3_value_pointer,
-        _dart_sqlite3_value_pointer>('sqlite3_value_pointer'))(
+    return (_sqlite3_value_pointer ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_pointer>>(
+                'sqlite3_value_pointer')
+            .asFunction<_dart_sqlite3_value_pointer>())(
       arg0,
       arg1,
     );
@@ -4434,8 +4515,8 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg0,
   ) {
     return (_sqlite3_value_text ??=
-        _dylib.lookupFunction<_c_sqlite3_value_text, _dart_sqlite3_value_text>(
-            'sqlite3_value_text'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_text>>('sqlite3_value_text')
+            .asFunction<_dart_sqlite3_value_text>())(
       arg0,
     );
   }
@@ -4445,9 +4526,10 @@ class SQLite {
   ffi.Pointer<ffi.Void> sqlite3_value_text16(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_text16 ??= _dylib.lookupFunction<
-        _c_sqlite3_value_text16,
-        _dart_sqlite3_value_text16>('sqlite3_value_text16'))(
+    return (_sqlite3_value_text16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_text16>>(
+                'sqlite3_value_text16')
+            .asFunction<_dart_sqlite3_value_text16>())(
       arg0,
     );
   }
@@ -4457,9 +4539,10 @@ class SQLite {
   ffi.Pointer<ffi.Void> sqlite3_value_text16le(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_text16le ??= _dylib.lookupFunction<
-        _c_sqlite3_value_text16le,
-        _dart_sqlite3_value_text16le>('sqlite3_value_text16le'))(
+    return (_sqlite3_value_text16le ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_text16le>>(
+                'sqlite3_value_text16le')
+            .asFunction<_dart_sqlite3_value_text16le>())(
       arg0,
     );
   }
@@ -4469,9 +4552,10 @@ class SQLite {
   ffi.Pointer<ffi.Void> sqlite3_value_text16be(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_text16be ??= _dylib.lookupFunction<
-        _c_sqlite3_value_text16be,
-        _dart_sqlite3_value_text16be>('sqlite3_value_text16be'))(
+    return (_sqlite3_value_text16be ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_text16be>>(
+                'sqlite3_value_text16be')
+            .asFunction<_dart_sqlite3_value_text16be>())(
       arg0,
     );
   }
@@ -4481,9 +4565,10 @@ class SQLite {
   int sqlite3_value_bytes(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_bytes ??= _dylib.lookupFunction<
-        _c_sqlite3_value_bytes,
-        _dart_sqlite3_value_bytes>('sqlite3_value_bytes'))(
+    return (_sqlite3_value_bytes ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_bytes>>(
+                'sqlite3_value_bytes')
+            .asFunction<_dart_sqlite3_value_bytes>())(
       arg0,
     );
   }
@@ -4493,9 +4578,10 @@ class SQLite {
   int sqlite3_value_bytes16(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_bytes16 ??= _dylib.lookupFunction<
-        _c_sqlite3_value_bytes16,
-        _dart_sqlite3_value_bytes16>('sqlite3_value_bytes16'))(
+    return (_sqlite3_value_bytes16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_bytes16>>(
+                'sqlite3_value_bytes16')
+            .asFunction<_dart_sqlite3_value_bytes16>())(
       arg0,
     );
   }
@@ -4506,8 +4592,8 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg0,
   ) {
     return (_sqlite3_value_type ??=
-        _dylib.lookupFunction<_c_sqlite3_value_type, _dart_sqlite3_value_type>(
-            'sqlite3_value_type'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_type>>('sqlite3_value_type')
+            .asFunction<_dart_sqlite3_value_type>())(
       arg0,
     );
   }
@@ -4517,9 +4603,10 @@ class SQLite {
   int sqlite3_value_numeric_type(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_numeric_type ??= _dylib.lookupFunction<
-        _c_sqlite3_value_numeric_type,
-        _dart_sqlite3_value_numeric_type>('sqlite3_value_numeric_type'))(
+    return (_sqlite3_value_numeric_type ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_numeric_type>>(
+                'sqlite3_value_numeric_type')
+            .asFunction<_dart_sqlite3_value_numeric_type>())(
       arg0,
     );
   }
@@ -4529,9 +4616,10 @@ class SQLite {
   int sqlite3_value_nochange(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_nochange ??= _dylib.lookupFunction<
-        _c_sqlite3_value_nochange,
-        _dart_sqlite3_value_nochange>('sqlite3_value_nochange'))(
+    return (_sqlite3_value_nochange ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_nochange>>(
+                'sqlite3_value_nochange')
+            .asFunction<_dart_sqlite3_value_nochange>())(
       arg0,
     );
   }
@@ -4541,9 +4629,10 @@ class SQLite {
   int sqlite3_value_frombind(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_frombind ??= _dylib.lookupFunction<
-        _c_sqlite3_value_frombind,
-        _dart_sqlite3_value_frombind>('sqlite3_value_frombind'))(
+    return (_sqlite3_value_frombind ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_frombind>>(
+                'sqlite3_value_frombind')
+            .asFunction<_dart_sqlite3_value_frombind>())(
       arg0,
     );
   }
@@ -4561,9 +4650,10 @@ class SQLite {
   int sqlite3_value_subtype(
     ffi.Pointer<sqlite3_value> arg0,
   ) {
-    return (_sqlite3_value_subtype ??= _dylib.lookupFunction<
-        _c_sqlite3_value_subtype,
-        _dart_sqlite3_value_subtype>('sqlite3_value_subtype'))(
+    return (_sqlite3_value_subtype ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_subtype>>(
+                'sqlite3_value_subtype')
+            .asFunction<_dart_sqlite3_value_subtype>())(
       arg0,
     );
   }
@@ -4586,8 +4676,8 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg0,
   ) {
     return (_sqlite3_value_dup ??=
-        _dylib.lookupFunction<_c_sqlite3_value_dup, _dart_sqlite3_value_dup>(
-            'sqlite3_value_dup'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_dup>>('sqlite3_value_dup')
+            .asFunction<_dart_sqlite3_value_dup>())(
       arg0,
     );
   }
@@ -4598,8 +4688,8 @@ class SQLite {
     ffi.Pointer<sqlite3_value> arg0,
   ) {
     return (_sqlite3_value_free ??=
-        _dylib.lookupFunction<_c_sqlite3_value_free, _dart_sqlite3_value_free>(
-            'sqlite3_value_free'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_value_free>>('sqlite3_value_free')
+            .asFunction<_dart_sqlite3_value_free>())(
       arg0,
     );
   }
@@ -4651,9 +4741,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     int nBytes,
   ) {
-    return (_sqlite3_aggregate_context ??= _dylib.lookupFunction<
-        _c_sqlite3_aggregate_context,
-        _dart_sqlite3_aggregate_context>('sqlite3_aggregate_context'))(
+    return (_sqlite3_aggregate_context ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_aggregate_context>>(
+                'sqlite3_aggregate_context')
+            .asFunction<_dart_sqlite3_aggregate_context>())(
       arg0,
       nBytes,
     );
@@ -4676,8 +4767,8 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
   ) {
     return (_sqlite3_user_data ??=
-        _dylib.lookupFunction<_c_sqlite3_user_data, _dart_sqlite3_user_data>(
-            'sqlite3_user_data'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_user_data>>('sqlite3_user_data')
+            .asFunction<_dart_sqlite3_user_data>())(
       arg0,
     );
   }
@@ -4695,9 +4786,10 @@ class SQLite {
   ffi.Pointer<sqlite3> sqlite3_context_db_handle(
     ffi.Pointer<sqlite3_context> arg0,
   ) {
-    return (_sqlite3_context_db_handle ??= _dylib.lookupFunction<
-        _c_sqlite3_context_db_handle,
-        _dart_sqlite3_context_db_handle>('sqlite3_context_db_handle'))(
+    return (_sqlite3_context_db_handle ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_context_db_handle>>(
+                'sqlite3_context_db_handle')
+            .asFunction<_dart_sqlite3_context_db_handle>())(
       arg0,
     );
   }
@@ -4763,9 +4855,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     int N,
   ) {
-    return (_sqlite3_get_auxdata ??= _dylib.lookupFunction<
-        _c_sqlite3_get_auxdata,
-        _dart_sqlite3_get_auxdata>('sqlite3_get_auxdata'))(
+    return (_sqlite3_get_auxdata ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_get_auxdata>>(
+                'sqlite3_get_auxdata')
+            .asFunction<_dart_sqlite3_get_auxdata>())(
       arg0,
       N,
     );
@@ -4779,9 +4872,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_48>> arg3,
   ) {
-    return (_sqlite3_set_auxdata ??= _dylib.lookupFunction<
-        _c_sqlite3_set_auxdata,
-        _dart_sqlite3_set_auxdata>('sqlite3_set_auxdata'))(
+    return (_sqlite3_set_auxdata ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_set_auxdata>>(
+                'sqlite3_set_auxdata')
+            .asFunction<_dart_sqlite3_set_auxdata>())(
       arg0,
       N,
       arg2,
@@ -4941,9 +5035,10 @@ class SQLite {
     int arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_49>> arg3,
   ) {
-    return (_sqlite3_result_blob ??= _dylib.lookupFunction<
-        _c_sqlite3_result_blob,
-        _dart_sqlite3_result_blob>('sqlite3_result_blob'))(
+    return (_sqlite3_result_blob ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_blob>>(
+                'sqlite3_result_blob')
+            .asFunction<_dart_sqlite3_result_blob>())(
       arg0,
       arg1,
       arg2,
@@ -4959,9 +5054,10 @@ class SQLite {
     int arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_50>> arg3,
   ) {
-    return (_sqlite3_result_blob64 ??= _dylib.lookupFunction<
-        _c_sqlite3_result_blob64,
-        _dart_sqlite3_result_blob64>('sqlite3_result_blob64'))(
+    return (_sqlite3_result_blob64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_blob64>>(
+                'sqlite3_result_blob64')
+            .asFunction<_dart_sqlite3_result_blob64>())(
       arg0,
       arg1,
       arg2,
@@ -4975,9 +5071,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     double arg1,
   ) {
-    return (_sqlite3_result_double ??= _dylib.lookupFunction<
-        _c_sqlite3_result_double,
-        _dart_sqlite3_result_double>('sqlite3_result_double'))(
+    return (_sqlite3_result_double ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_double>>(
+                'sqlite3_result_double')
+            .asFunction<_dart_sqlite3_result_double>())(
       arg0,
       arg1,
     );
@@ -4990,9 +5087,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> arg1,
     int arg2,
   ) {
-    return (_sqlite3_result_error ??= _dylib.lookupFunction<
-        _c_sqlite3_result_error,
-        _dart_sqlite3_result_error>('sqlite3_result_error'))(
+    return (_sqlite3_result_error ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_error>>(
+                'sqlite3_result_error')
+            .asFunction<_dart_sqlite3_result_error>())(
       arg0,
       arg1,
       arg2,
@@ -5006,9 +5104,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg1,
     int arg2,
   ) {
-    return (_sqlite3_result_error16 ??= _dylib.lookupFunction<
-        _c_sqlite3_result_error16,
-        _dart_sqlite3_result_error16>('sqlite3_result_error16'))(
+    return (_sqlite3_result_error16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_error16>>(
+                'sqlite3_result_error16')
+            .asFunction<_dart_sqlite3_result_error16>())(
       arg0,
       arg1,
       arg2,
@@ -5020,9 +5119,10 @@ class SQLite {
   void sqlite3_result_error_toobig(
     ffi.Pointer<sqlite3_context> arg0,
   ) {
-    return (_sqlite3_result_error_toobig ??= _dylib.lookupFunction<
-        _c_sqlite3_result_error_toobig,
-        _dart_sqlite3_result_error_toobig>('sqlite3_result_error_toobig'))(
+    return (_sqlite3_result_error_toobig ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_error_toobig>>(
+                'sqlite3_result_error_toobig')
+            .asFunction<_dart_sqlite3_result_error_toobig>())(
       arg0,
     );
   }
@@ -5032,9 +5132,10 @@ class SQLite {
   void sqlite3_result_error_nomem(
     ffi.Pointer<sqlite3_context> arg0,
   ) {
-    return (_sqlite3_result_error_nomem ??= _dylib.lookupFunction<
-        _c_sqlite3_result_error_nomem,
-        _dart_sqlite3_result_error_nomem>('sqlite3_result_error_nomem'))(
+    return (_sqlite3_result_error_nomem ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_error_nomem>>(
+                'sqlite3_result_error_nomem')
+            .asFunction<_dart_sqlite3_result_error_nomem>())(
       arg0,
     );
   }
@@ -5045,9 +5146,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     int arg1,
   ) {
-    return (_sqlite3_result_error_code ??= _dylib.lookupFunction<
-        _c_sqlite3_result_error_code,
-        _dart_sqlite3_result_error_code>('sqlite3_result_error_code'))(
+    return (_sqlite3_result_error_code ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_error_code>>(
+                'sqlite3_result_error_code')
+            .asFunction<_dart_sqlite3_result_error_code>())(
       arg0,
       arg1,
     );
@@ -5060,8 +5162,8 @@ class SQLite {
     int arg1,
   ) {
     return (_sqlite3_result_int ??=
-        _dylib.lookupFunction<_c_sqlite3_result_int, _dart_sqlite3_result_int>(
-            'sqlite3_result_int'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_int>>('sqlite3_result_int')
+            .asFunction<_dart_sqlite3_result_int>())(
       arg0,
       arg1,
     );
@@ -5073,9 +5175,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     int arg1,
   ) {
-    return (_sqlite3_result_int64 ??= _dylib.lookupFunction<
-        _c_sqlite3_result_int64,
-        _dart_sqlite3_result_int64>('sqlite3_result_int64'))(
+    return (_sqlite3_result_int64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_int64>>(
+                'sqlite3_result_int64')
+            .asFunction<_dart_sqlite3_result_int64>())(
       arg0,
       arg1,
     );
@@ -5086,9 +5189,10 @@ class SQLite {
   void sqlite3_result_null(
     ffi.Pointer<sqlite3_context> arg0,
   ) {
-    return (_sqlite3_result_null ??= _dylib.lookupFunction<
-        _c_sqlite3_result_null,
-        _dart_sqlite3_result_null>('sqlite3_result_null'))(
+    return (_sqlite3_result_null ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_null>>(
+                'sqlite3_result_null')
+            .asFunction<_dart_sqlite3_result_null>())(
       arg0,
     );
   }
@@ -5101,9 +5205,10 @@ class SQLite {
     int arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_51>> arg3,
   ) {
-    return (_sqlite3_result_text ??= _dylib.lookupFunction<
-        _c_sqlite3_result_text,
-        _dart_sqlite3_result_text>('sqlite3_result_text'))(
+    return (_sqlite3_result_text ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_text>>(
+                'sqlite3_result_text')
+            .asFunction<_dart_sqlite3_result_text>())(
       arg0,
       arg1,
       arg2,
@@ -5120,9 +5225,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_52>> arg3,
     int encoding,
   ) {
-    return (_sqlite3_result_text64 ??= _dylib.lookupFunction<
-        _c_sqlite3_result_text64,
-        _dart_sqlite3_result_text64>('sqlite3_result_text64'))(
+    return (_sqlite3_result_text64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_text64>>(
+                'sqlite3_result_text64')
+            .asFunction<_dart_sqlite3_result_text64>())(
       arg0,
       arg1,
       arg2,
@@ -5139,9 +5245,10 @@ class SQLite {
     int arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_53>> arg3,
   ) {
-    return (_sqlite3_result_text16 ??= _dylib.lookupFunction<
-        _c_sqlite3_result_text16,
-        _dart_sqlite3_result_text16>('sqlite3_result_text16'))(
+    return (_sqlite3_result_text16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_text16>>(
+                'sqlite3_result_text16')
+            .asFunction<_dart_sqlite3_result_text16>())(
       arg0,
       arg1,
       arg2,
@@ -5157,9 +5264,10 @@ class SQLite {
     int arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_54>> arg3,
   ) {
-    return (_sqlite3_result_text16le ??= _dylib.lookupFunction<
-        _c_sqlite3_result_text16le,
-        _dart_sqlite3_result_text16le>('sqlite3_result_text16le'))(
+    return (_sqlite3_result_text16le ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_text16le>>(
+                'sqlite3_result_text16le')
+            .asFunction<_dart_sqlite3_result_text16le>())(
       arg0,
       arg1,
       arg2,
@@ -5175,9 +5283,10 @@ class SQLite {
     int arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_55>> arg3,
   ) {
-    return (_sqlite3_result_text16be ??= _dylib.lookupFunction<
-        _c_sqlite3_result_text16be,
-        _dart_sqlite3_result_text16be>('sqlite3_result_text16be'))(
+    return (_sqlite3_result_text16be ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_text16be>>(
+                'sqlite3_result_text16be')
+            .asFunction<_dart_sqlite3_result_text16be>())(
       arg0,
       arg1,
       arg2,
@@ -5191,9 +5300,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     ffi.Pointer<sqlite3_value> arg1,
   ) {
-    return (_sqlite3_result_value ??= _dylib.lookupFunction<
-        _c_sqlite3_result_value,
-        _dart_sqlite3_result_value>('sqlite3_result_value'))(
+    return (_sqlite3_result_value ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_value>>(
+                'sqlite3_result_value')
+            .asFunction<_dart_sqlite3_result_value>())(
       arg0,
       arg1,
     );
@@ -5207,9 +5317,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> arg2,
     ffi.Pointer<ffi.NativeFunction<_typedefC_56>> arg3,
   ) {
-    return (_sqlite3_result_pointer ??= _dylib.lookupFunction<
-        _c_sqlite3_result_pointer,
-        _dart_sqlite3_result_pointer>('sqlite3_result_pointer'))(
+    return (_sqlite3_result_pointer ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_pointer>>(
+                'sqlite3_result_pointer')
+            .asFunction<_dart_sqlite3_result_pointer>())(
       arg0,
       arg1,
       arg2,
@@ -5223,9 +5334,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     int n,
   ) {
-    return (_sqlite3_result_zeroblob ??= _dylib.lookupFunction<
-        _c_sqlite3_result_zeroblob,
-        _dart_sqlite3_result_zeroblob>('sqlite3_result_zeroblob'))(
+    return (_sqlite3_result_zeroblob ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_zeroblob>>(
+                'sqlite3_result_zeroblob')
+            .asFunction<_dart_sqlite3_result_zeroblob>())(
       arg0,
       n,
     );
@@ -5237,9 +5349,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     int n,
   ) {
-    return (_sqlite3_result_zeroblob64 ??= _dylib.lookupFunction<
-        _c_sqlite3_result_zeroblob64,
-        _dart_sqlite3_result_zeroblob64>('sqlite3_result_zeroblob64'))(
+    return (_sqlite3_result_zeroblob64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_zeroblob64>>(
+                'sqlite3_result_zeroblob64')
+            .asFunction<_dart_sqlite3_result_zeroblob64>())(
       arg0,
       n,
     );
@@ -5261,9 +5374,10 @@ class SQLite {
     ffi.Pointer<sqlite3_context> arg0,
     int arg1,
   ) {
-    return (_sqlite3_result_subtype ??= _dylib.lookupFunction<
-        _c_sqlite3_result_subtype,
-        _dart_sqlite3_result_subtype>('sqlite3_result_subtype'))(
+    return (_sqlite3_result_subtype ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_result_subtype>>(
+                'sqlite3_result_subtype')
+            .asFunction<_dart_sqlite3_result_subtype>())(
       arg0,
       arg1,
     );
@@ -5357,9 +5471,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> pArg,
     ffi.Pointer<ffi.NativeFunction<_typedefC_57>> xCompare,
   ) {
-    return (_sqlite3_create_collation ??= _dylib.lookupFunction<
-        _c_sqlite3_create_collation,
-        _dart_sqlite3_create_collation>('sqlite3_create_collation'))(
+    return (_sqlite3_create_collation ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_collation>>(
+                'sqlite3_create_collation')
+            .asFunction<_dart_sqlite3_create_collation>())(
       arg0,
       zName,
       eTextRep,
@@ -5378,9 +5493,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_58>> xCompare,
     ffi.Pointer<ffi.NativeFunction<_typedefC_59>> xDestroy,
   ) {
-    return (_sqlite3_create_collation_v2 ??= _dylib.lookupFunction<
-        _c_sqlite3_create_collation_v2,
-        _dart_sqlite3_create_collation_v2>('sqlite3_create_collation_v2'))(
+    return (_sqlite3_create_collation_v2 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_collation_v2>>(
+                'sqlite3_create_collation_v2')
+            .asFunction<_dart_sqlite3_create_collation_v2>())(
       arg0,
       zName,
       eTextRep,
@@ -5399,9 +5515,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> pArg,
     ffi.Pointer<ffi.NativeFunction<_typedefC_60>> xCompare,
   ) {
-    return (_sqlite3_create_collation16 ??= _dylib.lookupFunction<
-        _c_sqlite3_create_collation16,
-        _dart_sqlite3_create_collation16>('sqlite3_create_collation16'))(
+    return (_sqlite3_create_collation16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_collation16>>(
+                'sqlite3_create_collation16')
+            .asFunction<_dart_sqlite3_create_collation16>())(
       arg0,
       zName,
       eTextRep,
@@ -5442,9 +5559,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg1,
     ffi.Pointer<ffi.NativeFunction<_typedefC_61>> arg2,
   ) {
-    return (_sqlite3_collation_needed ??= _dylib.lookupFunction<
-        _c_sqlite3_collation_needed,
-        _dart_sqlite3_collation_needed>('sqlite3_collation_needed'))(
+    return (_sqlite3_collation_needed ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_collation_needed>>(
+                'sqlite3_collation_needed')
+            .asFunction<_dart_sqlite3_collation_needed>())(
       arg0,
       arg1,
       arg2,
@@ -5458,9 +5576,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg1,
     ffi.Pointer<ffi.NativeFunction<_typedefC_62>> arg2,
   ) {
-    return (_sqlite3_collation_needed16 ??= _dylib.lookupFunction<
-        _c_sqlite3_collation_needed16,
-        _dart_sqlite3_collation_needed16>('sqlite3_collation_needed16'))(
+    return (_sqlite3_collation_needed16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_collation_needed16>>(
+                'sqlite3_collation_needed16')
+            .asFunction<_dart_sqlite3_collation_needed16>())(
       arg0,
       arg1,
       arg2,
@@ -5488,8 +5607,8 @@ class SQLite {
     int arg0,
   ) {
     return (_sqlite3_sleep ??=
-        _dylib.lookupFunction<_c_sqlite3_sleep, _dart_sqlite3_sleep>(
-            'sqlite3_sleep'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_sleep>>('sqlite3_sleep')
+            .asFunction<_dart_sqlite3_sleep>())(
       arg0,
     );
   }
@@ -5551,7 +5670,7 @@ class SQLite {
   /// sqlite3_temp_directory = sqlite3_mprintf("%s", zPathBuf);
   /// </pre></blockquote>
   late final ffi.Pointer<ffi.Pointer<ffi.Int8>> _sqlite3_temp_directory =
-      _dylib.lookup<ffi.Pointer<ffi.Int8>>('sqlite3_temp_directory');
+      _lookup<ffi.Pointer<ffi.Int8>>('sqlite3_temp_directory');
 
   ffi.Pointer<ffi.Int8> get sqlite3_temp_directory =>
       _sqlite3_temp_directory.value;
@@ -5593,7 +5712,7 @@ class SQLite {
   /// made NULL or made to point to memory obtained from [sqlite3_malloc]
   /// or else the use of the [data_store_directory pragma] should be avoided.
   late final ffi.Pointer<ffi.Pointer<ffi.Int8>> _sqlite3_data_directory =
-      _dylib.lookup<ffi.Pointer<ffi.Int8>>('sqlite3_data_directory');
+      _lookup<ffi.Pointer<ffi.Int8>>('sqlite3_data_directory');
 
   ffi.Pointer<ffi.Int8> get sqlite3_data_directory =>
       _sqlite3_data_directory.value;
@@ -5622,9 +5741,10 @@ class SQLite {
     int type,
     ffi.Pointer<ffi.Void> zValue,
   ) {
-    return (_sqlite3_win32_set_directory ??= _dylib.lookupFunction<
-        _c_sqlite3_win32_set_directory,
-        _dart_sqlite3_win32_set_directory>('sqlite3_win32_set_directory'))(
+    return (_sqlite3_win32_set_directory ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_win32_set_directory>>(
+                'sqlite3_win32_set_directory')
+            .asFunction<_dart_sqlite3_win32_set_directory>())(
       type,
       zValue,
     );
@@ -5636,9 +5756,10 @@ class SQLite {
     int type,
     ffi.Pointer<ffi.Int8> zValue,
   ) {
-    return (_sqlite3_win32_set_directory8 ??= _dylib.lookupFunction<
-        _c_sqlite3_win32_set_directory8,
-        _dart_sqlite3_win32_set_directory8>('sqlite3_win32_set_directory8'))(
+    return (_sqlite3_win32_set_directory8 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_win32_set_directory8>>(
+                'sqlite3_win32_set_directory8')
+            .asFunction<_dart_sqlite3_win32_set_directory8>())(
       type,
       zValue,
     );
@@ -5650,9 +5771,10 @@ class SQLite {
     int type,
     ffi.Pointer<ffi.Void> zValue,
   ) {
-    return (_sqlite3_win32_set_directory16 ??= _dylib.lookupFunction<
-        _c_sqlite3_win32_set_directory16,
-        _dart_sqlite3_win32_set_directory16>('sqlite3_win32_set_directory16'))(
+    return (_sqlite3_win32_set_directory16 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_win32_set_directory16>>(
+                'sqlite3_win32_set_directory16')
+            .asFunction<_dart_sqlite3_win32_set_directory16>())(
       type,
       zValue,
     );
@@ -5683,9 +5805,10 @@ class SQLite {
   int sqlite3_get_autocommit(
     ffi.Pointer<sqlite3> arg0,
   ) {
-    return (_sqlite3_get_autocommit ??= _dylib.lookupFunction<
-        _c_sqlite3_get_autocommit,
-        _dart_sqlite3_get_autocommit>('sqlite3_get_autocommit'))(
+    return (_sqlite3_get_autocommit ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_get_autocommit>>(
+                'sqlite3_get_autocommit')
+            .asFunction<_dart_sqlite3_get_autocommit>())(
       arg0,
     );
   }
@@ -5705,8 +5828,8 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> arg0,
   ) {
     return (_sqlite3_db_handle ??=
-        _dylib.lookupFunction<_c_sqlite3_db_handle, _dart_sqlite3_db_handle>(
-            'sqlite3_db_handle'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_handle>>('sqlite3_db_handle')
+            .asFunction<_dart_sqlite3_db_handle>())(
       arg0,
     );
   }
@@ -5745,9 +5868,10 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
     ffi.Pointer<ffi.Int8> zDbName,
   ) {
-    return (_sqlite3_db_filename ??= _dylib.lookupFunction<
-        _c_sqlite3_db_filename,
-        _dart_sqlite3_db_filename>('sqlite3_db_filename'))(
+    return (_sqlite3_db_filename ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_filename>>(
+                'sqlite3_db_filename')
+            .asFunction<_dart_sqlite3_db_filename>())(
       db,
       zDbName,
     );
@@ -5765,9 +5889,10 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
     ffi.Pointer<ffi.Int8> zDbName,
   ) {
-    return (_sqlite3_db_readonly ??= _dylib.lookupFunction<
-        _c_sqlite3_db_readonly,
-        _dart_sqlite3_db_readonly>('sqlite3_db_readonly'))(
+    return (_sqlite3_db_readonly ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_readonly>>(
+                'sqlite3_db_readonly')
+            .asFunction<_dart_sqlite3_db_readonly>())(
       db,
       zDbName,
     );
@@ -5792,8 +5917,8 @@ class SQLite {
     ffi.Pointer<sqlite3_stmt> pStmt,
   ) {
     return (_sqlite3_next_stmt ??=
-        _dylib.lookupFunction<_c_sqlite3_next_stmt, _dart_sqlite3_next_stmt>(
-            'sqlite3_next_stmt'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_next_stmt>>('sqlite3_next_stmt')
+            .asFunction<_dart_sqlite3_next_stmt>())(
       pDb,
       pStmt,
     );
@@ -5851,9 +5976,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_63>> arg1,
     ffi.Pointer<ffi.Void> arg2,
   ) {
-    return (_sqlite3_commit_hook ??= _dylib.lookupFunction<
-        _c_sqlite3_commit_hook,
-        _dart_sqlite3_commit_hook>('sqlite3_commit_hook'))(
+    return (_sqlite3_commit_hook ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_commit_hook>>(
+                'sqlite3_commit_hook')
+            .asFunction<_dart_sqlite3_commit_hook>())(
       arg0,
       arg1,
       arg2,
@@ -5867,9 +5993,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_64>> arg1,
     ffi.Pointer<ffi.Void> arg2,
   ) {
-    return (_sqlite3_rollback_hook ??= _dylib.lookupFunction<
-        _c_sqlite3_rollback_hook,
-        _dart_sqlite3_rollback_hook>('sqlite3_rollback_hook'))(
+    return (_sqlite3_rollback_hook ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_rollback_hook>>(
+                'sqlite3_rollback_hook')
+            .asFunction<_dart_sqlite3_rollback_hook>())(
       arg0,
       arg1,
       arg2,
@@ -5930,9 +6057,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_65>> arg1,
     ffi.Pointer<ffi.Void> arg2,
   ) {
-    return (_sqlite3_update_hook ??= _dylib.lookupFunction<
-        _c_sqlite3_update_hook,
-        _dart_sqlite3_update_hook>('sqlite3_update_hook'))(
+    return (_sqlite3_update_hook ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_update_hook>>(
+                'sqlite3_update_hook')
+            .asFunction<_dart_sqlite3_update_hook>())(
       arg0,
       arg1,
       arg2,
@@ -5981,9 +6109,10 @@ class SQLite {
   int sqlite3_enable_shared_cache(
     int arg0,
   ) {
-    return (_sqlite3_enable_shared_cache ??= _dylib.lookupFunction<
-        _c_sqlite3_enable_shared_cache,
-        _dart_sqlite3_enable_shared_cache>('sqlite3_enable_shared_cache'))(
+    return (_sqlite3_enable_shared_cache ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_enable_shared_cache>>(
+                'sqlite3_enable_shared_cache')
+            .asFunction<_dart_sqlite3_enable_shared_cache>())(
       arg0,
     );
   }
@@ -6005,9 +6134,10 @@ class SQLite {
   int sqlite3_release_memory(
     int arg0,
   ) {
-    return (_sqlite3_release_memory ??= _dylib.lookupFunction<
-        _c_sqlite3_release_memory,
-        _dart_sqlite3_release_memory>('sqlite3_release_memory'))(
+    return (_sqlite3_release_memory ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_release_memory>>(
+                'sqlite3_release_memory')
+            .asFunction<_dart_sqlite3_release_memory>())(
       arg0,
     );
   }
@@ -6027,9 +6157,10 @@ class SQLite {
   int sqlite3_db_release_memory(
     ffi.Pointer<sqlite3> arg0,
   ) {
-    return (_sqlite3_db_release_memory ??= _dylib.lookupFunction<
-        _c_sqlite3_db_release_memory,
-        _dart_sqlite3_db_release_memory>('sqlite3_db_release_memory'))(
+    return (_sqlite3_db_release_memory ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_release_memory>>(
+                'sqlite3_db_release_memory')
+            .asFunction<_dart_sqlite3_db_release_memory>())(
       arg0,
     );
   }
@@ -6101,9 +6232,10 @@ class SQLite {
   int sqlite3_soft_heap_limit64(
     int N,
   ) {
-    return (_sqlite3_soft_heap_limit64 ??= _dylib.lookupFunction<
-        _c_sqlite3_soft_heap_limit64,
-        _dart_sqlite3_soft_heap_limit64>('sqlite3_soft_heap_limit64'))(
+    return (_sqlite3_soft_heap_limit64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_soft_heap_limit64>>(
+                'sqlite3_soft_heap_limit64')
+            .asFunction<_dart_sqlite3_soft_heap_limit64>())(
       N,
     );
   }
@@ -6113,9 +6245,10 @@ class SQLite {
   int sqlite3_hard_heap_limit64(
     int N,
   ) {
-    return (_sqlite3_hard_heap_limit64 ??= _dylib.lookupFunction<
-        _c_sqlite3_hard_heap_limit64,
-        _dart_sqlite3_hard_heap_limit64>('sqlite3_hard_heap_limit64'))(
+    return (_sqlite3_hard_heap_limit64 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_hard_heap_limit64>>(
+                'sqlite3_hard_heap_limit64')
+            .asFunction<_dart_sqlite3_hard_heap_limit64>())(
       N,
     );
   }
@@ -6132,9 +6265,10 @@ class SQLite {
   void sqlite3_soft_heap_limit(
     int N,
   ) {
-    return (_sqlite3_soft_heap_limit ??= _dylib.lookupFunction<
-        _c_sqlite3_soft_heap_limit,
-        _dart_sqlite3_soft_heap_limit>('sqlite3_soft_heap_limit'))(
+    return (_sqlite3_soft_heap_limit ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_soft_heap_limit>>(
+                'sqlite3_soft_heap_limit')
+            .asFunction<_dart_sqlite3_soft_heap_limit>())(
       N,
     );
   }
@@ -6219,9 +6353,10 @@ class SQLite {
     ffi.Pointer<ffi.Int32> pPrimaryKey,
     ffi.Pointer<ffi.Int32> pAutoinc,
   ) {
-    return (_sqlite3_table_column_metadata ??= _dylib.lookupFunction<
-        _c_sqlite3_table_column_metadata,
-        _dart_sqlite3_table_column_metadata>('sqlite3_table_column_metadata'))(
+    return (_sqlite3_table_column_metadata ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_table_column_metadata>>(
+                'sqlite3_table_column_metadata')
+            .asFunction<_dart_sqlite3_table_column_metadata>())(
       db,
       zDbName,
       zTableName,
@@ -6284,9 +6419,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zProc,
     ffi.Pointer<ffi.Pointer<ffi.Int8>> pzErrMsg,
   ) {
-    return (_sqlite3_load_extension ??= _dylib.lookupFunction<
-        _c_sqlite3_load_extension,
-        _dart_sqlite3_load_extension>('sqlite3_load_extension'))(
+    return (_sqlite3_load_extension ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_load_extension>>(
+                'sqlite3_load_extension')
+            .asFunction<_dart_sqlite3_load_extension>())(
       db,
       zFile,
       zProc,
@@ -6323,9 +6459,10 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
     int onoff,
   ) {
-    return (_sqlite3_enable_load_extension ??= _dylib.lookupFunction<
-        _c_sqlite3_enable_load_extension,
-        _dart_sqlite3_enable_load_extension>('sqlite3_enable_load_extension'))(
+    return (_sqlite3_enable_load_extension ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_enable_load_extension>>(
+                'sqlite3_enable_load_extension')
+            .asFunction<_dart_sqlite3_enable_load_extension>())(
       db,
       onoff,
     );
@@ -6370,9 +6507,10 @@ class SQLite {
   int sqlite3_auto_extension(
     ffi.Pointer<ffi.NativeFunction<_typedefC_66>> xEntryPoint,
   ) {
-    return (_sqlite3_auto_extension ??= _dylib.lookupFunction<
-        _c_sqlite3_auto_extension,
-        _dart_sqlite3_auto_extension>('sqlite3_auto_extension'))(
+    return (_sqlite3_auto_extension ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_auto_extension>>(
+                'sqlite3_auto_extension')
+            .asFunction<_dart_sqlite3_auto_extension>())(
       xEntryPoint,
     );
   }
@@ -6390,9 +6528,10 @@ class SQLite {
   int sqlite3_cancel_auto_extension(
     ffi.Pointer<ffi.NativeFunction<_typedefC_67>> xEntryPoint,
   ) {
-    return (_sqlite3_cancel_auto_extension ??= _dylib.lookupFunction<
-        _c_sqlite3_cancel_auto_extension,
-        _dart_sqlite3_cancel_auto_extension>('sqlite3_cancel_auto_extension'))(
+    return (_sqlite3_cancel_auto_extension ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_cancel_auto_extension>>(
+                'sqlite3_cancel_auto_extension')
+            .asFunction<_dart_sqlite3_cancel_auto_extension>())(
       xEntryPoint,
     );
   }
@@ -6404,9 +6543,10 @@ class SQLite {
   /// ^This interface disables all automatic extensions previously
   /// registered using [sqlite3_auto_extension()].
   void sqlite3_reset_auto_extension() {
-    return (_sqlite3_reset_auto_extension ??= _dylib.lookupFunction<
-        _c_sqlite3_reset_auto_extension,
-        _dart_sqlite3_reset_auto_extension>('sqlite3_reset_auto_extension'))();
+    return (_sqlite3_reset_auto_extension ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_reset_auto_extension>>(
+                'sqlite3_reset_auto_extension')
+            .asFunction<_dart_sqlite3_reset_auto_extension>())();
   }
 
   _dart_sqlite3_reset_auto_extension? _sqlite3_reset_auto_extension;
@@ -6447,9 +6587,10 @@ class SQLite {
     ffi.Pointer<sqlite3_module> p,
     ffi.Pointer<ffi.Void> pClientData,
   ) {
-    return (_sqlite3_create_module ??= _dylib.lookupFunction<
-        _c_sqlite3_create_module,
-        _dart_sqlite3_create_module>('sqlite3_create_module'))(
+    return (_sqlite3_create_module ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_module>>(
+                'sqlite3_create_module')
+            .asFunction<_dart_sqlite3_create_module>())(
       db,
       zName,
       p,
@@ -6466,9 +6607,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> pClientData,
     ffi.Pointer<ffi.NativeFunction<_typedefC_68>> xDestroy,
   ) {
-    return (_sqlite3_create_module_v2 ??= _dylib.lookupFunction<
-        _c_sqlite3_create_module_v2,
-        _dart_sqlite3_create_module_v2>('sqlite3_create_module_v2'))(
+    return (_sqlite3_create_module_v2 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_create_module_v2>>(
+                'sqlite3_create_module_v2')
+            .asFunction<_dart_sqlite3_create_module_v2>())(
       db,
       zName,
       p,
@@ -6493,9 +6635,10 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
     ffi.Pointer<ffi.Pointer<ffi.Int8>> azKeep,
   ) {
-    return (_sqlite3_drop_modules ??= _dylib.lookupFunction<
-        _c_sqlite3_drop_modules,
-        _dart_sqlite3_drop_modules>('sqlite3_drop_modules'))(
+    return (_sqlite3_drop_modules ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_drop_modules>>(
+                'sqlite3_drop_modules')
+            .asFunction<_dart_sqlite3_drop_modules>())(
       db,
       azKeep,
     );
@@ -6513,9 +6656,10 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
     ffi.Pointer<ffi.Int8> zSQL,
   ) {
-    return (_sqlite3_declare_vtab ??= _dylib.lookupFunction<
-        _c_sqlite3_declare_vtab,
-        _dart_sqlite3_declare_vtab>('sqlite3_declare_vtab'))(
+    return (_sqlite3_declare_vtab ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_declare_vtab>>(
+                'sqlite3_declare_vtab')
+            .asFunction<_dart_sqlite3_declare_vtab>())(
       arg0,
       zSQL,
     );
@@ -6543,9 +6687,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zFuncName,
     int nArg,
   ) {
-    return (_sqlite3_overload_function ??= _dylib.lookupFunction<
-        _c_sqlite3_overload_function,
-        _dart_sqlite3_overload_function>('sqlite3_overload_function'))(
+    return (_sqlite3_overload_function ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_overload_function>>(
+                'sqlite3_overload_function')
+            .asFunction<_dart_sqlite3_overload_function>())(
       arg0,
       zFuncName,
       nArg,
@@ -6645,8 +6790,8 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<sqlite3_blob>> ppBlob,
   ) {
     return (_sqlite3_blob_open ??=
-        _dylib.lookupFunction<_c_sqlite3_blob_open, _dart_sqlite3_blob_open>(
-            'sqlite3_blob_open'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_blob_open>>('sqlite3_blob_open')
+            .asFunction<_dart_sqlite3_blob_open>())(
       arg0,
       zDb,
       zTable,
@@ -6684,9 +6829,10 @@ class SQLite {
     ffi.Pointer<sqlite3_blob> arg0,
     int arg1,
   ) {
-    return (_sqlite3_blob_reopen ??= _dylib.lookupFunction<
-        _c_sqlite3_blob_reopen,
-        _dart_sqlite3_blob_reopen>('sqlite3_blob_reopen'))(
+    return (_sqlite3_blob_reopen ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_blob_reopen>>(
+                'sqlite3_blob_reopen')
+            .asFunction<_dart_sqlite3_blob_reopen>())(
       arg0,
       arg1,
     );
@@ -6717,8 +6863,8 @@ class SQLite {
     ffi.Pointer<sqlite3_blob> arg0,
   ) {
     return (_sqlite3_blob_close ??=
-        _dylib.lookupFunction<_c_sqlite3_blob_close, _dart_sqlite3_blob_close>(
-            'sqlite3_blob_close'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_blob_close>>('sqlite3_blob_close')
+            .asFunction<_dart_sqlite3_blob_close>())(
       arg0,
     );
   }
@@ -6741,8 +6887,8 @@ class SQLite {
     ffi.Pointer<sqlite3_blob> arg0,
   ) {
     return (_sqlite3_blob_bytes ??=
-        _dylib.lookupFunction<_c_sqlite3_blob_bytes, _dart_sqlite3_blob_bytes>(
-            'sqlite3_blob_bytes'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_blob_bytes>>('sqlite3_blob_bytes')
+            .asFunction<_dart_sqlite3_blob_bytes>())(
       arg0,
     );
   }
@@ -6781,8 +6927,8 @@ class SQLite {
     int iOffset,
   ) {
     return (_sqlite3_blob_read ??=
-        _dylib.lookupFunction<_c_sqlite3_blob_read, _dart_sqlite3_blob_read>(
-            'sqlite3_blob_read'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_blob_read>>('sqlite3_blob_read')
+            .asFunction<_dart_sqlite3_blob_read>())(
       arg0,
       Z,
       N,
@@ -6837,8 +6983,8 @@ class SQLite {
     int iOffset,
   ) {
     return (_sqlite3_blob_write ??=
-        _dylib.lookupFunction<_c_sqlite3_blob_write, _dart_sqlite3_blob_write>(
-            'sqlite3_blob_write'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_blob_write>>('sqlite3_blob_write')
+            .asFunction<_dart_sqlite3_blob_write>())(
       arg0,
       z,
       n,
@@ -6879,8 +7025,8 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zVfsName,
   ) {
     return (_sqlite3_vfs_find ??=
-        _dylib.lookupFunction<_c_sqlite3_vfs_find, _dart_sqlite3_vfs_find>(
-            'sqlite3_vfs_find'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_vfs_find>>('sqlite3_vfs_find')
+            .asFunction<_dart_sqlite3_vfs_find>())(
       zVfsName,
     );
   }
@@ -6891,9 +7037,10 @@ class SQLite {
     ffi.Pointer<sqlite3_vfs> arg0,
     int makeDflt,
   ) {
-    return (_sqlite3_vfs_register ??= _dylib.lookupFunction<
-        _c_sqlite3_vfs_register,
-        _dart_sqlite3_vfs_register>('sqlite3_vfs_register'))(
+    return (_sqlite3_vfs_register ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_vfs_register>>(
+                'sqlite3_vfs_register')
+            .asFunction<_dart_sqlite3_vfs_register>())(
       arg0,
       makeDflt,
     );
@@ -6904,9 +7051,10 @@ class SQLite {
   int sqlite3_vfs_unregister(
     ffi.Pointer<sqlite3_vfs> arg0,
   ) {
-    return (_sqlite3_vfs_unregister ??= _dylib.lookupFunction<
-        _c_sqlite3_vfs_unregister,
-        _dart_sqlite3_vfs_unregister>('sqlite3_vfs_unregister'))(
+    return (_sqlite3_vfs_unregister ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_vfs_unregister>>(
+                'sqlite3_vfs_unregister')
+            .asFunction<_dart_sqlite3_vfs_unregister>())(
       arg0,
     );
   }
@@ -7028,9 +7176,10 @@ class SQLite {
   ffi.Pointer<sqlite3_mutex> sqlite3_mutex_alloc(
     int arg0,
   ) {
-    return (_sqlite3_mutex_alloc ??= _dylib.lookupFunction<
-        _c_sqlite3_mutex_alloc,
-        _dart_sqlite3_mutex_alloc>('sqlite3_mutex_alloc'))(
+    return (_sqlite3_mutex_alloc ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_mutex_alloc>>(
+                'sqlite3_mutex_alloc')
+            .asFunction<_dart_sqlite3_mutex_alloc>())(
       arg0,
     );
   }
@@ -7041,8 +7190,8 @@ class SQLite {
     ffi.Pointer<sqlite3_mutex> arg0,
   ) {
     return (_sqlite3_mutex_free ??=
-        _dylib.lookupFunction<_c_sqlite3_mutex_free, _dart_sqlite3_mutex_free>(
-            'sqlite3_mutex_free'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_mutex_free>>('sqlite3_mutex_free')
+            .asFunction<_dart_sqlite3_mutex_free>())(
       arg0,
     );
   }
@@ -7052,9 +7201,10 @@ class SQLite {
   void sqlite3_mutex_enter(
     ffi.Pointer<sqlite3_mutex> arg0,
   ) {
-    return (_sqlite3_mutex_enter ??= _dylib.lookupFunction<
-        _c_sqlite3_mutex_enter,
-        _dart_sqlite3_mutex_enter>('sqlite3_mutex_enter'))(
+    return (_sqlite3_mutex_enter ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_mutex_enter>>(
+                'sqlite3_mutex_enter')
+            .asFunction<_dart_sqlite3_mutex_enter>())(
       arg0,
     );
   }
@@ -7065,8 +7215,8 @@ class SQLite {
     ffi.Pointer<sqlite3_mutex> arg0,
   ) {
     return (_sqlite3_mutex_try ??=
-        _dylib.lookupFunction<_c_sqlite3_mutex_try, _dart_sqlite3_mutex_try>(
-            'sqlite3_mutex_try'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_mutex_try>>('sqlite3_mutex_try')
+            .asFunction<_dart_sqlite3_mutex_try>())(
       arg0,
     );
   }
@@ -7076,9 +7226,10 @@ class SQLite {
   void sqlite3_mutex_leave(
     ffi.Pointer<sqlite3_mutex> arg0,
   ) {
-    return (_sqlite3_mutex_leave ??= _dylib.lookupFunction<
-        _c_sqlite3_mutex_leave,
-        _dart_sqlite3_mutex_leave>('sqlite3_mutex_leave'))(
+    return (_sqlite3_mutex_leave ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_mutex_leave>>(
+                'sqlite3_mutex_leave')
+            .asFunction<_dart_sqlite3_mutex_leave>())(
       arg0,
     );
   }
@@ -7089,8 +7240,8 @@ class SQLite {
     ffi.Pointer<sqlite3_mutex> arg0,
   ) {
     return (_sqlite3_mutex_held ??=
-        _dylib.lookupFunction<_c_sqlite3_mutex_held, _dart_sqlite3_mutex_held>(
-            'sqlite3_mutex_held'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_mutex_held>>('sqlite3_mutex_held')
+            .asFunction<_dart_sqlite3_mutex_held>())(
       arg0,
     );
   }
@@ -7100,9 +7251,10 @@ class SQLite {
   int sqlite3_mutex_notheld(
     ffi.Pointer<sqlite3_mutex> arg0,
   ) {
-    return (_sqlite3_mutex_notheld ??= _dylib.lookupFunction<
-        _c_sqlite3_mutex_notheld,
-        _dart_sqlite3_mutex_notheld>('sqlite3_mutex_notheld'))(
+    return (_sqlite3_mutex_notheld ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_mutex_notheld>>(
+                'sqlite3_mutex_notheld')
+            .asFunction<_dart_sqlite3_mutex_notheld>())(
       arg0,
     );
   }
@@ -7121,8 +7273,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_db_mutex ??=
-        _dylib.lookupFunction<_c_sqlite3_db_mutex, _dart_sqlite3_db_mutex>(
-            'sqlite3_db_mutex'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_mutex>>('sqlite3_db_mutex')
+            .asFunction<_dart_sqlite3_db_mutex>())(
       arg0,
     );
   }
@@ -7174,9 +7326,10 @@ class SQLite {
     int op,
     ffi.Pointer<ffi.Void> arg3,
   ) {
-    return (_sqlite3_file_control ??= _dylib.lookupFunction<
-        _c_sqlite3_file_control,
-        _dart_sqlite3_file_control>('sqlite3_file_control'))(
+    return (_sqlite3_file_control ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_file_control>>(
+                'sqlite3_file_control')
+            .asFunction<_dart_sqlite3_file_control>())(
       arg0,
       zDbName,
       op,
@@ -7204,9 +7357,10 @@ class SQLite {
   int sqlite3_test_control(
     int op,
   ) {
-    return (_sqlite3_test_control ??= _dylib.lookupFunction<
-        _c_sqlite3_test_control,
-        _dart_sqlite3_test_control>('sqlite3_test_control'))(
+    return (_sqlite3_test_control ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_test_control>>(
+                'sqlite3_test_control')
+            .asFunction<_dart_sqlite3_test_control>())(
       op,
     );
   }
@@ -7259,9 +7413,10 @@ class SQLite {
   /// SQLite is compiled with the [-DSQLITE_OMIT_VACUUM] option.  Also,
   /// new keywords may be added to future releases of SQLite.
   int sqlite3_keyword_count() {
-    return (_sqlite3_keyword_count ??= _dylib.lookupFunction<
-        _c_sqlite3_keyword_count,
-        _dart_sqlite3_keyword_count>('sqlite3_keyword_count'))();
+    return (_sqlite3_keyword_count ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_keyword_count>>(
+                'sqlite3_keyword_count')
+            .asFunction<_dart_sqlite3_keyword_count>())();
   }
 
   _dart_sqlite3_keyword_count? _sqlite3_keyword_count;
@@ -7271,9 +7426,10 @@ class SQLite {
     ffi.Pointer<ffi.Pointer<ffi.Int8>> arg1,
     ffi.Pointer<ffi.Int32> arg2,
   ) {
-    return (_sqlite3_keyword_name ??= _dylib.lookupFunction<
-        _c_sqlite3_keyword_name,
-        _dart_sqlite3_keyword_name>('sqlite3_keyword_name'))(
+    return (_sqlite3_keyword_name ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_keyword_name>>(
+                'sqlite3_keyword_name')
+            .asFunction<_dart_sqlite3_keyword_name>())(
       arg0,
       arg1,
       arg2,
@@ -7286,9 +7442,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> arg0,
     int arg1,
   ) {
-    return (_sqlite3_keyword_check ??= _dylib.lookupFunction<
-        _c_sqlite3_keyword_check,
-        _dart_sqlite3_keyword_check>('sqlite3_keyword_check'))(
+    return (_sqlite3_keyword_check ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_keyword_check>>(
+                'sqlite3_keyword_check')
+            .asFunction<_dart_sqlite3_keyword_check>())(
       arg0,
       arg1,
     );
@@ -7323,8 +7480,8 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
   ) {
     return (_sqlite3_str_new ??=
-        _dylib.lookupFunction<_c_sqlite3_str_new, _dart_sqlite3_str_new>(
-            'sqlite3_str_new'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_new>>('sqlite3_str_new')
+            .asFunction<_dart_sqlite3_str_new>())(
       arg0,
     );
   }
@@ -7346,8 +7503,8 @@ class SQLite {
     ffi.Pointer<sqlite3_str> arg0,
   ) {
     return (_sqlite3_str_finish ??=
-        _dylib.lookupFunction<_c_sqlite3_str_finish, _dart_sqlite3_str_finish>(
-            'sqlite3_str_finish'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_finish>>('sqlite3_str_finish')
+            .asFunction<_dart_sqlite3_str_finish>())(
       arg0,
     );
   }
@@ -7388,9 +7545,10 @@ class SQLite {
     ffi.Pointer<sqlite3_str> arg0,
     ffi.Pointer<ffi.Int8> zFormat,
   ) {
-    return (_sqlite3_str_appendf ??= _dylib.lookupFunction<
-        _c_sqlite3_str_appendf,
-        _dart_sqlite3_str_appendf>('sqlite3_str_appendf'))(
+    return (_sqlite3_str_appendf ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_appendf>>(
+                'sqlite3_str_appendf')
+            .asFunction<_dart_sqlite3_str_appendf>())(
       arg0,
       zFormat,
     );
@@ -7404,8 +7562,8 @@ class SQLite {
     int N,
   ) {
     return (_sqlite3_str_append ??=
-        _dylib.lookupFunction<_c_sqlite3_str_append, _dart_sqlite3_str_append>(
-            'sqlite3_str_append'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_append>>('sqlite3_str_append')
+            .asFunction<_dart_sqlite3_str_append>())(
       arg0,
       zIn,
       N,
@@ -7418,9 +7576,10 @@ class SQLite {
     ffi.Pointer<sqlite3_str> arg0,
     ffi.Pointer<ffi.Int8> zIn,
   ) {
-    return (_sqlite3_str_appendall ??= _dylib.lookupFunction<
-        _c_sqlite3_str_appendall,
-        _dart_sqlite3_str_appendall>('sqlite3_str_appendall'))(
+    return (_sqlite3_str_appendall ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_appendall>>(
+                'sqlite3_str_appendall')
+            .asFunction<_dart_sqlite3_str_appendall>())(
       arg0,
       zIn,
     );
@@ -7433,9 +7592,10 @@ class SQLite {
     int N,
     int C,
   ) {
-    return (_sqlite3_str_appendchar ??= _dylib.lookupFunction<
-        _c_sqlite3_str_appendchar,
-        _dart_sqlite3_str_appendchar>('sqlite3_str_appendchar'))(
+    return (_sqlite3_str_appendchar ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_appendchar>>(
+                'sqlite3_str_appendchar')
+            .asFunction<_dart_sqlite3_str_appendchar>())(
       arg0,
       N,
       C,
@@ -7448,8 +7608,8 @@ class SQLite {
     ffi.Pointer<sqlite3_str> arg0,
   ) {
     return (_sqlite3_str_reset ??=
-        _dylib.lookupFunction<_c_sqlite3_str_reset, _dart_sqlite3_str_reset>(
-            'sqlite3_str_reset'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_reset>>('sqlite3_str_reset')
+            .asFunction<_dart_sqlite3_str_reset>())(
       arg0,
     );
   }
@@ -7486,9 +7646,10 @@ class SQLite {
   int sqlite3_str_errcode(
     ffi.Pointer<sqlite3_str> arg0,
   ) {
-    return (_sqlite3_str_errcode ??= _dylib.lookupFunction<
-        _c_sqlite3_str_errcode,
-        _dart_sqlite3_str_errcode>('sqlite3_str_errcode'))(
+    return (_sqlite3_str_errcode ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_errcode>>(
+                'sqlite3_str_errcode')
+            .asFunction<_dart_sqlite3_str_errcode>())(
       arg0,
     );
   }
@@ -7499,8 +7660,8 @@ class SQLite {
     ffi.Pointer<sqlite3_str> arg0,
   ) {
     return (_sqlite3_str_length ??=
-        _dylib.lookupFunction<_c_sqlite3_str_length, _dart_sqlite3_str_length>(
-            'sqlite3_str_length'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_length>>('sqlite3_str_length')
+            .asFunction<_dart_sqlite3_str_length>())(
       arg0,
     );
   }
@@ -7511,8 +7672,8 @@ class SQLite {
     ffi.Pointer<sqlite3_str> arg0,
   ) {
     return (_sqlite3_str_value ??=
-        _dylib.lookupFunction<_c_sqlite3_str_value, _dart_sqlite3_str_value>(
-            'sqlite3_str_value'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_str_value>>('sqlite3_str_value')
+            .asFunction<_dart_sqlite3_str_value>())(
       arg0,
     );
   }
@@ -7550,8 +7711,8 @@ class SQLite {
     int resetFlag,
   ) {
     return (_sqlite3_status ??=
-        _dylib.lookupFunction<_c_sqlite3_status, _dart_sqlite3_status>(
-            'sqlite3_status'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_status>>('sqlite3_status')
+            .asFunction<_dart_sqlite3_status>())(
       op,
       pCurrent,
       pHighwater,
@@ -7568,8 +7729,8 @@ class SQLite {
     int resetFlag,
   ) {
     return (_sqlite3_status64 ??=
-        _dylib.lookupFunction<_c_sqlite3_status64, _dart_sqlite3_status64>(
-            'sqlite3_status64'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_status64>>('sqlite3_status64')
+            .asFunction<_dart_sqlite3_status64>())(
       op,
       pCurrent,
       pHighwater,
@@ -7608,8 +7769,8 @@ class SQLite {
     int resetFlg,
   ) {
     return (_sqlite3_db_status ??=
-        _dylib.lookupFunction<_c_sqlite3_db_status, _dart_sqlite3_db_status>(
-            'sqlite3_db_status'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_status>>('sqlite3_db_status')
+            .asFunction<_dart_sqlite3_db_status>())(
       arg0,
       op,
       pCur,
@@ -7647,9 +7808,10 @@ class SQLite {
     int op,
     int resetFlg,
   ) {
-    return (_sqlite3_stmt_status ??= _dylib.lookupFunction<
-        _c_sqlite3_stmt_status,
-        _dart_sqlite3_stmt_status>('sqlite3_stmt_status'))(
+    return (_sqlite3_stmt_status ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_stmt_status>>(
+                'sqlite3_stmt_status')
+            .asFunction<_dart_sqlite3_stmt_status>())(
       arg0,
       op,
       resetFlg,
@@ -7848,9 +8010,10 @@ class SQLite {
     ffi.Pointer<sqlite3> pSource,
     ffi.Pointer<ffi.Int8> zSourceName,
   ) {
-    return (_sqlite3_backup_init ??= _dylib.lookupFunction<
-        _c_sqlite3_backup_init,
-        _dart_sqlite3_backup_init>('sqlite3_backup_init'))(
+    return (_sqlite3_backup_init ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_backup_init>>(
+                'sqlite3_backup_init')
+            .asFunction<_dart_sqlite3_backup_init>())(
       pDest,
       zDestName,
       pSource,
@@ -7864,9 +8027,10 @@ class SQLite {
     ffi.Pointer<sqlite3_backup> p,
     int nPage,
   ) {
-    return (_sqlite3_backup_step ??= _dylib.lookupFunction<
-        _c_sqlite3_backup_step,
-        _dart_sqlite3_backup_step>('sqlite3_backup_step'))(
+    return (_sqlite3_backup_step ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_backup_step>>(
+                'sqlite3_backup_step')
+            .asFunction<_dart_sqlite3_backup_step>())(
       p,
       nPage,
     );
@@ -7877,9 +8041,10 @@ class SQLite {
   int sqlite3_backup_finish(
     ffi.Pointer<sqlite3_backup> p,
   ) {
-    return (_sqlite3_backup_finish ??= _dylib.lookupFunction<
-        _c_sqlite3_backup_finish,
-        _dart_sqlite3_backup_finish>('sqlite3_backup_finish'))(
+    return (_sqlite3_backup_finish ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_backup_finish>>(
+                'sqlite3_backup_finish')
+            .asFunction<_dart_sqlite3_backup_finish>())(
       p,
     );
   }
@@ -7889,9 +8054,10 @@ class SQLite {
   int sqlite3_backup_remaining(
     ffi.Pointer<sqlite3_backup> p,
   ) {
-    return (_sqlite3_backup_remaining ??= _dylib.lookupFunction<
-        _c_sqlite3_backup_remaining,
-        _dart_sqlite3_backup_remaining>('sqlite3_backup_remaining'))(
+    return (_sqlite3_backup_remaining ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_backup_remaining>>(
+                'sqlite3_backup_remaining')
+            .asFunction<_dart_sqlite3_backup_remaining>())(
       p,
     );
   }
@@ -7901,9 +8067,10 @@ class SQLite {
   int sqlite3_backup_pagecount(
     ffi.Pointer<sqlite3_backup> p,
   ) {
-    return (_sqlite3_backup_pagecount ??= _dylib.lookupFunction<
-        _c_sqlite3_backup_pagecount,
-        _dart_sqlite3_backup_pagecount>('sqlite3_backup_pagecount'))(
+    return (_sqlite3_backup_pagecount ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_backup_pagecount>>(
+                'sqlite3_backup_pagecount')
+            .asFunction<_dart_sqlite3_backup_pagecount>())(
       p,
     );
   }
@@ -8028,9 +8195,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_69>> xNotify,
     ffi.Pointer<ffi.Void> pNotifyArg,
   ) {
-    return (_sqlite3_unlock_notify ??= _dylib.lookupFunction<
-        _c_sqlite3_unlock_notify,
-        _dart_sqlite3_unlock_notify>('sqlite3_unlock_notify'))(
+    return (_sqlite3_unlock_notify ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_unlock_notify>>(
+                'sqlite3_unlock_notify')
+            .asFunction<_dart_sqlite3_unlock_notify>())(
       pBlocked,
       xNotify,
       pNotifyArg,
@@ -8050,8 +8218,8 @@ class SQLite {
     ffi.Pointer<ffi.Int8> arg1,
   ) {
     return (_sqlite3_stricmp ??=
-        _dylib.lookupFunction<_c_sqlite3_stricmp, _dart_sqlite3_stricmp>(
-            'sqlite3_stricmp'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_stricmp>>('sqlite3_stricmp')
+            .asFunction<_dart_sqlite3_stricmp>())(
       arg0,
       arg1,
     );
@@ -8065,8 +8233,8 @@ class SQLite {
     int arg2,
   ) {
     return (_sqlite3_strnicmp ??=
-        _dylib.lookupFunction<_c_sqlite3_strnicmp, _dart_sqlite3_strnicmp>(
-            'sqlite3_strnicmp'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_strnicmp>>('sqlite3_strnicmp')
+            .asFunction<_dart_sqlite3_strnicmp>())(
       arg0,
       arg1,
       arg2,
@@ -8093,8 +8261,8 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zStr,
   ) {
     return (_sqlite3_strglob ??=
-        _dylib.lookupFunction<_c_sqlite3_strglob, _dart_sqlite3_strglob>(
-            'sqlite3_strglob'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_strglob>>('sqlite3_strglob')
+            .asFunction<_dart_sqlite3_strglob>())(
       zGlob,
       zStr,
     );
@@ -8127,8 +8295,8 @@ class SQLite {
     int cEsc,
   ) {
     return (_sqlite3_strlike ??=
-        _dylib.lookupFunction<_c_sqlite3_strlike, _dart_sqlite3_strlike>(
-            'sqlite3_strlike'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_strlike>>('sqlite3_strlike')
+            .asFunction<_dart_sqlite3_strlike>())(
       zGlob,
       zStr,
       cEsc,
@@ -8160,8 +8328,9 @@ class SQLite {
     int iErrCode,
     ffi.Pointer<ffi.Int8> zFormat,
   ) {
-    return (_sqlite3_log ??= _dylib
-        .lookupFunction<_c_sqlite3_log, _dart_sqlite3_log>('sqlite3_log'))(
+    return (_sqlite3_log ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_log>>('sqlite3_log')
+            .asFunction<_dart_sqlite3_log>())(
       iErrCode,
       zFormat,
     );
@@ -8207,8 +8376,8 @@ class SQLite {
     ffi.Pointer<ffi.Void> arg2,
   ) {
     return (_sqlite3_wal_hook ??=
-        _dylib.lookupFunction<_c_sqlite3_wal_hook, _dart_sqlite3_wal_hook>(
-            'sqlite3_wal_hook'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_wal_hook>>('sqlite3_wal_hook')
+            .asFunction<_dart_sqlite3_wal_hook>())(
       arg0,
       arg1,
       arg2,
@@ -8248,9 +8417,10 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
     int N,
   ) {
-    return (_sqlite3_wal_autocheckpoint ??= _dylib.lookupFunction<
-        _c_sqlite3_wal_autocheckpoint,
-        _dart_sqlite3_wal_autocheckpoint>('sqlite3_wal_autocheckpoint'))(
+    return (_sqlite3_wal_autocheckpoint ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_wal_autocheckpoint>>(
+                'sqlite3_wal_autocheckpoint')
+            .asFunction<_dart_sqlite3_wal_autocheckpoint>())(
       db,
       N,
     );
@@ -8280,9 +8450,10 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
     ffi.Pointer<ffi.Int8> zDb,
   ) {
-    return (_sqlite3_wal_checkpoint ??= _dylib.lookupFunction<
-        _c_sqlite3_wal_checkpoint,
-        _dart_sqlite3_wal_checkpoint>('sqlite3_wal_checkpoint'))(
+    return (_sqlite3_wal_checkpoint ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_wal_checkpoint>>(
+                'sqlite3_wal_checkpoint')
+            .asFunction<_dart_sqlite3_wal_checkpoint>())(
       db,
       zDb,
     );
@@ -8387,9 +8558,10 @@ class SQLite {
     ffi.Pointer<ffi.Int32> pnLog,
     ffi.Pointer<ffi.Int32> pnCkpt,
   ) {
-    return (_sqlite3_wal_checkpoint_v2 ??= _dylib.lookupFunction<
-        _c_sqlite3_wal_checkpoint_v2,
-        _dart_sqlite3_wal_checkpoint_v2>('sqlite3_wal_checkpoint_v2'))(
+    return (_sqlite3_wal_checkpoint_v2 ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_wal_checkpoint_v2>>(
+                'sqlite3_wal_checkpoint_v2')
+            .asFunction<_dart_sqlite3_wal_checkpoint_v2>())(
       db,
       zDb,
       eMode,
@@ -8420,9 +8592,10 @@ class SQLite {
     ffi.Pointer<sqlite3> arg0,
     int op,
   ) {
-    return (_sqlite3_vtab_config ??= _dylib.lookupFunction<
-        _c_sqlite3_vtab_config,
-        _dart_sqlite3_vtab_config>('sqlite3_vtab_config'))(
+    return (_sqlite3_vtab_config ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_vtab_config>>(
+                'sqlite3_vtab_config')
+            .asFunction<_dart_sqlite3_vtab_config>())(
       arg0,
       op,
     );
@@ -8441,9 +8614,10 @@ class SQLite {
   int sqlite3_vtab_on_conflict(
     ffi.Pointer<sqlite3> arg0,
   ) {
-    return (_sqlite3_vtab_on_conflict ??= _dylib.lookupFunction<
-        _c_sqlite3_vtab_on_conflict,
-        _dart_sqlite3_vtab_on_conflict>('sqlite3_vtab_on_conflict'))(
+    return (_sqlite3_vtab_on_conflict ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_vtab_on_conflict>>(
+                'sqlite3_vtab_on_conflict')
+            .asFunction<_dart_sqlite3_vtab_on_conflict>())(
       arg0,
     );
   }
@@ -8468,9 +8642,10 @@ class SQLite {
   int sqlite3_vtab_nochange(
     ffi.Pointer<sqlite3_context> arg0,
   ) {
-    return (_sqlite3_vtab_nochange ??= _dylib.lookupFunction<
-        _c_sqlite3_vtab_nochange,
-        _dart_sqlite3_vtab_nochange>('sqlite3_vtab_nochange'))(
+    return (_sqlite3_vtab_nochange ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_vtab_nochange>>(
+                'sqlite3_vtab_nochange')
+            .asFunction<_dart_sqlite3_vtab_nochange>())(
       arg0,
     );
   }
@@ -8492,9 +8667,10 @@ class SQLite {
     ffi.Pointer<sqlite3_index_info> arg0,
     int arg1,
   ) {
-    return (_sqlite3_vtab_collation ??= _dylib.lookupFunction<
-        _c_sqlite3_vtab_collation,
-        _dart_sqlite3_vtab_collation>('sqlite3_vtab_collation'))(
+    return (_sqlite3_vtab_collation ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_vtab_collation>>(
+                'sqlite3_vtab_collation')
+            .asFunction<_dart_sqlite3_vtab_collation>())(
       arg0,
       arg1,
     );
@@ -8537,9 +8713,10 @@ class SQLite {
     int iScanStatusOp,
     ffi.Pointer<ffi.Void> pOut,
   ) {
-    return (_sqlite3_stmt_scanstatus ??= _dylib.lookupFunction<
-        _c_sqlite3_stmt_scanstatus,
-        _dart_sqlite3_stmt_scanstatus>('sqlite3_stmt_scanstatus'))(
+    return (_sqlite3_stmt_scanstatus ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_stmt_scanstatus>>(
+                'sqlite3_stmt_scanstatus')
+            .asFunction<_dart_sqlite3_stmt_scanstatus>())(
       pStmt,
       idx,
       iScanStatusOp,
@@ -8559,9 +8736,10 @@ class SQLite {
   void sqlite3_stmt_scanstatus_reset(
     ffi.Pointer<sqlite3_stmt> arg0,
   ) {
-    return (_sqlite3_stmt_scanstatus_reset ??= _dylib.lookupFunction<
-        _c_sqlite3_stmt_scanstatus_reset,
-        _dart_sqlite3_stmt_scanstatus_reset>('sqlite3_stmt_scanstatus_reset'))(
+    return (_sqlite3_stmt_scanstatus_reset ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_stmt_scanstatus_reset>>(
+                'sqlite3_stmt_scanstatus_reset')
+            .asFunction<_dart_sqlite3_stmt_scanstatus_reset>())(
       arg0,
     );
   }
@@ -8599,9 +8777,10 @@ class SQLite {
   int sqlite3_db_cacheflush(
     ffi.Pointer<sqlite3> arg0,
   ) {
-    return (_sqlite3_db_cacheflush ??= _dylib.lookupFunction<
-        _c_sqlite3_db_cacheflush,
-        _dart_sqlite3_db_cacheflush>('sqlite3_db_cacheflush'))(
+    return (_sqlite3_db_cacheflush ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_db_cacheflush>>(
+                'sqlite3_db_cacheflush')
+            .asFunction<_dart_sqlite3_db_cacheflush>())(
       arg0,
     );
   }
@@ -8619,9 +8798,10 @@ class SQLite {
   int sqlite3_system_errno(
     ffi.Pointer<sqlite3> arg0,
   ) {
-    return (_sqlite3_system_errno ??= _dylib.lookupFunction<
-        _c_sqlite3_system_errno,
-        _dart_sqlite3_system_errno>('sqlite3_system_errno'))(
+    return (_sqlite3_system_errno ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_system_errno>>(
+                'sqlite3_system_errno')
+            .asFunction<_dart_sqlite3_system_errno>())(
       arg0,
     );
   }
@@ -8674,9 +8854,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zSchema,
     ffi.Pointer<ffi.Pointer<sqlite3_snapshot>> ppSnapshot,
   ) {
-    return (_sqlite3_snapshot_get ??= _dylib.lookupFunction<
-        _c_sqlite3_snapshot_get,
-        _dart_sqlite3_snapshot_get>('sqlite3_snapshot_get'))(
+    return (_sqlite3_snapshot_get ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_snapshot_get>>(
+                'sqlite3_snapshot_get')
+            .asFunction<_dart_sqlite3_snapshot_get>())(
       db,
       zSchema,
       ppSnapshot,
@@ -8731,9 +8912,10 @@ class SQLite {
     ffi.Pointer<ffi.Int8> zSchema,
     ffi.Pointer<sqlite3_snapshot> pSnapshot,
   ) {
-    return (_sqlite3_snapshot_open ??= _dylib.lookupFunction<
-        _c_sqlite3_snapshot_open,
-        _dart_sqlite3_snapshot_open>('sqlite3_snapshot_open'))(
+    return (_sqlite3_snapshot_open ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_snapshot_open>>(
+                'sqlite3_snapshot_open')
+            .asFunction<_dart_sqlite3_snapshot_open>())(
       db,
       zSchema,
       pSnapshot,
@@ -8754,9 +8936,10 @@ class SQLite {
   void sqlite3_snapshot_free(
     ffi.Pointer<sqlite3_snapshot> arg0,
   ) {
-    return (_sqlite3_snapshot_free ??= _dylib.lookupFunction<
-        _c_sqlite3_snapshot_free,
-        _dart_sqlite3_snapshot_free>('sqlite3_snapshot_free'))(
+    return (_sqlite3_snapshot_free ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_snapshot_free>>(
+                'sqlite3_snapshot_free')
+            .asFunction<_dart_sqlite3_snapshot_free>())(
       arg0,
     );
   }
@@ -8790,9 +8973,10 @@ class SQLite {
     ffi.Pointer<sqlite3_snapshot> p1,
     ffi.Pointer<sqlite3_snapshot> p2,
   ) {
-    return (_sqlite3_snapshot_cmp ??= _dylib.lookupFunction<
-        _c_sqlite3_snapshot_cmp,
-        _dart_sqlite3_snapshot_cmp>('sqlite3_snapshot_cmp'))(
+    return (_sqlite3_snapshot_cmp ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_snapshot_cmp>>(
+                'sqlite3_snapshot_cmp')
+            .asFunction<_dart_sqlite3_snapshot_cmp>())(
       p1,
       p2,
     );
@@ -8825,9 +9009,10 @@ class SQLite {
     ffi.Pointer<sqlite3> db,
     ffi.Pointer<ffi.Int8> zDb,
   ) {
-    return (_sqlite3_snapshot_recover ??= _dylib.lookupFunction<
-        _c_sqlite3_snapshot_recover,
-        _dart_sqlite3_snapshot_recover>('sqlite3_snapshot_recover'))(
+    return (_sqlite3_snapshot_recover ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_snapshot_recover>>(
+                'sqlite3_snapshot_recover')
+            .asFunction<_dart_sqlite3_snapshot_recover>())(
       db,
       zDb,
     );
@@ -8876,8 +9061,8 @@ class SQLite {
     int mFlags,
   ) {
     return (_sqlite3_serialize ??=
-        _dylib.lookupFunction<_c_sqlite3_serialize, _dart_sqlite3_serialize>(
-            'sqlite3_serialize'))(
+        _lookup<ffi.NativeFunction<_c_sqlite3_serialize>>('sqlite3_serialize')
+            .asFunction<_dart_sqlite3_serialize>())(
       db,
       zSchema,
       piSize,
@@ -8922,9 +9107,10 @@ class SQLite {
     int szBuf,
     int mFlags,
   ) {
-    return (_sqlite3_deserialize ??= _dylib.lookupFunction<
-        _c_sqlite3_deserialize,
-        _dart_sqlite3_deserialize>('sqlite3_deserialize'))(
+    return (_sqlite3_deserialize ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_deserialize>>(
+                'sqlite3_deserialize')
+            .asFunction<_dart_sqlite3_deserialize>())(
       db,
       zSchema,
       pData,
@@ -8946,10 +9132,10 @@ class SQLite {
     ffi.Pointer<ffi.NativeFunction<_typedefC_71>> xGeom,
     ffi.Pointer<ffi.Void> pContext,
   ) {
-    return (_sqlite3_rtree_geometry_callback ??= _dylib.lookupFunction<
-            _c_sqlite3_rtree_geometry_callback,
-            _dart_sqlite3_rtree_geometry_callback>(
-        'sqlite3_rtree_geometry_callback'))(
+    return (_sqlite3_rtree_geometry_callback ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_rtree_geometry_callback>>(
+                'sqlite3_rtree_geometry_callback')
+            .asFunction<_dart_sqlite3_rtree_geometry_callback>())(
       db,
       zGeom,
       xGeom,
@@ -8970,9 +9156,10 @@ class SQLite {
     ffi.Pointer<ffi.Void> pContext,
     ffi.Pointer<ffi.NativeFunction<_typedefC_73>> xDestructor,
   ) {
-    return (_sqlite3_rtree_query_callback ??= _dylib.lookupFunction<
-        _c_sqlite3_rtree_query_callback,
-        _dart_sqlite3_rtree_query_callback>('sqlite3_rtree_query_callback'))(
+    return (_sqlite3_rtree_query_callback ??=
+        _lookup<ffi.NativeFunction<_c_sqlite3_rtree_query_callback>>(
+                'sqlite3_rtree_query_callback')
+            .asFunction<_dart_sqlite3_rtree_query_callback>())(
       db,
       zQueryFunc,
       xQueryFunc,

--- a/test/large_integration_tests/_expected_sqlite_bindings.dart
+++ b/test/large_integration_tests/_expected_sqlite_bindings.dart
@@ -9347,7 +9347,7 @@ class ArrayHelper_sqlite3_snapshot_hidden_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 

--- a/test/native_test/native_test_bindings.dart
+++ b/test/native_test/native_test_bindings.dart
@@ -5,18 +5,26 @@ import 'dart:ffi' as ffi;
 
 /// Native tests.
 class NativeLibrary {
-  /// Holds the Dynamic library.
-  final ffi.DynamicLibrary _dylib;
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  NativeLibrary(ffi.DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  NativeLibrary(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  NativeLibrary.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   bool Function1Bool(
     bool x,
   ) {
     return (_Function1Bool ??=
-            _dylib.lookupFunction<_c_Function1Bool, _dart_Function1Bool>(
-                'Function1Bool'))(
+            _lookup<ffi.NativeFunction<_c_Function1Bool>>('Function1Bool')
+                .asFunction<_dart_Function1Bool>())(
           x ? 1 : 0,
         ) !=
         0;
@@ -28,8 +36,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Uint8 ??=
-        _dylib.lookupFunction<_c_Function1Uint8, _dart_Function1Uint8>(
-            'Function1Uint8'))(
+        _lookup<ffi.NativeFunction<_c_Function1Uint8>>('Function1Uint8')
+            .asFunction<_dart_Function1Uint8>())(
       x,
     );
   }
@@ -40,8 +48,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Uint16 ??=
-        _dylib.lookupFunction<_c_Function1Uint16, _dart_Function1Uint16>(
-            'Function1Uint16'))(
+        _lookup<ffi.NativeFunction<_c_Function1Uint16>>('Function1Uint16')
+            .asFunction<_dart_Function1Uint16>())(
       x,
     );
   }
@@ -52,8 +60,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Uint32 ??=
-        _dylib.lookupFunction<_c_Function1Uint32, _dart_Function1Uint32>(
-            'Function1Uint32'))(
+        _lookup<ffi.NativeFunction<_c_Function1Uint32>>('Function1Uint32')
+            .asFunction<_dart_Function1Uint32>())(
       x,
     );
   }
@@ -64,8 +72,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Uint64 ??=
-        _dylib.lookupFunction<_c_Function1Uint64, _dart_Function1Uint64>(
-            'Function1Uint64'))(
+        _lookup<ffi.NativeFunction<_c_Function1Uint64>>('Function1Uint64')
+            .asFunction<_dart_Function1Uint64>())(
       x,
     );
   }
@@ -76,8 +84,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Int8 ??=
-        _dylib.lookupFunction<_c_Function1Int8, _dart_Function1Int8>(
-            'Function1Int8'))(
+        _lookup<ffi.NativeFunction<_c_Function1Int8>>('Function1Int8')
+            .asFunction<_dart_Function1Int8>())(
       x,
     );
   }
@@ -88,8 +96,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Int16 ??=
-        _dylib.lookupFunction<_c_Function1Int16, _dart_Function1Int16>(
-            'Function1Int16'))(
+        _lookup<ffi.NativeFunction<_c_Function1Int16>>('Function1Int16')
+            .asFunction<_dart_Function1Int16>())(
       x,
     );
   }
@@ -100,8 +108,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Int32 ??=
-        _dylib.lookupFunction<_c_Function1Int32, _dart_Function1Int32>(
-            'Function1Int32'))(
+        _lookup<ffi.NativeFunction<_c_Function1Int32>>('Function1Int32')
+            .asFunction<_dart_Function1Int32>())(
       x,
     );
   }
@@ -112,8 +120,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1Int64 ??=
-        _dylib.lookupFunction<_c_Function1Int64, _dart_Function1Int64>(
-            'Function1Int64'))(
+        _lookup<ffi.NativeFunction<_c_Function1Int64>>('Function1Int64')
+            .asFunction<_dart_Function1Int64>())(
       x,
     );
   }
@@ -124,8 +132,8 @@ class NativeLibrary {
     int x,
   ) {
     return (_Function1IntPtr ??=
-        _dylib.lookupFunction<_c_Function1IntPtr, _dart_Function1IntPtr>(
-            'Function1IntPtr'))(
+        _lookup<ffi.NativeFunction<_c_Function1IntPtr>>('Function1IntPtr')
+            .asFunction<_dart_Function1IntPtr>())(
       x,
     );
   }
@@ -136,8 +144,8 @@ class NativeLibrary {
     double x,
   ) {
     return (_Function1Float ??=
-        _dylib.lookupFunction<_c_Function1Float, _dart_Function1Float>(
-            'Function1Float'))(
+        _lookup<ffi.NativeFunction<_c_Function1Float>>('Function1Float')
+            .asFunction<_dart_Function1Float>())(
       x,
     );
   }
@@ -148,8 +156,8 @@ class NativeLibrary {
     double x,
   ) {
     return (_Function1Double ??=
-        _dylib.lookupFunction<_c_Function1Double, _dart_Function1Double>(
-            'Function1Double'))(
+        _lookup<ffi.NativeFunction<_c_Function1Double>>('Function1Double')
+            .asFunction<_dart_Function1Double>())(
       x,
     );
   }
@@ -158,7 +166,8 @@ class NativeLibrary {
 
   ffi.Pointer<Struct1> getStruct1() {
     return (_getStruct1 ??=
-        _dylib.lookupFunction<_c_getStruct1, _dart_getStruct1>('getStruct1'))();
+        _lookup<ffi.NativeFunction<_c_getStruct1>>('getStruct1')
+            .asFunction<_dart_getStruct1>())();
   }
 
   _dart_getStruct1? _getStruct1;
@@ -168,9 +177,10 @@ class NativeLibrary {
     int b,
     int c,
   ) {
-    return (_Function1StructReturnByValue ??= _dylib.lookupFunction<
-        _c_Function1StructReturnByValue,
-        _dart_Function1StructReturnByValue>('Function1StructReturnByValue'))(
+    return (_Function1StructReturnByValue ??=
+        _lookup<ffi.NativeFunction<_c_Function1StructReturnByValue>>(
+                'Function1StructReturnByValue')
+            .asFunction<_dart_Function1StructReturnByValue>())(
       a,
       b,
       c,
@@ -182,9 +192,10 @@ class NativeLibrary {
   int Function1StructPassByValue(
     Struct3 sum_a_b_c,
   ) {
-    return (_Function1StructPassByValue ??= _dylib.lookupFunction<
-        _c_Function1StructPassByValue,
-        _dart_Function1StructPassByValue>('Function1StructPassByValue'))(
+    return (_Function1StructPassByValue ??=
+        _lookup<ffi.NativeFunction<_c_Function1StructPassByValue>>(
+                'Function1StructPassByValue')
+            .asFunction<_dart_Function1StructPassByValue>())(
       sum_a_b_c,
     );
   }

--- a/test/native_test/native_test_bindings.dart
+++ b/test/native_test/native_test_bindings.dart
@@ -226,7 +226,7 @@ class ArrayHelper_Struct1_data_level0 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -253,7 +253,7 @@ class ArrayHelper_Struct1_data_level1 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 
@@ -280,7 +280,7 @@ class ArrayHelper_Struct1_data_level2 {
   void _checkBounds(int index) {
     if (index >= length || index < 0) {
       throw RangeError(
-          'Dimension $level: index not in range 0..${length} exclusive.');
+          'Dimension $level: index not in range 0..$length exclusive.');
     }
   }
 


### PR DESCRIPTION
Closes #173, Closes #127
- Added lint rule `unnecessary_brace_in_string_interps`.
- Added `.fromLookup` constructor to support dynamic linking. (173)
- Updated version (`2.0.3 => 2.1.0`, changelog, examples, test.
- Updated travis to target version`2.12.0` (127).
- Updated SDK constraints to `>=2.12.0 <3.0.0`.

---

I am not sure why we were suddenly getting `info - Avoid using braces in interpolation when not needed at ...` [on Travis after pushing to master](https://github.com/dart-lang/ffigen/runs/2023575453), but I went ahead and added this lint rule.