### PR TITLE
Add default location for LLVM on M1 Mac

### DIFF
--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -186,6 +186,7 @@ const windowsDylibLocations = [
 ];
 const macOsDylibLocations = [
   '/usr/local/opt/llvm/lib/',
+  '/opt/homebrew/opt/llvm/lib/',
 ];
 
 // Writen doubles.

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -174,20 +174,20 @@ const libclang_dylib_macos = 'libclang.dylib';
 const libclang_dylib_windows = 'libclang.dll';
 
 // Dynamic library default locations.
-const linuxDylibLocations = [
+const linuxDylibLocations = {
   '/usr/lib/llvm-9/lib/',
   '/usr/lib/llvm-10/lib/',
   '/usr/lib/llvm-11/lib/',
   '/usr/lib/',
   '/usr/lib64/',
-];
-const windowsDylibLocations = [
+};
+const windowsDylibLocations = {
   r'C:\Program Files\LLVM\bin\',
-];
-const macOsDylibLocations = [
+};
+const macOsDylibLocations = {
   '/usr/local/opt/llvm/lib/',
   '/opt/homebrew/opt/llvm/lib/',
-];
+};
 
 // Writen doubles.
 const doubleInfinity = 'double.infinity';

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -187,6 +187,7 @@ const windowsDylibLocations = [
 const macOsDylibLocations = [
   '/usr/local/opt/llvm/lib/',
   '/opt/homebrew/opt/llvm/lib/',
+  '/noNotSubmit/',
 ];
 
 // Writen doubles.

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -187,7 +187,6 @@ const windowsDylibLocations = [
 const macOsDylibLocations = [
   '/usr/local/opt/llvm/lib/',
   '/opt/homebrew/opt/llvm/lib/',
-  '/noNotSubmit/',
 ];
 
 // Writen doubles.


### PR DESCRIPTION
I've verified on my M1 Macbook Pro that `brew install llvm` installs llvm in /opt/homebrew/opt/llvm/lib/ (as the [Homebrew documentation](https://docs.brew.sh/Installation) explains:  `/usr/local for macOS Intel, /opt/homebrew for Apple Silicon`)

Currently this path can be provided with symlinks or in ffigen's config with llvm-path, but it would be great to check the default brew install location by default.