### PR TITLE
Skip methods that have incomplete types

### DIFF
--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -125,7 +125,7 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
     for (final m in methods.values) {
       final methodName = m._getDartMethodName(uniqueNamer);
       final isStatic = m.isClass;
-      final returnType = m.returnType!;
+      final returnType = m.returnType;
 
       // The method declaration.
       if (m.dartDoc != null) {
@@ -397,7 +397,7 @@ class ObjCMethod {
   final String? dartDoc;
   final String originalName;
   final ObjCProperty? property;
-  Type? returnType;
+  final Type returnType;
   final bool isNullableReturn;
   final List<ObjCMethodParam> params;
   final ObjCMethodKind kind;
@@ -412,7 +412,7 @@ class ObjCMethod {
     this.dartDoc,
     required this.kind,
     required this.isClass,
-    this.returnType,
+    required this.returnType,
     this.isNullableReturn = false,
     List<ObjCMethodParam>? params_,
   }) : params = params_ ?? [];
@@ -423,14 +423,13 @@ class ObjCMethod {
 
   void addDependencies(
       Set<Binding> dependencies, ObjCBuiltInFunctions builtInFunctions) {
-    returnType ??= NativeType(SupportedNativeType.Void);
-    returnType!.addDependencies(dependencies);
+    returnType.addDependencies(dependencies);
     for (final p in params) {
       p.type.addDependencies(dependencies);
     }
     selObject ??= builtInFunctions.getSelObject(originalName)
       ..addDependencies(dependencies);
-    msgSend ??= builtInFunctions.getMsgSendFunc(returnType!, params)
+    msgSend ??= builtInFunctions.getMsgSendFunc(returnType, params)
       ..addDependencies(dependencies);
   }
 

--- a/lib/src/header_parser/clang_bindings/clang_bindings.dart
+++ b/lib/src/header_parser/clang_bindings/clang_bindings.dart
@@ -791,6 +791,23 @@ class Clang {
       _clang_Type_getObjCObjectBaseTypePtr
           .asFunction<CXType Function(CXType)>();
 
+  /// Retrieve the return type associated with a given cursor.
+  ///
+  /// This only returns a valid type if the cursor refers to a function or method.
+  CXType clang_getCursorResultType(
+    CXCursor C,
+  ) {
+    return _clang_getCursorResultType(
+      C,
+    );
+  }
+
+  late final _clang_getCursorResultTypePtr =
+      _lookup<ffi.NativeFunction<CXType Function(CXCursor)>>(
+          'clang_getCursorResultType');
+  late final _clang_getCursorResultType =
+      _clang_getCursorResultTypePtr.asFunction<CXType Function(CXCursor)>();
+
   /// Return the number of elements of an array or vector type.
   ///
   /// If a type is passed in that is not an array or vector type,

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -45,6 +45,12 @@ Type getCodeGenType(
   if (config.language == Language.objc) {
     switch (cxtype.kind) {
       case clang_types.CXTypeKind.CXType_ObjCObjectPointer:
+        final pt = clang.clang_getPointeeType(cxtype);
+        final s = getCodeGenType(pt, pointerReference: true);
+        if (s is ObjCInterface) {
+          return s;
+        }
+        return PointerType(objCObjectType);
       case clang_types.CXTypeKind.CXType_ObjCId:
       case clang_types.CXTypeKind.CXType_ObjCTypeParam:
       case clang_types.CXTypeKind.CXType_ObjCClass:

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -46,7 +46,8 @@ Type getCodeGenType(
     switch (cxtype.kind) {
       case clang_types.CXTypeKind.CXType_ObjCObjectPointer:
         final pt = clang.clang_getPointeeType(cxtype);
-        final s = getCodeGenType(pt, pointerReference: true);
+        final s = getCodeGenType(pt,
+            ignoreFilter: ignoreFilter, pointerReference: true);
         if (s is ObjCInterface) {
           return s;
         }

--- a/test/native_objc_test/bad_method_config.yaml
+++ b/test/native_objc_test/bad_method_config.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+# =================== GENERATING TEST BINDINGS ==================
+#    dart run ffigen --config test/bad_method_test/config.yaml
+# ===============================================================
+
+name: NativeObjCLibrary
+description: 'Native Objective C test'
+language: objc
+output: 'test/native_objc_test/bad_method_test_bindings.dart'
+objc-interfaces:
+  include:
+    - 'BadMethodTestObject'
+functions:
+  exclude:
+    - '.*'
+headers:
+  entry-points:
+    - 'test/native_objc_test/bad_method_test.m'
+preamble: |
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, unused_element, unused_field

--- a/test/native_objc_test/bad_method_test.dart
+++ b/test/native_objc_test/bad_method_test.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Objective C support is only available on mac.
+@TestOn('mac-os')
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import '../test_utils.dart';
+import 'bad_method_test_bindings.dart';
+import 'util.dart';
+
+void main() {
+  late NativeObjCLibrary lib;
+  group('bad_method_test', () {
+    setUpAll(() {
+      logWarnings();
+      final dylib = File('test/native_objc_test/bad_method_test.dylib');
+      verifySetupFile(dylib);
+      lib = NativeObjCLibrary(DynamicLibrary.open(dylib.absolute.path));
+      generateBindingsForCoverage('bad_method');
+    });
+
+    test("Test methods that weren't skipped", () {
+      final obj = BadMethodTestObject.new1(lib);
+      final structPtr = obj.incompletePointerReturn();
+      expect(structPtr.address, 1234);
+      expect(obj.incompletePointerParam_(structPtr), 1234);
+    });
+  });
+}

--- a/test/native_objc_test/bad_method_test.m
+++ b/test/native_objc_test/bad_method_test.m
@@ -1,0 +1,29 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#import <Foundation/NSObject.h>
+
+struct IncompleteStruct;
+
+@interface BadMethodTestObject : NSObject {
+}
+
+- (struct IncompleteStruct)incompleteReturn;  // Skipped.
+- (struct IncompleteStruct*)incompletePointerReturn;  // Not skipped.
+- (int64_t)incompleteParam:(struct IncompleteStruct)x;  // Skipped.
+- (int64_t)incompletePointerParam:(struct IncompleteStruct*)x;  // Not skipped.
+
+@end
+
+@implementation BadMethodTestObject
+
+- (struct IncompleteStruct*)incompletePointerReturn {
+  return (struct IncompleteStruct*)1234;
+}
+
+- (int64_t)incompletePointerParam:(struct IncompleteStruct*)x {
+  return (int64_t)x;
+}
+
+@end

--- a/test/native_objc_test/setup.dart
+++ b/test/native_objc_test/setup.dart
@@ -47,6 +47,7 @@ Future<void> _generateBindings(String config) async {
 
 const testNames = [
   'automated_ref_count',
+  'bad_method',
   'block',
   'cast',
   'category',

--- a/tool/libclang_config.yaml
+++ b/tool/libclang_config.yaml
@@ -90,6 +90,7 @@ functions:
     - clang_Cursor_getArgument
     - clang_getNumArgTypes
     - clang_getArgType
+    - clang_getCursorResultType
     - clang_getEnumConstantDeclValue
     - clang_equalRanges
     - clang_Cursor_getCommentRange


### PR DESCRIPTION
Fixes #410

Also change how method return types are parsed to fix #409, since I couldn't write the test otherwise. This also fixes #328, fixes #373, fixes #341, and fixes #317