### PR TITLE
Use `package:ffi` 1.2.1

### DIFF
--- a/example/c_json/pubspec.yaml
+++ b/example/c_json/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ^1.2.1
   path: ^1.8.0
 
 dev_dependencies:

--- a/example/libclang-example/pubspec.yaml
+++ b/example/libclang-example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ^1.2.1
 dev_dependencies:
   ffigen:
     path: '../../'

--- a/example/simple/pubspec.yaml
+++ b/example/simple/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ^1.2.1
 dev_dependencies:
   ffigen:
     path: '../../'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ^1.2.1
   yaml: ^3.0.0
   path: ^1.8.0
   quiver: ^3.0.0


### PR DESCRIPTION
For https://github.com/dart-lang/native/issues/279

To prevent having to run

> `dart pub downgrade` then `dart pub upgrade`

due to the downgrade from 1.2.0 dev to 1.1.2 earlier.