### PR TITLE
Memory management for Blocks

### DIFF
--- a/lib/src/code_generator/objc_block.dart
+++ b/lib/src/code_generator/objc_block.dart
@@ -28,6 +28,8 @@ class ObjCBlock extends BindingType {
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
 
+    builtInFunctions.ensureBlockUtilsExist(w, s);
+
     final params = <Parameter>[];
     for (int i = 0; i < argTypes.length; ++i) {
       params.add(Parameter(name: 'arg$i', type: argTypes[i]));
@@ -152,12 +154,7 @@ class $name extends _ObjCBlockBase {
     for (final t in argTypes) {
       t.addDependencies(dependencies);
     }
-
-    builtInFunctions.newBlockDesc.addDependencies(dependencies);
-    builtInFunctions.blockDescSingleton.addDependencies(dependencies);
-    builtInFunctions.blockStruct.addDependencies(dependencies);
-    builtInFunctions.concreteGlobalBlock.addDependencies(dependencies);
-    builtInFunctions.newBlock.addDependencies(dependencies);
+    builtInFunctions.addBlockDependencies(dependencies);
   }
 
   @override

--- a/lib/src/code_generator/objc_built_in_functions.dart
+++ b/lib/src/code_generator/objc_built_in_functions.dart
@@ -176,7 +176,7 @@ $descPtr $name() {
         "'_NSConcreteGlobalBlock')",
   );
   late final newBlock =
-      ObjCInternalFunction('_newBlock', null, (Writer w, String name) {
+      ObjCInternalFunction('_newBlock', _blockCopyFunc, (Writer w, String name) {
     final s = StringBuffer();
     final blockType = blockStruct.getCType(w);
     final blockPtr = PointerType(blockStruct).getCType(w);
@@ -189,7 +189,9 @@ $blockPtr $name($voidPtr invoke, $voidPtr target) {
   b.ref.invoke = invoke;
   b.ref.target = target;
   b.ref.descriptor = ${blockDescSingleton.name};
-  return b;
+  final copy = ${_blockCopyFunc.name}(b.cast()).cast<$blockType>();
+  ${w.ffiPkgLibraryPrefix}.calloc.free(b);
+  return copy;
 }
 ''');
     return s.toString();

--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -103,7 +103,7 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
   }
 
   /// Returns a [$name] that wraps the given raw object pointer.
-  static $name castFromPointer($natLib lib, ffi.Pointer<ObjCObject> other,
+  static $name castFromPointer($natLib lib, $objType other,
       {bool retain = false, bool release = false}) {
     return $name._(other, lib, retain: retain, release: release);
   }

--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -350,11 +350,10 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
         _isObject(arg.type) ||
         _isInstanceType(arg.type) ||
         arg.type is ObjCBlock) {
-      final field = arg.type is ObjCBlock ? '_impl' : '_id';
       if (arg.isNullable) {
-        return '${arg.name}?.$field ?? ffi.nullptr';
+        return '${arg.name}?._id ?? ffi.nullptr';
       } else {
-        return '${arg.name}.$field';
+        return '${arg.name}._id';
       }
     }
     return arg.name;

--- a/test/native_objc_test/block_test.dart
+++ b/test/native_objc_test/block_test.dart
@@ -9,12 +9,14 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:test/test.dart';
+import 'package:ffi/ffi.dart';
 import '../test_utils.dart';
 import 'block_bindings.dart';
 import 'util.dart';
 
 void main() {
   late BlockTestObjCLibrary lib;
+  late void Function(Pointer<Char>, Pointer<Void>) executeInternalCommand;
 
   group('Blocks', () {
     setUpAll(() {
@@ -22,8 +24,20 @@ void main() {
       final dylib = File('test/native_objc_test/block_test.dylib');
       verifySetupFile(dylib);
       lib = BlockTestObjCLibrary(DynamicLibrary.open(dylib.absolute.path));
+
+      executeInternalCommand = DynamicLibrary.process().lookupFunction<
+          Void Function(Pointer<Char>, Pointer<Void>),
+          void Function(
+              Pointer<Char>, Pointer<Void>)>('Dart_ExecuteInternalCommand');
+
       generateBindingsForCoverage('block');
     });
+
+    doGC() {
+      final gcNow = "gc-now".toNativeUtf8();
+      executeInternalCommand(gcNow.cast(), nullptr);
+      calloc.free(gcNow);
+    }
 
     test('BlockTester is working', () {
       // This doesn't test any Block functionality, just that the BlockTester
@@ -55,6 +69,19 @@ void main() {
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 4123);
       expect(block(123), 4123);
+    });
+
+    Pointer<Void> funcPointerBlockRefCountTest() {
+      final block = ObjCBlock.fromFunctionPointer(
+          lib, Pointer.fromFunction(_add100, 999));
+      expect(BlockTester.getBlockRetainCount_(lib, block.pointer), 1);
+      return block.pointer.cast();
+    }
+
+    test('Function pointer block ref counting', () {
+      final rawBlock = funcPointerBlockRefCountTest();
+      doGC();
+      expect(BlockTester.getBlockRetainCount_(lib, rawBlock.cast()), 0);
     });
   });
 }

--- a/test/native_objc_test/block_test.dart
+++ b/test/native_objc_test/block_test.dart
@@ -83,6 +83,18 @@ void main() {
       doGC();
       expect(BlockTester.getBlockRetainCount_(lib, rawBlock.cast()), 0);
     });
+
+    Pointer<Void> funcBlockRefCountTest() {
+      final block = ObjCBlock.fromFunction(lib, makeAdder(4000));
+      expect(BlockTester.getBlockRetainCount_(lib, block.pointer), 1);
+      return block.pointer.cast();
+    }
+
+    test('Function pointer block ref counting', () {
+      final rawBlock = funcBlockRefCountTest();
+      doGC();
+      expect(BlockTester.getBlockRetainCount_(lib, rawBlock.cast()), 0);
+    });
   });
 }
 

--- a/test/native_objc_test/block_test.m
+++ b/test/native_objc_test/block_test.m
@@ -13,6 +13,7 @@ typedef int32_t (^IntBlock)(int32_t);
 }
 + (BlockTester*)makeFromBlock:(IntBlock)block;
 + (BlockTester*)makeFromMultiplier:(int32_t)mult;
++ (uint64_t)getBlockRetainCount:(IntBlock)block;
 - (int32_t)call:(int32_t)x;
 - (IntBlock)getBlock;
 - (void)pokeBlock;
@@ -31,6 +32,33 @@ typedef int32_t (^IntBlock)(int32_t);
     return x * mult;
   } copy];
   return bt;
+}
+
+typedef struct {
+  void* isa;
+  int flags;
+  // There are other fields, but we just need the flags and isa.
+} BlockRefCountExtractor;
+
+void* valid_block_isa = NULL;
++ (uint64_t)getBlockRetainCount:(IntBlock)block {
+  BlockRefCountExtractor* b = (BlockRefCountExtractor*)block;
+  // HACK: The only way I can find to reliably figure out that a block has been
+  // deleted is to check the isa field (the lower bits of the flags field seem
+  // to be randomized, not just set to 0). But we also don't know the value this
+  // field has when it's constructed (copying the block changes it from
+  // _NSConcreteGlobalBlock to an internal value). So we assume that the first
+  // time this function is called, we have a valid block, and on subsequent
+  // calls we check to see if the isa field changed.
+  if (valid_block_isa == NULL) {
+    valid_block_isa = b->isa;
+  }
+  if (b->isa != valid_block_isa) {
+    return 0;
+  }
+  // The ref count is stored in the lower bits of the flags field, but skips the
+  // 0x1 bit.
+  return (b->flags & 0xFFFF) >> 1;
 }
 
 - (int32_t)call:(int32_t)x {

--- a/test/native_objc_test/setup.dart
+++ b/test/native_objc_test/setup.dart
@@ -57,9 +57,7 @@ List<String> _getTestNames() {
   return names;
 }
 
-final testNames = _getTestNames();
-
-Future<void> build() async {
+Future<void> build(List<String> testNames) async {
   print('Building Dynamic Library for Objective C Native Tests...');
   for (final name in testNames) {
     await _buildLib('${name}_test.m', '${name}_test.dylib');
@@ -71,7 +69,7 @@ Future<void> build() async {
   }
 }
 
-Future<void> clean() async {
+Future<void> clean(List<String> testNames) async {
   print('Deleting generated and built files...');
   final filenames = [
     for (final name in testNames) ...[
@@ -93,8 +91,8 @@ Future<void> main(List<String> arguments) async {
   }
 
   if (arguments.isNotEmpty && arguments[0] == 'clean') {
-    return await clean();
+    return await clean(_getTestNames());
   }
 
-  return await build();
+  return await build(arguments.isNotEmpty ? arguments : _getTestNames());
 }


### PR DESCRIPTION
Add a copy/release finalizer for blocks, same as we have for NSObjects. Automatically cleans up the native memory associated with Blocks.

This implements all but the last dot point from https://github.com/dart-lang/ffigen/issues/381#issuecomment-1194456759. Note that this still leaks the Dart Function objects (see https://github.com/dart-lang/ffigen/issues/381#issuecomment-1196093581)

Fixes #381. Filed a separate issue (#428) for cleaning up the Dart Functions, since that's not going to happen any time soon.