### PR TITLE
Use `ldconfig` to find libclang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.0.1
 
 - Replace path separators in `include-directives` before matching file names.
+- Add more ways to find `libclang`.
 
 # 6.0.0
 - Removed config `dart-bool`. Booleans are now always generated with `bool`

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -381,6 +381,20 @@ String findDylibAtDefaultLocations() {
       k = findLibclangDylib(l);
       if (k != null) return k;
     }
+    Process.runSync('ldconfig', ['-p']);
+    final ldConfigResult = Process.runSync('ldconfig', ['-p']);
+    if (ldConfigResult.exitCode == 0) {
+      final lines = (ldConfigResult.stdout as String).split('\n');
+      final paths = [
+        for (final line in lines)
+          if (line.contains('libclang')) line.split(' => ')[1],
+      ];
+      for (final location in paths) {
+        if (File(location).existsSync()) {
+          return location;
+        }
+      }
+    }
   } else if (Platform.isWindows) {
     for (final l in strings.windowsDylibLocations) {
       k = findLibclangDylib(l);


### PR DESCRIPTION
Having more robust ways to find libclang could help finding it on Flutter bots as well.

* https://github.com/flutter/flutter/pull/105688