### PR TITLE
Handle NS_RETURNS_RETAINED and methods that start with new/alloc or contain copy

### DIFF
--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -387,6 +387,7 @@ class ObjCMethod {
   final List<ObjCMethodParam> params;
   final ObjCMethodKind kind;
   final bool isClass;
+  bool returnsRetained = false;
   ObjCInternalGlobal? selObject;
   Func? msgSend;
 
@@ -445,7 +446,12 @@ class ObjCMethod {
     return msgSend == other.msgSend;
   }
 
-  bool get isOwnedReturn => originalName == 'new' || originalName == 'alloc';
+  static final _copyRegExp = RegExp('[cC]opy');
+  bool get isOwnedReturn =>
+      returnsRetained ||
+      originalName.startsWith('new') ||
+      originalName.startsWith('alloc') ||
+      originalName.contains(_copyRegExp);
 }
 
 class ObjCMethodParam {

--- a/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -222,6 +222,9 @@ int _parseMethodVisitor(clang_types.CXCursor cursor,
     case clang_types.CXCursorKind.CXCursor_ParmDecl:
       _parseMethodParam(cursor);
       break;
+    case clang_types.CXCursorKind.CXCursor_NSReturnsRetained:
+      _markMethodReturnsRetained(cursor);
+      break;
     default:
   }
   return clang_types.CXChildVisitResult.CXChildVisit_Continue;
@@ -265,6 +268,10 @@ void _parseMethodParam(clang_types.CXCursor cursor) {
       '           >> Parameter: $type $name ${cursor.completeStringRepr()}');
   _methodStack.top.method.params
       .add(ObjCMethodParam(type, name, isNullable: isNullable));
+}
+
+void _markMethodReturnsRetained(clang_types.CXCursor cursor) {
+  _methodStack.top.method.returnsRetained = true;
 }
 
 BindingType? parseObjCCategoryDeclaration(clang_types.CXCursor cursor) {

--- a/test/native_objc_test/automated_ref_count_test.dart
+++ b/test/native_objc_test/automated_ref_count_test.dart
@@ -42,12 +42,20 @@ void main() {
     }
 
     verifyRefCountsInner(Pointer<Int32> counter) {
-      final obj1 = ArcTestObject.alloc(lib).initWithCounter_(counter);
+      final obj1 = ArcTestObject.new1(lib);
+      obj1.setCounter_(counter);
       expect(counter.value, 1);
       final obj2 = ArcTestObject.alloc(lib).initWithCounter_(counter);
       expect(counter.value, 2);
-      final obj3 = ArcTestObject.alloc(lib).initWithCounter_(counter);
+      final obj3 = ArcTestObject.castFrom(ArcTestObject.alloc(lib).init());
+      obj3.setCounter_(counter);
       expect(counter.value, 3);
+      final obj4 = obj3.makeACopy();
+      expect(counter.value, 4);
+      final obj5 = ArcTestObject.allocTheThing(lib).initWithCounter_(counter);
+      expect(counter.value, 5);
+      final obj6 = ArcTestObject.newWithCounter_(lib, counter);
+      expect(counter.value, 6);
     }
 
     test('Verify ref counts', () {
@@ -62,22 +70,36 @@ void main() {
 
     test('Manual release', () {
       final counter = calloc<Int32>();
-      final obj1 = ArcTestObject.alloc(lib).initWithCounter_(counter);
+      final obj1 = ArcTestObject.new1(lib);
+      obj1.setCounter_(counter);
       expect(counter.value, 1);
       final obj2 = ArcTestObject.alloc(lib).initWithCounter_(counter);
       expect(counter.value, 2);
-      final obj3 = ArcTestObject.alloc(lib).initWithCounter_(counter);
+      final obj3 = ArcTestObject.castFrom(ArcTestObject.alloc(lib).init());
+      obj3.setCounter_(counter);
       expect(counter.value, 3);
+      final obj4 = obj3.makeACopy();
+      expect(counter.value, 4);
+      final obj5 = ArcTestObject.allocTheThing(lib).initWithCounter_(counter);
+      expect(counter.value, 5);
+      final obj6 = ArcTestObject.newWithCounter_(lib, counter);
+      expect(counter.value, 6);
 
-      // GC to clean up temporaries created between alloc and initWithCounter_.
+      // GC to clean up temporaries created between alloc and init.
       doGC();
-      expect(counter.value, 3);
+      expect(counter.value, 6);
 
       obj1.release();
-      expect(counter.value, 2);
+      expect(counter.value, 5);
       obj2.release();
-      expect(counter.value, 1);
+      expect(counter.value, 4);
       obj3.release();
+      expect(counter.value, 3);
+      obj4.release();
+      expect(counter.value, 2);
+      obj5.release();
+      expect(counter.value, 1);
+      obj6.release();
       expect(counter.value, 0);
 
       expect(() => obj1.release(), throwsStateError);
@@ -85,7 +107,8 @@ void main() {
     });
 
     ArcTestObject unownedReferenceInner2(Pointer<Int32> counter) {
-      final obj1 = ArcTestObject.alloc(lib).initWithCounter_(counter);
+      final obj1 = ArcTestObject.new1(lib);
+      obj1.setCounter_(counter);
       expect(counter.value, 1);
       final obj1b = obj1.unownedReference();
       expect(counter.value, 1);
@@ -93,7 +116,8 @@ void main() {
       // Make a second object so that the counter check in unownedReferenceInner
       // sees some sort of change. Otherwise this test could pass just by the GC
       // not working correctly.
-      final obj2 = ArcTestObject.alloc(lib).initWithCounter_(counter);
+      final obj2 = ArcTestObject.new1(lib);
+      obj2.setCounter_(counter);
       expect(counter.value, 2);
 
       return obj1b;

--- a/test/native_objc_test/automated_ref_count_test.m
+++ b/test/native_objc_test/automated_ref_count_test.m
@@ -8,18 +8,36 @@
   int32_t* counter;
 }
 
++ (instancetype)allocTheThing;
++ (instancetype)newWithCounter:(int32_t*) _counter;
 - (instancetype)initWithCounter:(int32_t*) _counter;
+- (void)setCounter:(int32_t*) _counter;
 - (void)dealloc;
 - (ArcTestObject*)unownedReference;
+- (ArcTestObject*)makeACopy;
+- (ArcTestObject*)returnsRetained NS_RETURNS_RETAINED;
 
 @end
 
 @implementation ArcTestObject
 
++ (instancetype)allocTheThing {
+  return [ArcTestObject alloc];
+}
+
++ (instancetype)newWithCounter:(int32_t*) _counter {
+  return [[ArcTestObject alloc] initWithCounter: _counter];
+}
+
 - (instancetype)initWithCounter:(int32_t*) _counter {
   counter = _counter;
   ++*counter;
   return [super init];
+}
+
+- (void)setCounter:(int32_t*) _counter {
+  counter = _counter;
+  ++*counter;
 }
 
 - (void)dealloc {
@@ -29,6 +47,14 @@
 
 - (ArcTestObject*)unownedReference {
   return self;
+}
+
+- (ArcTestObject*)makeACopy {
+  return [[ArcTestObject alloc] initWithCounter: counter];
+}
+
+- (ArcTestObject*)returnsRetained NS_RETURNS_RETAINED {
+  return [self retain];
 }
 
 @end

--- a/test/native_objc_test/automated_ref_count_test.m
+++ b/test/native_objc_test/automated_ref_count_test.m
@@ -14,6 +14,7 @@
 - (void)setCounter:(int32_t*) _counter;
 - (void)dealloc;
 - (ArcTestObject*)unownedReference;
+- (ArcTestObject*)copyMe;
 - (ArcTestObject*)makeACopy;
 - (ArcTestObject*)returnsRetained NS_RETURNS_RETAINED;
 
@@ -47,6 +48,10 @@
 
 - (ArcTestObject*)unownedReference {
   return self;
+}
+
+- (ArcTestObject*)copyMe {
+  return [[ArcTestObject alloc] initWithCounter: counter];
 }
 
 - (ArcTestObject*)makeACopy {


### PR DESCRIPTION
Rather than just exact matching "new" and "alloc" methods.

#379 