### PR TITLE
Added key `llvm-path`. Deprecate `llvm-lib`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.0
+- Added new key `llvm-path` that accepts a list of `path/to/llvm`.
+- Deprecated `llvm-lib`.
+
 # 2.3.0
 - Added config key `compiler-opts-automatic -> macos -> include-c-standard-library`
 (default: true) to automatically find and add C standard library on macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.4.0
-- Added new key `llvm-path` that accepts a list of `path/to/llvm`.
-- Deprecated `llvm-lib`.
+- Added new config key `llvm-path` that accepts a list of `path/to/llvm`.
+- Deprecated config key `llvm-lib`.
 
 # 2.3.0
 - Added config key `compiler-opts-automatic -> macos -> include-c-standard-library`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ output: 'generated_bindings.dart'
 ```yaml
 llvm-path:
   - '/usr/local/opt/llvm/lib'
-  - 'C:Program Files\llvm`
+  - 'C:\Program Files\llvm`
   - '/usr/lib/llvm-11'
 ```
   </td>

--- a/README.md
+++ b/README.md
@@ -87,12 +87,15 @@ output: 'generated_bindings.dart'
   </td>
   </tr>
   <tr>
-    <td>llvm-lib</td>
-    <td>Path to <i>llvm/lib</i> folder. Required if ffigen is unable to find this at default locations.</td>
+    <td>llvm-path</td>
+    <td>Path to <i>llvm</i> folder. ffigen will sequentially search all the specified paths. Required if ffigen is unable to find this at default locations.</td>
     <td>
 
 ```yaml
-llvm-lib: '/usr/local/opt/llvm/lib'
+llvm-path:
+  - '/usr/local/opt/llvm/lib'
+  - 'C:Program Files\llvm`
+  - '/usr/lib/llvm-11'
 ```
   </td>
   </tr>

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -181,10 +181,20 @@ class Config {
   /// Key: Name, Value: [Specification]
   Map<List<String>, Specification> _getSpecs() {
     return <List<String>, Specification>{
+      //TODO: Deprecated, remove in next major update.
       [strings.llvmLib]: Specification<String>(
         requirement: Requirement.no,
         validator: llvmLibValidator,
         extractor: llvmLibExtractor,
+        defaultValue: () => '',
+        extractedResult: (dynamic result) {
+          if ((result as String).isNotEmpty) _libclangDylib = result;
+        },
+      ),
+      [strings.llvmPath]: Specification<String>(
+        requirement: Requirement.no,
+        validator: llvmPathValidator,
+        extractor: llvmPathExtractor,
         defaultValue: () => findDylibAtDefaultLocations(),
         extractedResult: (dynamic result) => _libclangDylib = result as String,
       ),

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -197,6 +197,7 @@ class Config {
         extractor: llvmPathExtractor,
         defaultValue: () => findDylibAtDefaultLocations(),
         extractedResult: (dynamic result) {
+          // If this key wasn't already set by `llvm-lib` use this result.
           if (_libclangDylib.isEmpty) _libclangDylib = result as String;
         },
       ),

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -196,7 +196,9 @@ class Config {
         validator: llvmPathValidator,
         extractor: llvmPathExtractor,
         defaultValue: () => findDylibAtDefaultLocations(),
-        extractedResult: (dynamic result) => _libclangDylib = result as String,
+        extractedResult: (dynamic result) {
+          if (_libclangDylib.isEmpty) _libclangDylib = result as String;
+        },
       ),
       [strings.output]: Specification<String>(
         requirement: Requirement.yes,

--- a/lib/src/config_provider/config.dart
+++ b/lib/src/config_provider/config.dart
@@ -188,7 +188,7 @@ class Config {
         extractor: llvmLibExtractor,
         defaultValue: () => '',
         extractedResult: (dynamic result) {
-          if ((result as String).isNotEmpty) _libclangDylib = result;
+          _libclangDylib = result as String;
         },
       ),
       [strings.llvmPath]: Specification<String>(

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -340,8 +340,6 @@ String? findLibclangDylib(String parentFolder) {
 }
 
 String llvmLibExtractor(dynamic value) {
-  _logger.severe(
-      'Deprecated ${strings.llvmLib}: please use ${strings.llvmPath} instead.');
   // Extract libclang's dylib from this.
   final p = findLibclangDylib(value as String);
   if (p == null) {
@@ -353,6 +351,8 @@ String llvmLibExtractor(dynamic value) {
 }
 
 bool llvmLibValidator(List<String> name, dynamic value) {
+  _logger.severe(
+      'Deprecated ${strings.llvmLib}: please use ${strings.llvmPath} instead.');
   if (!checkType<String>(name, value) ||
       !Directory(value as String).existsSync()) {
     _logger.severe('Expected $name to be a valid folder Path.');
@@ -372,7 +372,9 @@ String llvmPathExtractor(dynamic value) {
       return dylibPath;
     }
   }
-  // Extract path from default locations if not found in specified locations.
+  _logger.fine(
+      "Couldn't find dynamic library under paths specified by ${strings.llvmPath}.");
+  // Extract path from default locations.
   try {
     final res = findDylibAtDefaultLocations();
     return res;

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -351,7 +351,7 @@ String llvmLibExtractor(dynamic value) {
 }
 
 bool llvmLibValidator(List<String> name, dynamic value) {
-  _logger.severe(
+  _logger.warning(
       'Deprecated ${strings.llvmLib}: please use ${strings.llvmPath} instead.');
   if (!checkType<String>(name, value) ||
       !Directory(value as String).existsSync()) {

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -23,6 +23,10 @@ String get dylibFileName {
 }
 
 const llvmLib = 'llvm-lib';
+const llvmPath = 'llvm-path';
+
+/// Name of the parent folder of dynamic library `lib` or `bin`(on windows).
+String get dynamicLibParentName => Platform.isWindows ? 'bin' : 'lib';
 
 const output = 'output';
 

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -25,7 +25,7 @@ String get dylibFileName {
 const llvmLib = 'llvm-lib';
 const llvmPath = 'llvm-path';
 
-/// Name of the parent folder of dynamic library `lib` or `bin`(on windows).
+/// Name of the parent folder of dynamic library `lib` or `bin` (on windows).
 String get dynamicLibParentName => Platform.isWindows ? 'bin' : 'lib';
 
 const output = 'output';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.3.0
+version: 2.4.0
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 


### PR DESCRIPTION
Close #156
- Added key `llvm-path`. This takes a list of `path/to/llvm`.
- Deprecated key `llvm-lib`
- Update version, changelog, readme.