### PR TITLE
Add a step for building cursor definition map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 7.1.0
+- Handle declarations with definition accessible from a different entry-point.
+
 # 7.0.0
 
 - Fix typedef include/exclude config.

--- a/lib/src/header_parser/data.dart
+++ b/lib/src/header_parser/data.dart
@@ -7,7 +7,7 @@ import 'dart:ffi';
 import 'package:ffigen/src/code_generator.dart'
     show Constant, ObjCBuiltInFunctions;
 import 'package:ffigen/src/config_provider.dart' show Config;
-import 'clang_bindings/clang_bindings.dart' show Clang;
+import 'clang_bindings/clang_bindings.dart' show Clang, CXCursor;
 
 import 'utils.dart';
 
@@ -20,6 +20,10 @@ late Config _config;
 /// Holds clang functions.
 Clang get clang => _clang;
 late Clang _clang;
+
+// Cursor index.
+CursorIndex get cursorIndex => _cursorIndex;
+CursorIndex _cursorIndex = CursorIndex();
 
 // Tracks seen status for bindings
 BindingsIndex get bindingsIndex => _bindingsIndex;
@@ -47,6 +51,7 @@ void initializeGlobals({required Config config}) {
   _incrementalNamer = IncrementalNamer();
   _savedMacros = {};
   _unnamedEnumConstants = [];
+  _cursorIndex = CursorIndex();
   _bindingsIndex = BindingsIndex();
   _objCBuiltInFunctions = ObjCBuiltInFunctions();
 }

--- a/lib/src/header_parser/data.dart
+++ b/lib/src/header_parser/data.dart
@@ -7,7 +7,7 @@ import 'dart:ffi';
 import 'package:ffigen/src/code_generator.dart'
     show Constant, ObjCBuiltInFunctions;
 import 'package:ffigen/src/config_provider.dart' show Config;
-import 'clang_bindings/clang_bindings.dart' show Clang, CXCursor;
+import 'clang_bindings/clang_bindings.dart' show Clang;
 
 import 'utils.dart';
 

--- a/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -105,9 +105,7 @@ Compound? parseCompoundDeclaration(
   }
 
   // Parse the cursor definition instead, if this is a forward declaration.
-  if (isForwardDeclaration(cursor)) {
-    cursor = clang.clang_getCursorDefinition(cursor);
-  }
+  cursor = cursorIndex.getDefinition(cursor);
   final declUsr = cursor.usr();
   final String declName;
 
@@ -162,6 +160,7 @@ void fillCompoundMembersIfNeeded(
   /// generate these as opaque if `dependency-only` was set to opaque).
   bool pointerReference = false,
 }) {
+  cursor = cursorIndex.getDefinition(cursor);
   final compoundType = compound.compoundType;
 
   // Skip dependencies if already seen OR user has specified `dependency-only`

--- a/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -40,9 +40,7 @@ EnumClass? parseEnumDeclaration(
   _stack.push(_ParsedEnum());
 
   // Parse the cursor definition instead, if this is a forward declaration.
-  if (isForwardDeclaration(cursor)) {
-    cursor = clang.clang_getCursorDefinition(cursor);
-  }
+  cursor = cursorIndex.getDefinition(cursor);
 
   final enumUsr = cursor.usr();
   final String enumName;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 7.0.0
+version: 7.1.0
 description: Generator for FFI bindings, using LibClang to parse C header files.
 repository: https://github.com/dart-lang/ffigen
 

--- a/test/header_parser_tests/separate_definition.h
+++ b/test/header_parser_tests/separate_definition.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Forward declaration to SeparatelyDefinedStruct, with definition in
+// separate_definition_base.h
+struct SeparatelyDefinedStruct;
+
+void func(struct SeparatelyDefinedStruct s);
+
+void func2(struct SeparatelyDefinedStruct *s);

--- a/test/header_parser_tests/separate_definition_base.h
+++ b/test/header_parser_tests/separate_definition_base.h
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+struct SeparatelyDefinedStruct{
+    int a;
+    int b;
+};

--- a/test/header_parser_tests/separate_definition_test.dart
+++ b/test/header_parser_tests/separate_definition_test.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:ffigen/src/code_generator.dart';
+import 'package:ffigen/src/config_provider.dart';
+import 'package:ffigen/src/header_parser.dart' as parser;
+import 'package:ffigen/src/strings.dart' as strings;
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart' as yaml;
+
+import '../test_utils.dart';
+
+late Library actual, expected;
+
+void main() {
+  group('separate_definition', () {
+    setUpAll(() {
+      logWarnings(Level.SEVERE);
+    });
+    test('different header order', () {
+      final entryPoints = [
+        "test/header_parser_tests/separate_definition_base.h",
+        "test/header_parser_tests/separate_definition.h"
+      ];
+      final library1String = parser.parse(_makeConfig(entryPoints)).generate();
+      final library2String =
+          parser.parse(_makeConfig(entryPoints.reversed.toList())).generate();
+
+      expect(library1String, library2String);
+    });
+  });
+}
+
+Config _makeConfig(List<String> entryPoints) {
+  final entryPointBuilder = StringBuffer();
+  for (final ep in entryPoints) {
+    entryPointBuilder.writeln("    - $ep");
+  }
+  final config = Config.fromYaml(yaml.loadYaml('''
+${strings.name}: 'Bindings'
+${strings.output}: 'unused'
+
+${strings.headers}:
+  ${strings.entryPoints}:
+${entryPointBuilder.toString()}
+''') as yaml.YamlMap);
+  return config;
+}


### PR DESCRIPTION
Closes #179 
- Handle declarations with definitions accessible from a different entry point header.
- Added tests
- Update version, changelog.

C allows us to forward declarations without any reference as to where it is defined. This can lead to different entry-point header ordering, resulting in some Structs being generated as Opaque (and skipped declarations which depend on these by value since they are incomplete)

This is fixed by adding another step before parsing the declarations. 
1. Parse all the entry-points, and build a map (`CursorIndex`) of USR to CXCursor  (only for Structs/Unions/Enums currently).
2. When parsing these declaration types to binding
    1. We find its definition in current translation unit with libclang (`clang_getCursorDefinition`).
    2. If not found, we use `CursorIndex` for finding the CXCursor definition since it may be in another translation unit.
    3. If not found, log a warning for user that the definition could not be found (So they may add more entry-points if need be)
