### PR TITLE
Fix error caused by duplicate declaration names and collision with ffi library prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.4.2
+- Fix issues due to declarations having duplicate names.
+
 # 2.4.1
 - Added `/usr/lib` to default dynamic library location for linux.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.4.2
 - Fix issues due to declarations having duplicate names.
 - Fix name conflict of declaration with ffi library prefix.
+- Fix `char` not being recognized on platforms where it's unsigned by default.
 
 # 2.4.1
 - Added `/usr/lib` to default dynamic library location for linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.4.2
 - Fix issues due to declarations having duplicate names.
+- Fix name conflict of declaration with ffi library prefix.
 
 # 2.4.1
 - Added `/usr/lib` to default dynamic library location for linux.

--- a/lib/src/code_generator/library.dart
+++ b/lib/src/code_generator/library.dart
@@ -31,23 +31,16 @@ class Library {
   }) {
     if (sort) _sort();
 
+    /// Handle any declaration-declaration name conflicts.
+    final declConflictHandler = UniqueNamer({});
+    for (final b in bindings) {
+      _warnIfPrivateDeclaration(b);
+      _resolveIfNameConflicts(declConflictHandler, b);
+    }
+
     // Seperate bindings which require lookup.
     final lookUpBindings = bindings.whereType<LookUpBinding>().toList();
     final noLookUpBindings = bindings.whereType<NoLookUpBinding>().toList();
-
-    /// Handle any declaration-declaration name conflict in [lookUpBindings].
-    final lookUpDeclConflictHandler = UniqueNamer({});
-    for (final b in lookUpBindings) {
-      _warnIfPrivateDeclaration(b);
-      _resolveIfNameConflicts(lookUpDeclConflictHandler, b);
-    }
-
-    /// Handle any declaration-declaration name conflict in [noLookUpBindings].
-    final noLookUpDeclConflictHandler = UniqueNamer({});
-    for (final b in noLookUpBindings) {
-      _warnIfPrivateDeclaration(b);
-      _resolveIfNameConflicts(noLookUpDeclConflictHandler, b);
-    }
 
     _writer = Writer(
       lookUpBindings: lookUpBindings,

--- a/lib/src/code_generator/writer.dart
+++ b/lib/src/code_generator/writer.dart
@@ -70,23 +70,42 @@ class Writer {
     final allLevelsUniqueNamer = UniqueNamer(allNameSet);
 
     /// Wrapper class name must be unique among all names.
-    _className = allLevelsUniqueNamer.makeUnique(className);
-    _initialWrapperLevelUniqueNamer.markUsed(_className);
-    _initialTopLevelUniqueNamer.markUsed(_className);
+    _className = _resolveNameConflict(
+      name: className,
+      makeUnique: allLevelsUniqueNamer,
+      markUsed: [_initialWrapperLevelUniqueNamer, _initialTopLevelUniqueNamer],
+    );
 
-    /// [_ffiLibraryPrefix] should be unique in top level.
-    _ffiLibraryPrefix = _initialTopLevelUniqueNamer.makeUnique('ffi');
+    /// [_ffiLibraryPrefix] should be unique unique among all names.
+    _ffiLibraryPrefix = _resolveNameConflict(
+      name: 'ffi',
+      makeUnique: allLevelsUniqueNamer,
+      markUsed: [_initialWrapperLevelUniqueNamer, _initialTopLevelUniqueNamer],
+    );
 
     /// [_lookupFuncIdentifier] should be unique in top level.
-    _lookupFuncIdentifier = _initialTopLevelUniqueNamer.makeUnique('_lookup');
+    _lookupFuncIdentifier = _resolveNameConflict(
+      name: '_lookup',
+      makeUnique: _initialTopLevelUniqueNamer,
+      markUsed: [_initialTopLevelUniqueNamer],
+    );
 
     /// Resolve name conflicts of identifiers used for SymbolAddresses.
-    _symbolAddressClassName =
-        allLevelsUniqueNamer.makeUnique('_SymbolAddresses');
-    _symbolAddressVariableName =
-        _initialWrapperLevelUniqueNamer.makeUnique('addresses');
-    _symbolAddressLibraryVarName =
-        _initialWrapperLevelUniqueNamer.makeUnique('_library');
+    _symbolAddressClassName = _resolveNameConflict(
+      name: '_SymbolAddresses',
+      makeUnique: allLevelsUniqueNamer,
+      markUsed: [_initialWrapperLevelUniqueNamer, _initialTopLevelUniqueNamer],
+    );
+    _symbolAddressVariableName = _resolveNameConflict(
+      name: 'addresses',
+      makeUnique: _initialWrapperLevelUniqueNamer,
+      markUsed: [_initialWrapperLevelUniqueNamer],
+    );
+    _symbolAddressLibraryVarName = _resolveNameConflict(
+      name: '_library',
+      makeUnique: _initialWrapperLevelUniqueNamer,
+      markUsed: [_initialWrapperLevelUniqueNamer],
+    );
 
     /// Finding a unique prefix for Array Helper Classes and store into
     /// [_arrayHelperClassPrefix].
@@ -103,6 +122,20 @@ class Writer {
     }
 
     _resetUniqueNamersNamers();
+  }
+
+  /// Resolved name conflict using [makeUnique] and marks the result as used in
+  /// all [markUsed].
+  String _resolveNameConflict({
+    required String name,
+    required UniqueNamer makeUnique,
+    List<UniqueNamer> markUsed = const [],
+  }) {
+    final s = makeUnique.makeUnique(name);
+    for (final un in markUsed) {
+      un.markUsed(s);
+    }
+    return s;
   }
 
   /// Resets the namers to initial state. Namers are reset before generating.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 2.4.1
+version: 2.4.2
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 

--- a/test/collision_tests/decl_decl_collision_test.dart
+++ b/test/collision_tests/decl_decl_collision_test.dart
@@ -44,6 +44,12 @@ void main() {
             returnType: Type.nativeType(SupportedNativeType.Void)),
         Constant(name: 'testCrossDecl', rawValue: '0', rawType: 'int'),
         EnumClass(name: 'testCrossDecl'),
+
+        /// Conflicts with ffi library prefix, name of prefix is changed.
+        Struc(name: 'ffi'),
+        Func(
+            name: 'ffi_1',
+            returnType: Type.nativeType(SupportedNativeType.Void)),
       ]);
       final l2 = Library(name: 'Bindings', bindings: [
         Struc(name: 'TestStruc'),
@@ -77,6 +83,10 @@ void main() {
             returnType: Type.nativeType(SupportedNativeType.Void)),
         Constant(name: 'testCrossDecl_2', rawValue: '0', rawType: 'int'),
         EnumClass(name: 'testCrossDecl_3'),
+        Struc(name: 'ffi'),
+        Func(
+            name: 'ffi_1',
+            returnType: Type.nativeType(SupportedNativeType.Void)),
       ]);
 
       expect(l1.generate(), l2.generate());

