### PR TITLE
`ffi-native` -> `asset` stop logger warning

### DIFF
--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -932,8 +932,8 @@ bool ffiNativeValidator(List<String> name, dynamic yamlConfig) {
   if (!checkType<YamlMap?>(name, yamlConfig)) {
     return false;
   }
-  // ignore: prefer_void_to_null
-  if (checkType<Null>(name, yamlConfig)) {
+  if (yamlConfig == null) {
+    // Empty means no asset name.
     return true;
   }
   for (final key in (yamlConfig as YamlMap).keys) {


### PR DESCRIPTION
Providing an asset gives a SEVERE in the logger even though it works fine.

(Skipping releasing a new version because this feature is experimental.)