### PR TITLE
Update readme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.4.1
+- Added `/usr/lib` to default dynamic library location for linux.
+
 # 2.4.0
 - Added new config key `llvm-path` that accepts a list of `path/to/llvm`.
 - Deprecated config key `llvm-lib`.

--- a/README.md
+++ b/README.md
@@ -21,15 +21,21 @@ ffigen:
 Output (_generated_bindings.dart_).
 ```dart
 class NativeLibrary {
-  final DynamicLibrary _dylib;
-
-  NativeLibrary(DynamicLibrary dynamicLibrary) : _dylib = dynamicLibrary;
+  final Pointer<T> Function<T extends NativeType>(String symbolName)
+      _lookup;
+  NativeLibrary(DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
+  NativeLibrary.fromLookup(
+      Pointer<T> Function<T extends NativeType>(String symbolName)
+          lookup)
+      : _lookup = lookup;
 
   int sum(int a, int b) {
-    return (_sum ??= _dylib.lookupFunction<_c_sum, _dart_sum>('sum'))(a, b);
+    return _sum(a, b);
   }
 
-  _dart_sum? _sum;
+  late final _sum_ptr = _lookup<NativeFunction<_c_sum>>('sum');
+  late final _dart_sum _sum = _sum_ptr.asFunction<_dart_sum>();
 }
 typedef _c_sum = Int32 Function(Int32 a, Int32 b);
 typedef _dart_sum = int Function(int a, int b);
@@ -77,7 +83,7 @@ The following configuration options are available-
 </thead>
 <tbody>
   <tr>
-    <td>output<br><i>(Required)</i></td>
+    <td>output<br><i><b>(Required)</b></i></td>
     <td>Output path of the generated bindings.</td>
     <td>
 
@@ -88,7 +94,7 @@ output: 'generated_bindings.dart'
   </tr>
   <tr>
     <td>llvm-path</td>
-    <td>Path to <i>llvm</i> folder. ffigen will sequentially search
+    <td>Path to <i>llvm</i> folder.<br> ffigen will sequentially search
     for `lib/libclang.so` on linux, `lib/libclang.dylib` on macOs and
     `bin\libclang.dll` on windows, in the specified paths.<br>
     <i>Required</i> if ffigen is unable to find this at default locations.</td>
@@ -103,8 +109,9 @@ llvm-path:
   </td>
   </tr>
   <tr>
-    <td>headers<br><i>(Required)</i></td>
-    <td>The header entry-points and include-directives. Glob syntax is allowed.</td>
+    <td>headers<br><i><b>(Required)</b></i></td>
+    <td>The header entry-points and include-directives. Glob syntax is allowed.<br>
+    If include-directives are not specified ffigen will generate everything directly/transitively under the entry-points.</td>
     <td>
 
 ```yaml
@@ -173,7 +180,13 @@ compiler-opts-automatic:
   </tr>
   <tr>
     <td>functions<br>structs<br>enums<br>unnamed-enums<br>macros<br>globals</td>
-    <td>Filters for declarations.<br><b>Default: all are included</b></td>
+    <td>Filters for declarations.<br><b>Default: all are included.</b><br><br>
+    Options -<br>
+    - Include/Exclude declarations.<br>
+    - Rename declarations.<br>
+    - Rename enum and struct members.<br>
+    - Expose symbol-address and typedef for functions and globals.<br>
+    </td>
     <td>
 
 ```yaml
@@ -233,7 +246,7 @@ array-workaround: true
   <tr>
     <td>comments</td>
     <td>Extract documentation comments for declarations.<br>
-    The style and length of the comments can be specified with the following options.<br>
+    The style and length of the comments recognized can be specified with the following options- <br>
     <i>style: doxygen(default) | any </i><br>
     <i>length: brief | full(default) </i><br>
     If you want to disable all comments you can also pass<br>
@@ -243,7 +256,7 @@ array-workaround: true
 
 ```yaml
 comments:
-  style: doxygen
+  style: any
   length: full
 ```
   </td>
@@ -253,7 +266,7 @@ comments:
     <td>If `opaque`, generates empty `Opaque` structs if structs
 were not included in config (but were added since they are a dependency) and
 only passed by reference(pointer).<br>
-    Options - full(default) | opaque </i><br>
+    <i>Options - full(default) | opaque</i><br>
     </td>
     <td>
 
@@ -289,7 +302,7 @@ use-supported-typedefs: true
   </tr>
   <tr>
     <td>dart-bool</td>
-    <td>Should generate dart `bool` for c99 bool in functions.<br>
+    <td>Should generate dart `bool` instead of Uint8 for c99 bool in functions.<br>
     <b>Default: true</b>
     </td>
     <td>

--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ output: 'generated_bindings.dart'
   </tr>
   <tr>
     <td>llvm-path</td>
-    <td>Path to <i>llvm</i> folder. ffigen will sequentially search all the specified paths. Required if ffigen is unable to find this at default locations.</td>
+    <td>Path to <i>llvm</i> folder. ffigen will sequentially search
+    for `lib/libclang.so` on linux, `lib/libclang.dylib` on macOs and
+    `bin\libclang.dll` on windows, in the specified paths.<br>
+    <i>Required</i> if ffigen is unable to find this at default locations.</td>
     <td>
 
 ```yaml
 llvm-path:
