### PR TITLE
Fix obscure NSTimeZone parsing bug

### DIFF
--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -224,7 +224,9 @@ _CreateTypeFromCursorResult _createTypeFromCursor(clang_types.CXType cxtype,
       return _CreateTypeFromCursorResult(
           parseObjCInterfaceDeclaration(cursor, ignoreFilter: ignoreFilter));
     default:
-      throw UnimplementedError('Unknown type: ${cxtype.completeStringRepr()}');
+      return _CreateTypeFromCursorResult(
+        UnimplementedType('Unknown type: ${cxtype.completeStringRepr()}'),
+            addToCache: false);
   }
 }
 

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -225,8 +225,8 @@ _CreateTypeFromCursorResult _createTypeFromCursor(clang_types.CXType cxtype,
           parseObjCInterfaceDeclaration(cursor, ignoreFilter: ignoreFilter));
     default:
       return _CreateTypeFromCursorResult(
-        UnimplementedType('Unknown type: ${cxtype.completeStringRepr()}'),
-            addToCache: false);
+          UnimplementedType('Unknown type: ${cxtype.completeStringRepr()}'),
+          addToCache: false);
   }
 }
 

--- a/test/native_objc_test/category_test.dart
+++ b/test/native_objc_test/category_test.dart
@@ -14,7 +14,7 @@ import 'category_bindings.dart';
 import 'util.dart';
 
 void main() {
-  Thing? testInstance;
+  late Thing testInstance;
   late CategoryTestObjCLibrary lib;
 
   group('categories', () {
@@ -28,8 +28,10 @@ void main() {
     });
 
     test('Category method', () {
-      expect(testInstance!.add_Y_(1000, 234), 1234);
-      expect(testInstance!.sub_Y_(1234, 1000), 234);
+      expect(testInstance.add_Y_(1000, 234), 1234);
+      expect(testInstance.sub_Y_(1234, 1000), 234);
+      expect(testInstance.mul_Y_(1234, 1000), 1234000);
+      expect(testInstance.someProperty, 456);
     });
   });
 }

--- a/test/native_objc_test/category_test.m
+++ b/test/native_objc_test/category_test.m
@@ -19,3 +19,19 @@
   return x - y;
 }
 @end
+
+@interface Thing (Mul)
+-(int32_t)mul:(int32_t)x Y:(int32_t) y;
+
+@property (readonly) int32_t someProperty;
+@end
+
+@implementation Thing (Mul)
+-(int32_t)mul:(int32_t)x Y:(int32_t) y {
+  return x * y;
+}
+
+-(int32_t)someProperty {
+  return 456;
+}
+@end

--- a/test/native_objc_test/property_test.m
+++ b/test/native_objc_test/property_test.m
@@ -1,10 +1,13 @@
 #import <Foundation/NSObject.h>
 
+@class UndefinedTemplate<ObjectType>;
+
 @interface PropertyInterface : NSObject {
 }
 
 @property (readonly) int32_t readOnlyProperty;
 @property int32_t readWriteProperty;
+@property (class, readonly, copy) UndefinedTemplate<NSString *> *regressGH436;
 @property (class, readonly) int32_t classReadOnlyProperty;
 @property (class) int32_t classReadWriteProperty;
 


### PR DESCRIPTION
`NSTimeZone`'s definition is spread across multiple categories. When parsing one of the properties on one of the categories, it was hitting an unknown type (specifically, a template that was forward declared using `@class`), causing it to throw an exception in extractor.dart's `_createTypeFromCursor` function. This exception is uncaught, so it should be reported to the user, but because it's thrown inside a visitor callback (which means our call stack looks like Dart->C->Dart), the native callback handler hides the exception. So properties after the culprit, `knownTimeZoneNames`, are just silently omitted.

The fix is just to return `UnimplementedType` in `_createTypeFromCursor`, rather than throwing an exception. This is how every other error in extractor.dart is reported. There's a fallback higher up that will convert this to an `NSObject`, so the property will still be generated.

This edge case is tested in property_test. category_test contains a couple extra tests that I wrote while debugging (they're not relevant to this bug, but we may as well keep them).

Fixes #436 