### PR TITLE
Use `dart_style` over `dart` CLI for formatting

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   cli_util: ^0.3.0
   glob: ^2.0.0
   file: ^6.0.0
+  dart_style: ^2.2.4
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
Using `dart_style` directly instead of invoking `dart format` avoids an extra layer of indirection.