-  - '/usr/local/opt/llvm/lib'
+  - '/usr/local/opt/llvm'
   - 'C:\Program Files\llvm`
   - '/usr/lib/llvm-11'
 ```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ dart run ffigen --compiler-opts "-I/headers
     <tr>
     <td>compiler-opts-automatic -> macos -> include-c-standard-library</td>
     <td>Tries to automatically find and add C standard library path to
-    compiler-opts on macos.
+    compiler-opts on macos.<br>
     <b>Default: true</b>
     </td>
     <td>
@@ -179,7 +179,7 @@ compiler-opts-automatic:
   </td>
   </tr>
   <tr>
-    <td>functions<br>structs<br>enums<br>unnamed-enums<br>macros<br>globals</td>
+    <td>functions<br><br>structs<br><br>enums<br><br>unnamed-enums<br><br>macros<br><br>globals</td>
     <td>Filters for declarations.<br><b>Default: all are included.</b><br><br>
     Options -<br>
     - Include/Exclude declarations.<br>

--- a/README.md
+++ b/README.md
@@ -179,16 +179,19 @@ compiler-opts-automatic:
 ```yaml
 functions:
   include: # 'exclude' is also available.
-    - [a-z][a-zA-Z0-9]* # Matches using regexp.
-    - prefix.* # '.' matches any character.
-    - someFuncName # Matches with exact name
-    - anotherName # Full names have higher priority.
+    # Matches using regexp.
+    - [a-z][a-zA-Z0-9]*
+    # '.' matches any character.
+    - prefix.*
+    # Matches with exact name
+    - someFuncName
+    # Full names have higher priority.
+    - anotherName
   rename:
     # Regexp groups based replacement.
     'clang_(.*)': '$1'
-    # full name matches have higher priority.
     'clang_dispose': 'dispose'
-    # Removes '_' from beginning of a name.
+    # Removes '_' from beginning.
     '_(.*)': '$1'
   symbol-address:
     # Used to expose symbol and typedef.
@@ -197,16 +200,20 @@ functions:
 enums:
   member-rename:
     '(.*)': # Matches any enum.
-      # Removes '_' from beginning enum member name.
+      # Removes '_' from beginning
+      # enum member name.
       '_(.*)': '$1'
-    'CXTypeKind': # Full names have higher priority.
-      # $1 keeps only the 1st group i.e '(.*)'.
+    # Full names have higher priority.
+    'CXTypeKind':
+      # $1 keeps only the 1st
+      # group i.e only '(.*)'.
       'CXType(.*)': '$1'
 globals:
   exclude:
     - aGlobal
   rename:
-    # Removes '_' from beginning of a name.
+    # Removes '_' from
+    # beginning of a name.
     '_(.*)': '$1'
 ```
   </td>
@@ -341,7 +348,8 @@ typedef-map:
 
 ```yaml
 # These are optional and also default,
-# Omitting any and the default will be used.
+# Omitting any and the default
+# will be used.
 size-map:
   char: 1
   unsigned char: 1

--- a/example/libclang-example/pubspec.yaml
+++ b/example/libclang-example/pubspec.yaml
@@ -30,7 +30,7 @@ ffigen:
       - '**Index.h'
 
   compiler-opts:
-    - '-Ithird_party/libclang/include'
+    - '-I../../third_party/libclang/include'
     - '-Wno-nullability-completeness'
   functions:
     include:

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -380,7 +380,7 @@ String llvmPathExtractor(dynamic value) {
     return res;
   } catch (e) {
     _logger.severe(
-        "Couldn't find libclang dynamic library in specified locations.");
+        "Couldn't find ${p.join(strings.dynamicLibParentName, strings.dylibFileName)} in specified locations.");
     exit(1);
   }
 }

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -146,7 +146,8 @@ const libclang_dylib_windows = 'libclang.dll';
 const linuxDylibLocations = [
   '/usr/lib/llvm-9/lib/',
   '/usr/lib/llvm-10/lib/',
-  '/usr/lib/llvm-11/lib/'
+  '/usr/lib/llvm-11/lib/',
+  '/usr/lib/'
 ];
 const windowsDylibLocations = [
   r'C:\Program Files\LLVM\bin\',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 


### PR DESCRIPTION
- Update readme to improve readability, the config table's explanation column is slightly wider now.
- Update to latest bindings in readme example, fix compiler-opts for ibclang-example.
- Added `/usr/lib` to default locations for Linux, specify exact search path in readme and logs. (See https://github.com/dart-lang/ffigen/issues/195#issuecomment-805255912). 
- Update version and changelog.