### PR TITLE
Allow users to specify complete dylib path 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.0-dev.1
+- Users can now specify exact path to dynamic library in `llvm-path`.
+
 # 3.1.0-dev.0
 - Added support for generating unions.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ output: 'generated_bindings.dart'
     <td>llvm-path</td>
     <td>Path to <i>llvm</i> folder.<br> ffigen will sequentially search
     for `lib/libclang.so` on linux, `lib/libclang.dylib` on macOs and
-    `bin\libclang.dll` on windows, in the specified paths.<br>
+    `bin\libclang.dll` on windows, in the specified paths.<br><br>
+    Complete path to the dynamic library can also be supplied.<br>
     <i>Required</i> if ffigen is unable to find this at default locations.</td>
     <td>
 
@@ -107,6 +108,8 @@ llvm-path:
   - '/usr/local/opt/llvm'
   - 'C:\Program Files\llvm`
   - '/usr/lib/llvm-11'
+  # Specify exact path to dylib
+  - '/usr/lib64/libclang.so'
 ```
   </td>
   </tr>

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -349,6 +349,14 @@ String llvmPathExtractor(dynamic value) {
       _logger.fine('Found dynamic library at: $dylibPath');
       return dylibPath;
     }
+    // Check if user has specified complete path to dylib.
+    final completeDylibPath = path;
+    if (p.extension(completeDylibPath).isNotEmpty &&
+        File(completeDylibPath).existsSync()) {
+      _logger.info(
+          'Using complete dylib path: $completeDylibPath from llvm-path.');
+      return completeDylibPath;
+    }
   }
   _logger.fine(
       "Couldn't find dynamic library under paths specified by ${strings.llvmPath}.");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 3.1.0-dev.0
+version: 3.1.0-dev.1
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 


### PR DESCRIPTION
Closes #220 
- `llvm-path` can now contain a complete path to dylib as well.
- Update version, changelog
- Update README.md.

---

On Fedora the libclang dylib is saved in `/usr/lib64/libclang.so`. Other different OSs could have something else as well. Having the option to directly specify the complete path to dylib will be useful to such users.