### PR TITLE
Remove unnecessary root cursor filtering

### DIFF
--- a/lib/src/header_parser/includer.dart
+++ b/lib/src/header_parser/includer.dart
@@ -80,13 +80,6 @@ bool shouldIncludeRootCursor(String sourceFile) {
     return false;
   }
 
-  // Objective C has some extra system headers that have a non-empty sourceFile.
-  if (config.language == Language.objc &&
-      strings.objCInternalDirectories
-          .any((path) => sourceFile.startsWith(path))) {
-    return false;
-  }
-
   // Add header to seen if it's not.
   if (!bindingsIndex.isSeenHeader(sourceFile)) {
     bindingsIndex.addHeaderToSeen(

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -44,14 +44,6 @@ const clangInclude = '-include';
 const objcBOOL = 'BOOL';
 const objcInstanceType = 'instancetype';
 
-// Internal objective C directories that are automatically pulled in by clang,
-// and should be excluded from output (unless explicitly used).
-const objCInternalDirectories = [
-  '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include',
-  '/Applications/Xcode.app/Contents/Developer',
-  '/usr/local/opt/llvm/lib',
-];
-
 const headers = 'headers';
 
 // Sub-fields of headers


### PR DESCRIPTION
This was added early on in objective c binding development, to reduce the amount of code generated. But now that we have interface filtering and exclude-all-by-default it's not necessary (and in some cases it's too aggressive and excludes the interface the user wants).

#470 