### PR TITLE
Allow user compiler options to override built-in options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 7.2.3
+
+- Change compiler option order so that user options can override built-in
+  options.
+
 # 7.2.2
 
 - Added newer versions of LLVM, to default `linuxDylibLocations`.

--- a/lib/src/header_parser/parser.dart
+++ b/lib/src/header_parser/parser.dart
@@ -56,21 +56,24 @@ List<Binding> parseToBindings() {
   final index = clang.clang_createIndex(0, 0);
 
   Pointer<Pointer<Utf8>> clangCmdArgs = nullptr;
-  final compilerOpts = List<String>.from(config.compilerOpts);
+  final compilerOpts = <String>[];
 
-  /// Add compiler opt for comment parsing for clang based on config.
-  if (config.commentType.length != CommentLength.none &&
-      config.commentType.style == CommentStyle.any) {
-    compilerOpts.add(strings.fparseAllComments);
-  }
-
-  /// If the config targets Objective C, add a compiler opt for it.
+  // If the config targets Objective C, add a compiler opt for it.
   if (config.language == Language.objc) {
     compilerOpts.addAll([
       ...strings.clangLangObjC,
       ..._findObjectiveCSysroot(),
     ]);
   }
+
+  // Add compiler opt for comment parsing for clang based on config.
+  if (config.commentType.length != CommentLength.none &&
+      config.commentType.style == CommentStyle.any) {
+    compilerOpts.add(strings.fparseAllComments);
+  }
+
+  // Add the user options last so they can override any other options.
+  compilerOpts.addAll(config.compilerOpts);
 
   _logger.fine('CompilerOpts used: $compilerOpts');
   clangCmdArgs = createDynamicStringArray(compilerOpts);

--- a/lib/src/header_parser/parser.dart
+++ b/lib/src/header_parser/parser.dart
@@ -58,18 +58,18 @@ List<Binding> parseToBindings() {
   Pointer<Pointer<Utf8>> clangCmdArgs = nullptr;
   final compilerOpts = <String>[];
 
+  // Add compiler opt for comment parsing for clang based on config.
+  if (config.commentType.length != CommentLength.none &&
+      config.commentType.style == CommentStyle.any) {
+    compilerOpts.add(strings.fparseAllComments);
+  }
+
   // If the config targets Objective C, add a compiler opt for it.
   if (config.language == Language.objc) {
     compilerOpts.addAll([
       ...strings.clangLangObjC,
       ..._findObjectiveCSysroot(),
     ]);
-  }
-
-  // Add compiler opt for comment parsing for clang based on config.
-  if (config.commentType.length != CommentLength.none &&
-      config.commentType.style == CommentStyle.any) {
-    compilerOpts.add(strings.fparseAllComments);
   }
 
   // Add the user options last so they can override any other options.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 7.2.2
+version: 7.2.3
 description: Generator for FFI bindings, using LibClang to parse C header files.
 repository: https://github.com/dart-lang/ffigen
 


### PR DESCRIPTION
If clang sees 2 of the same flag with different values, it takes the second. So if we insert user options second they can override our defaults. In #493, this is needed so that the user can target iOS by overriding the default mac sysroot that the ObjC flags default to.