### PR TITLE
Add a static isInstance method to ObjC classes

### DIFF
--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -46,8 +46,6 @@ class ObjCInterface extends BindingType {
   late final ObjCInternalGlobal _classObject;
   late final ObjCInternalGlobal _isKindOfClass;
   late final Func _isKindOfClassMsgSend;
-  late final ObjCInternalGlobal _classGetter;
-  late final Func _classGetterMsgSend;
 
   ObjCInterface({
     String? usr,
@@ -113,8 +111,7 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
   static bool isInstance(_ObjCWrapper obj) {
     return obj._lib.${_isKindOfClassMsgSend.name}(
         obj._id, obj._lib.${_isKindOfClass.name},
-        obj._lib.${_classGetterMsgSend.name}(
-            obj._lib.${_classObject.name}, obj._lib.${_classGetter.name}));
+        obj._lib.${_classObject.name});
   }
 
 ''');
@@ -236,9 +233,6 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
     _isKindOfClass = builtInFunctions.getSelObject('isKindOfClass:');
     _isKindOfClassMsgSend = builtInFunctions.getMsgSendFunc(
         BooleanType(), [ObjCMethodParam(PointerType(objCObjectType), 'clazz')]);
-    _classGetter = builtInFunctions.getSelObject('class');
-    _classGetterMsgSend = builtInFunctions.getMsgSendFunc(
-        PointerType(objCObjectType), []);
 
     if (isNSString) {
       _addNSStringMethods();

--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -44,6 +44,10 @@ class ObjCInterface extends BindingType {
   final ObjCBuiltInFunctions builtInFunctions;
   final bool isBuiltIn;
   late final ObjCInternalGlobal _classObject;
+  late final ObjCInternalGlobal _isKindOfClass;
+  late final Func _isKindOfClassMsgSend;
+  late final ObjCInternalGlobal _classGetter;
+  late final Func _classGetterMsgSend;
 
   ObjCInterface({
     String? usr,
@@ -95,12 +99,22 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
       {bool retain = false, bool release = false}) :
           super._(id, lib, retain: retain, release: release);
 
+  /// Returns a [$name] that points to the same underlying object as [other].
   static $name castFrom<T extends _ObjCWrapper>(T other) {
     return $name._(other._id, other._lib, retain: true, release: true);
   }
 
+  /// Returns a [$name] that wraps the given raw object pointer.
   static $name castFromPointer($natLib lib, ffi.Pointer<ObjCObject> other) {
     return $name._(other, lib, retain: true, release: true);
+  }
+
+  /// Returns whether [obj] is an instance of [$name].
+  static bool isInstance(_ObjCWrapper obj) {
+    return obj._lib.${_isKindOfClassMsgSend.name}(
+        obj._id, obj._lib.${_isKindOfClass.name},
+        obj._lib.${_classGetterMsgSend.name}(
+            obj._lib.${_classObject.name}, obj._lib.${_classGetter.name}));
   }
 
 ''');
@@ -219,6 +233,12 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
         (Writer w) => '${builtInFunctions.getClass.name}("$originalName")',
         builtInFunctions.getClass)
       ..addDependencies(dependencies);
