### PR TITLE
Automatically add std lib for macos, allow passing list to compiler-opts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.3.0
-- Added config key `compiler-opts-auto -> macos -> include-c-standard-library`
+- Added config key `compiler-opts-automatic -> macos -> include-c-standard-library`
 (default: true) to automatically find and add C standard library on macOS.
 - Allow passing list of string to config key `compiler-opts`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0
+- Added config key `compiler-opts-auto -> macos -> include-c-standard-library`
+(default: true) to automatically find and add C standard library on macOS.
+- Allow passing list of string to config key `compiler-opts`.
+
 # 2.2.5
 - Added new command line flag `--compiler-opts` to the command line tool.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ description: 'Bindings to SQLite'
     <td>
 
 ```yaml
-compiler-opts: # You can also pass in a string.
+compiler-opts:
   - '-I/usr/lib/llvm-9/include/'
 ```
 and/or via the command line -

--- a/README.md
+++ b/README.md
@@ -140,12 +140,28 @@ description: 'Bindings to SQLite'
     <td>
 
 ```yaml
-compiler-opts: '-I/usr/lib/llvm-9/include/'
+compiler-opts: # You can also pass in a string.
+  - '-I/usr/lib/llvm-9/include/'
 ```
 and/or via the command line -
 ```bash
 dart run ffigen --compiler-opts "-I/headers
 -L 'path/to/folder name/file'"
+```
+  </td>
+  </tr>
+    <tr>
+    <td>compiler-opts-automatic -> macos -> include-c-standard-library</td>
+    <td>Tries to automatically find and add C standard library path to
+    compiler-opts on macos.
+    <b>Default: true</b>
+    </td>
+    <td>
+
+```yaml
+compiler-opts-automatic:
+  macos:
+    include-c-standard-library: false
 ```
   </td>
   </tr>

--- a/example/libclang-example/pubspec.yaml
+++ b/example/libclang-example/pubspec.yaml
@@ -29,7 +29,9 @@ ffigen:
       - '**CXString.h'
       - '**Index.h'
 
-  compiler-opts: '-Ithird_party/libclang/include -IC:\Progra~1\LLVM\include -I/usr/local/opt/llvm/include/ -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -Wno-nullability-completeness'
+  compiler-opts:
+    - '-Ithird_party/libclang/include'
+    - '-Wno-nullability-completeness'
   functions:
     include:
       - 'clang_.*' # Can be a regexp, '.' matches any character.

--- a/lib/src/config_provider/config_types.dart
+++ b/lib/src/config_provider/config_types.dart
@@ -2,11 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Contains all the neccesary classes required by config.
 import 'dart:io';
 
-/// Contains all the neccesary classes required by config.
-
 import 'package:quiver/pattern.dart' as quiver;
