### PR TITLE
Fixed generation of duplicate constants due to multiple entry points.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.1
+- Fixed generation of duplicate constants suffixed with `_<int>` when using multiple entry points.
+
 # 2.2.0
 - Added subkey `symbol-address` to expose native symbol pointers for `functions` and `globals`.
 

--- a/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
@@ -55,15 +55,17 @@ int _unnamedenumCursorVisitor(clang_types.CXCursor cursor,
 
 /// Adds the parameter to func in [functiondecl_parser.dart].
 void _addUnNamedEnumConstant(clang_types.CXCursor cursor) {
-  unnamedEnumConstants.add(
-    Constant(
-      usr: cursor.usr(),
-      originalName: cursor.spelling(),
-      name: config.unnamedEnumConstants.renameUsingConfig(
-        cursor.spelling(),
-      ),
-      rawType: 'int',
-      rawValue: clang.clang_getEnumConstantDeclValue(cursor).toString(),
+  _logger.fine(
+      '++++ Adding Constant from unnamed enum: ${cursor.completeStringRepr()}');
+  final constant = Constant(
+    usr: cursor.usr(),
+    originalName: cursor.spelling(),
+    name: config.unnamedEnumConstants.renameUsingConfig(
+      cursor.spelling(),
     ),
+    rawType: 'int',
+    rawValue: clang.clang_getEnumConstantDeclValue(cursor).toString(),
   );
+  bindingsIndex.addUnnamedEnumConstantToSeen(cursor.usr(), constant);
+  unnamedEnumConstants.add(constant);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 


### PR DESCRIPTION
Closes #177.
- Fixed generation of duplicate constants due to multiple entry points.
- Updated version, changelog

---

@dcharkes I haven't added any new test specifically for this, since this is almost a one-liner change (earlier seen unnamed enum constants were not being marked as seen and hence included multiple times)