--- a/test/collision_tests/decl_decl_collision_test.dart
+++ b/test/collision_tests/decl_decl_collision_test.dart
@@ -37,7 +37,7 @@ void main() {
           rawValue: '0',
         ),
 
-        /// Conflicts across declarations
+        /// Conflicts across declarations.
         Struc(name: 'testCrossDecl'),
         Func(
             name: 'testCrossDecl',

--- a/test/collision_tests/decl_decl_collision_test.dart
+++ b/test/collision_tests/decl_decl_collision_test.dart
@@ -36,6 +36,14 @@ void main() {
           rawType: 'int',
           rawValue: '0',
         ),
+
+        /// Conflicts across declarations
+        Struc(name: 'testCrossDecl'),
+        Func(
+            name: 'testCrossDecl',
+            returnType: Type.nativeType(SupportedNativeType.Void)),
+        Constant(name: 'testCrossDecl', rawValue: '0', rawType: 'int'),
+        EnumClass(name: 'testCrossDecl'),
       ]);
       final l2 = Library(name: 'Bindings', bindings: [
         Struc(name: 'TestStruc'),
@@ -62,6 +70,13 @@ void main() {
           rawType: 'int',
           rawValue: '0',
         ),
+        Struc(name: 'testCrossDecl', originalName: 'testCrossDecl'),
+        Func(
+            name: 'testCrossDecl_1',
+            originalName: 'testCrossDecl',
+            returnType: Type.nativeType(SupportedNativeType.Void)),
+        Constant(name: 'testCrossDecl_2', rawValue: '0', rawType: 'int'),
+        EnumClass(name: 'testCrossDecl_3'),
       ]);
 
       expect(l1.generate(), l2.generate());


### PR DESCRIPTION
Closes #199 

- Fix error caused by duplicate declaration names across different namespaces (global and inside NativeLibrary).
- Fix name conflict of lookup bindings with ffi library prefix.
- Updated tests, version, and changelog.

---

Fixes for some corner cases of name conflicts that we missed earlier.