+    _isKindOfClass = builtInFunctions.getSelObject('isKindOfClass:');
+    _isKindOfClassMsgSend = builtInFunctions.getMsgSendFunc(
+        BooleanType(), [ObjCMethodParam(PointerType(objCObjectType), 'clazz')]);
+    _classGetter = builtInFunctions.getSelObject('class');
+    _classGetterMsgSend = builtInFunctions.getMsgSendFunc(
+        PointerType(objCObjectType), []);
 
     if (isNSString) {
       _addNSStringMethods();

--- a/test/native_objc_test/is_instance_config.yaml
+++ b/test/native_objc_test/is_instance_config.yaml
@@ -1,0 +1,12 @@
+name: IsInstanceTestObjCLibrary
+description: 'Tests isInstance'
+language: objc
+output: 'test/native_objc_test/is_instance_bindings.dart'
+functions:
+  exclude:
+    - '.*'
+headers:
+  entry-points:
+    - 'test/native_objc_test/is_instance_test.m'
+preamble: |
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, unused_element, unused_field

--- a/test/native_objc_test/is_instance_test.dart
+++ b/test/native_objc_test/is_instance_test.dart
@@ -27,8 +27,8 @@ void main() {
     });
 
     test('Unrelated classes', () {
-      final base = BaseClass.new1(lib);
-      final unrelated = UnrelatedClass.new1(lib);
+      final base = NSObject.castFrom(BaseClass.new1(lib));
+      final unrelated = NSObject.castFrom(UnrelatedClass.new1(lib));
       expect(BaseClass.isInstance(base), isTrue);
       expect(BaseClass.isInstance(unrelated), isFalse);
       expect(UnrelatedClass.isInstance(base), isFalse);
@@ -36,8 +36,8 @@ void main() {
     });
 
     test('Base class vs child class', () {
-      final base = BaseClass.new1(lib);
-      final child = ChildClass.new1(lib);
+      final base = NSObject.castFrom(BaseClass.new1(lib));
+      final child = NSObject.castFrom(ChildClass.new1(lib));
       expect(BaseClass.isInstance(base), isTrue);
       expect(BaseClass.isInstance(child), isTrue);
       expect(ChildClass.isInstance(base), isFalse);

--- a/test/native_objc_test/is_instance_test.dart
+++ b/test/native_objc_test/is_instance_test.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Objective C support is only available on mac.
+
+@TestOn('mac-os')
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import '../test_utils.dart';
+import 'is_instance_bindings.dart';
+import 'util.dart';
+
+void main() {
+  late IsInstanceTestObjCLibrary lib;
+
+  group('isInstance', () {
+    setUpAll(() {
+      logWarnings();
+      final dylib = File('test/native_objc_test/is_instance_test.dylib');
+      verifySetupFile(dylib);
+      lib = IsInstanceTestObjCLibrary(DynamicLibrary.open(dylib.absolute.path));
+      generateBindingsForCoverage('is_instance');
+    });
+
+    test('Unrelated classes', () {
+      final base = BaseClass.new1(lib);
+      final unrelated = UnrelatedClass.new1(lib);
+      expect(BaseClass.isInstance(base), isTrue);
+      expect(BaseClass.isInstance(unrelated), isFalse);
+      expect(UnrelatedClass.isInstance(base), isFalse);
+      expect(UnrelatedClass.isInstance(unrelated), isTrue);
+    });
+
+    test('Base class vs child class', () {
+      final base = BaseClass.new1(lib);
+      final child = ChildClass.new1(lib);
+      expect(BaseClass.isInstance(base), isTrue);
+      expect(BaseClass.isInstance(child), isTrue);
+      expect(ChildClass.isInstance(base), isFalse);
+      expect(ChildClass.isInstance(child), isTrue);
+    });
+  });
+}

--- a/test/native_objc_test/is_instance_test.m
+++ b/test/native_objc_test/is_instance_test.m
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#import <Foundation/NSObject.h>
+
+@interface BaseClass : NSObject {}
+@end
+
+@interface ChildClass : BaseClass {}
+@end
+
+@interface UnrelatedClass : NSObject {}
+@end
+
+@implementation BaseClass
+@end
+
+@implementation ChildClass
+@end
+
+@implementation UnrelatedClass
+@end

--- a/test/native_objc_test/setup.dart
+++ b/test/native_objc_test/setup.dart
@@ -51,6 +51,7 @@ const testNames = [
   'cast',
   'category',
   'forward_decl',
+  'is_instance',
   'method',
   'native_objc',
   'nullable',


### PR DESCRIPTION
This method is a wrapper around [isKindOfClass](https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418511-iskindofclass), but inverts the args (`Class.isInstance(obj)` instead of `obj.isKindOfClass(Class)` or `obj.isKindOfClass<Class>()`) due to limitations in dart templates.

Fixes #374 