+
+import 'path_finder.dart';
 
 class CommentType {
   CommentStyle style;
@@ -332,14 +333,9 @@ class CompilerOptsAuto {
   /// Extracts compiler options based on OS and config.
   List<String> extractCompilerOpts() {
     if (Platform.isMacOS) {
-      return _macExtractCompilerOpts();
+      return getHeadersForMac();
     }
 
-    return [];
-  }
-
-  List<String> _macExtractCompilerOpts() {
-    // TODO: complete implementation.
     return [];
   }
 }

--- a/lib/src/config_provider/config_types.dart
+++ b/lib/src/config_provider/config_types.dart
@@ -333,7 +333,7 @@ class CompilerOptsAuto {
   /// Extracts compiler options based on OS and config.
   List<String> extractCompilerOpts() {
     if (Platform.isMacOS && macIncludeStdLib) {
-      return getHeadersForMac();
+      return getCStandardLibraryHeadersForMac();
     }
 
     return [];

--- a/lib/src/config_provider/config_types.dart
+++ b/lib/src/config_provider/config_types.dart
@@ -332,7 +332,7 @@ class CompilerOptsAuto {
 
   /// Extracts compiler options based on OS and config.
   List<String> extractCompilerOpts() {
-    if (Platform.isMacOS) {
+    if (Platform.isMacOS && macIncludeStdLib) {
       return getHeadersForMac();
     }
 

--- a/lib/src/config_provider/config_types.dart
+++ b/lib/src/config_provider/config_types.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 /// Contains all the neccesary classes required by config.
 
 import 'package:quiver/pattern.dart' as quiver;
@@ -317,5 +319,27 @@ class MemberRenamer {
 
     // No renaming is provided for this declaration, return unchanged.
     return member;
+  }
+}
+
+/// Handles config for automatically added compiler options.
+class CompilerOptsAuto {
+  final bool macIncludeStdLib;
+
+  CompilerOptsAuto({bool? macIncludeStdLib})
+      : macIncludeStdLib = macIncludeStdLib ?? true;
+
+  /// Extracts compiler options based on OS and config.
+  List<String> extractCompilerOpts() {
+    if (Platform.isMacOS) {
+      return _macExtractCompilerOpts();
+    }
+
+    return [];
+  }
+
+  List<String> _macExtractCompilerOpts() {
+    // TODO: complete implementation.
+    return [];
   }
 }

--- a/lib/src/config_provider/path_finder.dart
+++ b/lib/src/config_provider/path_finder.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+/// Utils for finding headers on system.
+final _logger = Logger('ffigen.config_provider.path_finder');
+
+List<String> getHeadersForMac() {
+  final includePaths = <String>[];
+
+  /// If CommandLineTools are installed use those headers.
+  const cmdLineToolHeaders =
+      '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/';
+  if (Directory(cmdLineToolHeaders).existsSync()) {
+    includePaths.add('-I' + cmdLineToolHeaders);
+  }
+
+  /// Find headers from XCode or LLVM installed via brew.
+  const brewLlvmPath = '/usr/local/opt/llvm/lib/clang';
+  const xcodeClangPath =
+      '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/';
+  const searchPaths = [brewLlvmPath, xcodeClangPath];
+  for (final searchPath in searchPaths) {
+    if (!Directory(searchPath).existsSync()) continue;
+
+    final result = Process.runSync('ls', [searchPath]);
+    final stdout = result.stdout as String;
+    if (stdout != '') {
+      final versions = stdout.split('\n').where((s) => s != '');
+      for (final version in versions) {
+        final path = '$searchPath/$version/include';
+        if (Directory(path).existsSync()) {
+          includePaths.add('-I' + path);
+        }
+      }
+    }
+  }
+  if (includePaths.isEmpty) {
+    // Warnings for missing headers are printed by libclang while parsing.
+    _logger.fine('Couldn\'t find stdlib headers in default locations.');
+    _logger.fine('Paths searched: ${[cmdLineToolHeaders, ...searchPaths]}');
+  } else {
+    _logger.fine('Added paths $includePaths to compiler-opts.');
+  }
+
+  return includePaths;
+}

--- a/lib/src/config_provider/path_finder.dart
+++ b/lib/src/config_provider/path_finder.dart
@@ -13,14 +13,14 @@ final _logger = Logger('ffigen.config_provider.path_finder');
 
 /// This will return include path from either LLVM, XCode or CommandLineTools.
 List<String> getHeadersForMac() {
-  final includePath = <String>[];
+  final includePaths = <String>[];
 
   /// Add system headers.
   const systemHeaders =
       '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include';
   if (Directory(systemHeaders).existsSync()) {
     _logger.fine('Added $systemHeaders to compiler-opts.');
-    includePath.add('-I' + systemHeaders);
+    includePaths.add('-I' + systemHeaders);
   }
 
   /// Find headers from XCode or LLVM installed via brew.
@@ -39,8 +39,8 @@ List<String> getHeadersForMac() {
         final path = p.join(searchPath, version, 'include');
         if (Directory(path).existsSync()) {
           _logger.fine('Added stdlib path: $path to compiler-opts.');
-          includePath.add('-I' + path);
-          return includePath;
+          includePaths.add('-I' + path);
+          return includePaths;
         }
       }
     }
@@ -51,8 +51,8 @@ List<String> getHeadersForMac() {
       '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/';
   if (Directory(cmdLineToolHeaders).existsSync()) {
     _logger.fine('Added stdlib path: $cmdLineToolHeaders to compiler-opts.');
-    includePath.add('-I' + cmdLineToolHeaders);
-    return includePath;
+    includePaths.add('-I' + cmdLineToolHeaders);
+    return includePaths;
   }
 
   // Warnings for missing headers are printed by libclang while parsing.

--- a/lib/src/config_provider/path_finder.dart
+++ b/lib/src/config_provider/path_finder.dart
@@ -2,12 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Utils for finding header paths on system.
+
 import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
-/// Utils for finding headers on system.
 final _logger = Logger('ffigen.config_provider.path_finder');
 
 /// This will return include path from either LLVM, XCode or CommandLineTools.

--- a/lib/src/config_provider/path_finder.dart
+++ b/lib/src/config_provider/path_finder.dart
@@ -13,6 +13,16 @@ final _logger = Logger('ffigen.config_provider.path_finder');
 
 /// This will return include path from either LLVM, XCode or CommandLineTools.
 List<String> getHeadersForMac() {
+  final includePath = <String>[];
+
+  /// Add system headers.
+  const systemHeaders =
+      '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include';
+  if (Directory(systemHeaders).existsSync()) {
+    _logger.fine('Added $systemHeaders to compiler-opts.');
+    includePath.add('-I' + systemHeaders);
+  }
+
   /// Find headers from XCode or LLVM installed via brew.
   const brewLlvmPath = '/usr/local/opt/llvm/lib/clang';
   const xcodeClangPath =
@@ -29,7 +39,8 @@ List<String> getHeadersForMac() {
         final path = p.join(searchPath, version, 'include');
         if (Directory(path).existsSync()) {
           _logger.fine('Added stdlib path: $path to compiler-opts.');
-          return ['-I' + path];
+          includePath.add('-I' + path);
+          return includePath;
         }
       }
     }
@@ -40,7 +51,8 @@ List<String> getHeadersForMac() {
       '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/';
   if (Directory(cmdLineToolHeaders).existsSync()) {
     _logger.fine('Added stdlib path: $cmdLineToolHeaders to compiler-opts.');
-    return ['-I' + cmdLineToolHeaders];
+    includePath.add('-I' + cmdLineToolHeaders);
+    return includePath;
   }
 
   // Warnings for missing headers are printed by libclang while parsing.

--- a/lib/src/config_provider/path_finder.dart
+++ b/lib/src/config_provider/path_finder.dart
@@ -12,7 +12,7 @@ import 'package:path/path.dart' as p;
 final _logger = Logger('ffigen.config_provider.path_finder');
 
 /// This will return include path from either LLVM, XCode or CommandLineTools.
-List<String> getHeadersForMac() {
+List<String> getCStandardLibraryHeadersForMac() {
   final includePaths = <String>[];
 
   /// Add system headers.

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -147,11 +147,28 @@ List<String> compilerOptsToList(String compilerOpts) {
   return list;
 }
 
-List<String> compilerOptsExtractor(dynamic value) =>
-    compilerOptsToList(value as String);
+List<String> compilerOptsExtractor(dynamic value) {
+  if (value is String) {
+    return compilerOptsToList(value);
+  }
 
-bool compilerOptsValidator(List<String> name, dynamic value) =>
-    checkType<String>(name, value);
+  final list = <String>[];
+  for (final el in (value as YamlList)) {
+    if (el is String) {
+      list.addAll(compilerOptsToList(el));
+    }
+  }
+  return list;
+}
+
+bool compilerOptsValidator(List<String> name, dynamic value) {
+  if (value is String || value is YamlList) {
+    return true;
+  } else {
+    _logger.severe('Expected $name to be a String or List of String.');
+    return false;
+  }
+}
 
 CompilerOptsAuto compilerOptsAutoExtractor(dynamic value) {
   return CompilerOptsAuto(
@@ -236,7 +253,7 @@ bool headersValidator(List<String> name, dynamic value) {
     return false;
   }
   if (!(value as YamlMap).containsKey(strings.entryPoints)) {
-    _logger.severe("Expected '$name -> ${strings.entryPoints}' to be a Map.");
+    _logger.severe("Required '$name -> ${strings.entryPoints}'.");
     return false;
   } else {
     for (final key in value.keys) {

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -194,7 +194,8 @@ bool compilerOptsAutoValidator(List<String> name, dynamic value) {
 
       for (final inckey in (value[oskey] as YamlMap).keys) {
         if (inckey == strings.includeCStdLib) {
-          if (!checkType<bool>([...name, oskey, inckey as String], value)) {
+          if (!checkType<bool>(
+              [...name, oskey, inckey as String], value[oskey][inckey])) {
             _result = false;
           }
         } else {

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -38,6 +38,33 @@ bool checkType<T>(List<String> keys, dynamic value) {
   return true;
 }
 
+/// Checks if there are nested [key] in [map].
+bool checkKeyInYaml(List<String> key, YamlMap map) {
+  dynamic last = map;
+  for (final k in key) {
+    if (last is YamlMap) {
+      if (!last.containsKey(k)) return false;
+      last = last[k];
+    } else {
+      return false;
+    }
+  }
+  return last != null;
+}
+
+/// Extracts value of nested [key] from [map].
+dynamic getKeyValueFromYaml(List<String> key, YamlMap map) {
+  if (checkKeyInYaml(key, map)) {
+    dynamic last = map;
+    for (final k in key) {
+      last = last[k];
+    }
+    return last;
+  }
+
+  return null;
+}
+
 bool booleanExtractor(dynamic value) => value as bool;
 
 bool booleanValidator(List<String> name, dynamic value) =>
@@ -125,6 +152,46 @@ List<String> compilerOptsExtractor(dynamic value) =>
 
 bool compilerOptsValidator(List<String> name, dynamic value) =>
     checkType<String>(name, value);
+
+CompilerOptsAuto compilerOptsAutoExtractor(dynamic value) {
+  return CompilerOptsAuto(
+    macIncludeStdLib: getKeyValueFromYaml(
+      [strings.macos, strings.includeCStdLib],
+      value as YamlMap,
+    ) as bool?,
+  );
+}
+
+bool compilerOptsAutoValidator(List<String> name, dynamic value) {
+  var _result = true;
+
+  if (!checkType<YamlMap>(name, value)) {
+    return false;
+  }
+
+  for (final oskey in (value as YamlMap).keys) {
+    if (oskey == strings.macos) {
+      if (!checkType<YamlMap>([...name, oskey as String], value[oskey])) {
+        return false;
+      }
+
+      for (final inckey in (value[oskey] as YamlMap).keys) {
+        if (inckey == strings.includeCStdLib) {
+          if (!checkType<bool>([...name, oskey, inckey as String], value)) {
+            _result = false;
+          }
+        } else {
+          _logger.severe("Unknown key '$inckey' in '$name -> $oskey.");
+          _result = false;
+        }
+      }
+    } else {
+      _logger.severe("Unknown key '$oskey' in '$name'.");
+      _result = false;
+    }
+  }
+  return _result;
+}
 
 Headers headersExtractor(dynamic yamlConfig) {
   final entryPoints = <String>[];

--- a/lib/src/header_parser/parser.dart
+++ b/lib/src/header_parser/parser.dart
@@ -62,6 +62,7 @@ List<Binding> parseToBindings() {
     config.compilerOpts.add(strings.fparseAllComments);
   }
 
+  _logger.fine('CompilerOpts used: ${config.compilerOpts}');
   clangCmdArgs = createDynamicStringArray(config.compilerOpts);
   cmdLen = config.compilerOpts.length;
 

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -34,6 +34,12 @@ const includeDirectives = 'include-directives';
 
 const compilerOpts = 'compiler-opts';
 
+const compilerOptsAuto = 'compiler-opts-automatic';
+// Sub-fields of compilerOptsAuto.
+const macos = 'macos';
+// Sub-fields of macos.
+const includeCStdLib = 'include-c-standard-library';
+
 // Declarations.
 const functions = 'functions';
 const structs = 'structs';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.2.5
+version: 2.3.0
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/config_tests/compiler_opts_test.dart
+++ b/test/config_tests/compiler_opts_test.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:ffigen/ffigen.dart';
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/config_provider/spec_utils.dart';
+import 'package:ffigen/src/strings.dart' as strings;
+import 'package:yaml/yaml.dart' as yaml;
 import 'package:test/test.dart';
 
 late Library actual, expected;
@@ -24,6 +27,20 @@ void main() {
           '-tab=separated',
         ],
       );
+    });
+    test('Compiler Opts Automatic', () {
+      final config = Config.fromYaml(yaml.loadYaml('''
+${strings.name}: 'NativeLibrary'
+${strings.description}: 'Compiler Opts Test'
+${strings.output}: 'unused'
+${strings.headers}:
+  ${strings.entryPoints}:
+    - 'test/header_parser_tests/comment_markup.h'
+${strings.compilerOptsAuto}:
+  ${strings.macos}:
+    ${strings.includeCStdLib}: false
+        ''') as yaml.YamlMap);
+      expect(config.compilerOpts.isEmpty, true);
     });
   });
 }

--- a/test/header_parser_tests/dart_handle_test.dart
+++ b/test/header_parser_tests/dart_handle_test.dart
@@ -25,7 +25,7 @@ void main() {
 ${strings.name}: 'NativeLibrary'
 ${strings.description}: 'Dart_Handle Test'
 ${strings.output}: 'unused'
-${strings.compilerOpts}: '-I${path.join(getSdkPath(), "include")} -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/'
+${strings.compilerOpts}: '-I${path.join(getSdkPath(), "include")}'
 
 ${strings.headers}:
   ${strings.entryPoints}:

--- a/test/header_parser_tests/globals_test.dart
+++ b/test/header_parser_tests/globals_test.dart
@@ -36,8 +36,7 @@ ${strings.globals}:
       - myInt
       - pointerToLongDouble
       - globalStruct
-# Needed for stdbool.h in MacOS
-${strings.compilerOpts}: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/ -Wno-nullability-completeness'
+${strings.compilerOpts}: '-Wno-nullability-completeness'
         ''') as yaml.YamlMap),
       );
     });

--- a/test/large_integration_tests/large_test.dart
+++ b/test/large_integration_tests/large_test.dart
@@ -79,8 +79,6 @@ ${strings.name}: SQLite
 ${strings.description}: Bindings to SQLite.
 ${strings.output}: unused
 ${strings.arrayWorkaround}: true
-# Needed for stdarg.h in MacOS
-${strings.compilerOpts}: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/'
 ${strings.comments}:
   ${strings.style}: ${strings.any}
   ${strings.length}: ${strings.full}

--- a/test/native_test/config.yaml
+++ b/test/native_test/config.yaml
@@ -16,5 +16,4 @@ headers:
     - '**native_test.c'
 array-workaround: true
 
-# Needed for stdbool.h in MacOS
-compiler-opts: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Headers/ -Wno-nullability-completeness'
+compiler-opts: '-Wno-nullability-completeness'

--- a/tool/libclang_config.yaml
+++ b/tool/libclang_config.yaml
@@ -12,8 +12,9 @@
 name: Clang
 description: Holds bindings to LibClang.
 output: 'lib/src/header_parser/clang_bindings/clang_bindings.dart'
-sort: true
-compiler-opts: '-Ithird_party/libclang/include -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -Wno-nullability-completeness'
+compiler-opts:
+  - '-Ithird_party/libclang/include'
+  - '-Wno-nullability-completeness'
 headers:
   entry-points:
     - 'third_party/libclang/include/clang-c/Index.h'


### PR DESCRIPTION
Closes #190 
- Added config key `compiler-opts-automatic -> macos -> include-c-standard-library`.
- Allow passing list to compiler-opts.
- Update test, version, changelog, readme.