### PR TITLE
Remove the built in flag from ObjC interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+# 7.2.1
+
+- Fix helper methods sometimes missing from NSString.
+
 # 7.2.0
+
 - Added support for sharing bindings using `symbol-file` config. (See `README.md`
 and examples/shared_bindings).
 
 # 7.1.0
+
 - Handle declarations with definition accessible from a different entry-point.
 
 # 7.0.0

--- a/lib/src/code_generator/objc_built_in_functions.dart
+++ b/lib/src/code_generator/objc_built_in_functions.dart
@@ -311,7 +311,6 @@ class $name implements ${w.ffiLibraryPrefix}.Finalizable {
         (ObjCInterface(
           originalName: "NSData",
           builtInFunctions: this,
-          isBuiltIn: true,
         ));
   }
 

--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -44,7 +44,6 @@ class ObjCInterface extends BindingType {
 
   final String lookupName;
   final ObjCBuiltInFunctions builtInFunctions;
-  final bool isBuiltIn;
   late final ObjCInternalGlobal _classObject;
   late final ObjCInternalGlobal _isKindOfClass;
   late final Func _isKindOfClassMsgSend;
@@ -56,7 +55,6 @@ class ObjCInterface extends BindingType {
     String? lookupName,
     String? dartDoc,
     required this.builtInFunctions,
-    required this.isBuiltIn,
   })  : lookupName = lookupName ?? originalName,
         super(
           usr: usr,
@@ -64,13 +62,11 @@ class ObjCInterface extends BindingType {
           name: name ?? originalName,
           dartDoc: dartDoc,
         ) {
-    if (isBuiltIn) {
-      builtInFunctions.registerInterface(this);
-    }
+    builtInFunctions.registerInterface(this);
   }
 
-  bool get isNSString => isBuiltIn && originalName == "NSString";
-  bool get isNSData => isBuiltIn && originalName == "NSData";
+  bool get isNSString => originalName == "NSString";
+  bool get isNSData => originalName == "NSData";
 
   @override
   BindingString toBindingString(Writer w) {

--- a/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -75,7 +75,6 @@ Type? parseObjCInterfaceDeclaration(
     lookupName: config.objcModulePrefixer.applyPrefix(name),
     dartDoc: getCursorDocComment(cursor),
     builtInFunctions: objCBuiltInFunctions,
-    isBuiltIn: cursor.isInSystemHeader(),
   );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 7.2.0
+version: 7.2.1
 description: Generator for FFI bindings, using LibClang to parse C header files.
 repository: https://github.com/dart-lang/ffigen
 


### PR DESCRIPTION
I was using it to try to make sure we only add helper methods like those on NSString to the official versions of those interfaces. This would prevent a user defined NSString from getting those methods. But the flag is unreliable, so in some cases we end up omitting the helper methods when they should be there. So it's better to just remove this restriction.

Fixes #484 