### PR TITLE
Exclude all on empty include list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.1.2
+- Added fix for empty include list to exclude all
+
 # 4.1.1
 - Added fix for errors due to name collision between member name
 and type name used internally in structs/unions.

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -397,6 +397,9 @@ Includer _extractIncluderFromYaml(dynamic yamlMap) {
 
   final include = (yamlMap[strings.include] as YamlList?)?.cast<String>();
   if (include != null) {
+    if (include.isEmpty) {
+      return Includer.excludeByDefault();
+    }
     for (final str in include) {
       if (isFullDeclarationName(str)) {
         includeFull.add(str);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 4.1.1
+version: 4.1.2
 homepage: https://github.com/dart-lang/ffigen
 description: Generator for FFI bindings, using LibClang to parse C header files.
 


### PR DESCRIPTION
When setting `include: []`, I expected nothing will be included. When I saw everything was included anyway, I thought that null and empty list probably are processed the same and the next try `exclude: [".*"]` worked.

Anyway, I think the correct behavior for `include: []` is include nothing. In my use case, I explicitly allowlist every item and `include: []` is more intuitive for the categories without any items.