### PR TITLE
Add support nested anonymous union/struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.2.5
+
+- Add support for nested structures/unions
+
 # 7.2.4
 
 - Add new supported typedef - `uintptr_t` (mapped to `ffi.UintPtr`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 7.2.4
 
+- Add support nested anonymous union/struct
+
+# 7.2.4
+
 - Add new supported typedef - `uintptr_t` (mapped to `ffi.UintPtr`).
 
 # 7.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 7.2.4
+# 7.2.5
 
 - Add support nested anonymous union/struct
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 7.2.5
-
-- Add support for nested structures/unions
-
 # 7.2.4
 
 - Add new supported typedef - `uintptr_t` (mapped to `ffi.UintPtr`).

--- a/lib/src/code_generator/utils.dart
+++ b/lib/src/code_generator/utils.dart
@@ -15,6 +15,12 @@ class UniqueNamer {
   ///
   /// Adds the resulting name to the used names by default.
   String makeUnique(String name, [bool addToUsedUpNames = true]) {
+
+    // For example, nested structures/unions may not have a name
+    if (name.isEmpty) {
+      name = 'unnamed';
+    }
+
     var crName = name;
     var i = 1;
     while (_usedUpNames.contains(crName)) {

--- a/lib/src/code_generator/utils.dart
+++ b/lib/src/code_generator/utils.dart
@@ -15,7 +15,6 @@ class UniqueNamer {
   ///
   /// Adds the resulting name to the used names by default.
   String makeUnique(String name, [bool addToUsedUpNames = true]) {
-
     // For example, nested structures/unions may not have a name
     if (name.isEmpty) {
       name = 'unnamed';

--- a/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -6,6 +6,7 @@ import 'dart:ffi';
 
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/config_provider/config_types.dart';
+import 'package:ffigen/src/header_parser/type_extractor/extractor.dart';
 import 'package:logging/logging.dart';
 
 import '../../strings.dart' as strings;
@@ -44,10 +45,13 @@ class _ParsedCompound {
   // A struct without any attribute is definitely not packed. #pragma pack(...)
   // also adds an attribute, but it's unexposed and cannot be travesed.
   bool hasAttr = false;
+
   // A struct which as a __packed__ attribute is definitely packed.
   bool hasPackedAttr = false;
+
   // Stores the maximum alignment from all the children.
   int maxChildAlignment = 0;
+
   // Alignment of this struct.
   int alignment = 0;
 
@@ -240,50 +244,80 @@ int _compoundMembersVisitor(clang_types.CXCursor cursor,
     clang_types.CXCursor parent, Pointer<Void> clientData) {
   final parsed = _stack.top;
   try {
-    if (cursor.kind == clang_types.CXCursorKind.CXCursor_FieldDecl) {
-      _logger.finer('===== member: ${cursor.completeStringRepr()}');
+    switch (cursor.kind) {
+      case clang_types.CXCursorKind.CXCursor_FieldDecl:
+        _logger.finer('===== member: ${cursor.completeStringRepr()}');
 
-      // Set maxChildAlignValue.
-      final align = cursor.type().alignment();
-      if (align > parsed.maxChildAlignment) {
-        parsed.maxChildAlignment = align;
-      }
+        // Set maxChildAlignValue.
+        final align = cursor.type().alignment();
+        if (align > parsed.maxChildAlignment) {
+          parsed.maxChildAlignment = align;
+        }
 
-      final mt = cursor.type().toCodeGenType();
-      if (mt is IncompleteArray) {
-        // TODO(68): Structs with flexible Array Members are not supported.
-        parsed.flexibleArrayMember = true;
-      }
-      if (clang.clang_getFieldDeclBitWidth(cursor) != -1) {
-        // TODO(84): Struct with bitfields are not suppoorted.
-        parsed.bitFieldMember = true;
-      }
-      if (mt is HandleType) {
-        parsed.dartHandleMember = true;
-      }
-      if (mt.isIncompleteCompound) {
-        parsed.incompleteCompoundMember = true;
-      }
-      if (mt.baseType is UnimplementedType) {
-        parsed.unimplementedMemberType = true;
-      }
+        final mt = cursor.type().toCodeGenType();
+        if (mt is IncompleteArray) {
+          // TODO(68): Structs with flexible Array Members are not supported.
+          parsed.flexibleArrayMember = true;
+        }
+        if (clang.clang_getFieldDeclBitWidth(cursor) != -1) {
+          // TODO(84): Struct with bitfields are not suppoorted.
+          parsed.bitFieldMember = true;
+        }
+        if (mt is HandleType) {
+          parsed.dartHandleMember = true;
+        }
+        if (mt.isIncompleteCompound) {
+          parsed.incompleteCompoundMember = true;
+        }
+        if (mt.baseType is UnimplementedType) {
+          parsed.unimplementedMemberType = true;
+        }
 
-      parsed.compound.members.add(
-        Member(
-          dartDoc: getCursorDocComment(
-            cursor,
-            nesting.length + commentPrefix.length,
+        parsed.compound.members.add(
+          Member(
+            dartDoc: getCursorDocComment(
+              cursor,
+              nesting.length + commentPrefix.length,
+            ),
+            originalName: cursor.spelling(),
+            name: config.structDecl.renameMemberUsingConfig(
+              parsed.compound.originalName,
+              cursor.spelling(),
+            ),
+            type: mt,
           ),
-          originalName: cursor.spelling(),
-          name: config.structDecl.renameMemberUsingConfig(
-            parsed.compound.originalName,
-            cursor.spelling(),
+        );
+
+        break;
+      case clang_types.CXCursorKind.CXCursor_PackedAttr:
+        parsed.hasPackedAttr = true;
+
+        break;
+
+      case clang_types.CXCursorKind.CXCursor_UnionDecl:
+      case clang_types.CXCursorKind.CXCursor_StructDecl:
+        String name = config.structDecl.renameMemberUsingConfig(
+          parsed.compound.originalName,
+          cursor.spelling(),
+        );
+
+        if (name.isEmpty) {
+          name = 'unnamed${parsed.compound.members.length}';
+        }
+
+        parsed.compound.members.add(
+          Member(
+            dartDoc: getCursorDocComment(
+              cursor,
+              nesting.length + commentPrefix.length,
+            ),
+            originalName: cursor.spelling(),
+            name: name,
+            type: getCodeGenType(cursor.type(), ignoreFilter: true),
           ),
-          type: mt,
-        ),
-      );
-    } else if (cursor.kind == clang_types.CXCursorKind.CXCursor_PackedAttr) {
-      parsed.hasPackedAttr = true;
+        );
+
+        break;
     }
   } catch (e, s) {
     _logger.severe(e);

--- a/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -6,7 +6,6 @@ import 'dart:ffi';
 
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/config_provider/config_types.dart';
-import 'package:ffigen/src/header_parser/type_extractor/extractor.dart';
 import 'package:logging/logging.dart';
 
 import '../../strings.dart' as strings;
@@ -45,13 +44,10 @@ class _ParsedCompound {
   // A struct without any attribute is definitely not packed. #pragma pack(...)
   // also adds an attribute, but it's unexposed and cannot be travesed.
   bool hasAttr = false;
-
   // A struct which as a __packed__ attribute is definitely packed.
   bool hasPackedAttr = false;
-
   // Stores the maximum alignment from all the children.
   int maxChildAlignment = 0;
-
   // Alignment of this struct.
   int alignment = 0;
 
@@ -244,80 +240,50 @@ int _compoundMembersVisitor(clang_types.CXCursor cursor,
     clang_types.CXCursor parent, Pointer<Void> clientData) {
   final parsed = _stack.top;
   try {
-    switch (cursor.kind) {
-      case clang_types.CXCursorKind.CXCursor_FieldDecl:
-        _logger.finer('===== member: ${cursor.completeStringRepr()}');
+    if (cursor.kind == clang_types.CXCursorKind.CXCursor_FieldDecl) {
+      _logger.finer('===== member: ${cursor.completeStringRepr()}');
 
-        // Set maxChildAlignValue.
-        final align = cursor.type().alignment();
-        if (align > parsed.maxChildAlignment) {
-          parsed.maxChildAlignment = align;
-        }
+      // Set maxChildAlignValue.
+      final align = cursor.type().alignment();
+      if (align > parsed.maxChildAlignment) {
+        parsed.maxChildAlignment = align;
+      }
 
-        final mt = cursor.type().toCodeGenType();
-        if (mt is IncompleteArray) {
-          // TODO(68): Structs with flexible Array Members are not supported.
-          parsed.flexibleArrayMember = true;
-        }
-        if (clang.clang_getFieldDeclBitWidth(cursor) != -1) {
-          // TODO(84): Struct with bitfields are not suppoorted.
-          parsed.bitFieldMember = true;
-        }
-        if (mt is HandleType) {
-          parsed.dartHandleMember = true;
-        }
-        if (mt.isIncompleteCompound) {
-          parsed.incompleteCompoundMember = true;
-        }
-        if (mt.baseType is UnimplementedType) {
-          parsed.unimplementedMemberType = true;
-        }
+      final mt = cursor.type().toCodeGenType();
+      if (mt is IncompleteArray) {
+        // TODO(68): Structs with flexible Array Members are not supported.
+        parsed.flexibleArrayMember = true;
+      }
+      if (clang.clang_getFieldDeclBitWidth(cursor) != -1) {
+        // TODO(84): Struct with bitfields are not suppoorted.
+        parsed.bitFieldMember = true;
+      }
+      if (mt is HandleType) {
+        parsed.dartHandleMember = true;
+      }
+      if (mt.isIncompleteCompound) {
+        parsed.incompleteCompoundMember = true;
+      }
+      if (mt.baseType is UnimplementedType) {
+        parsed.unimplementedMemberType = true;
+      }
 
-        parsed.compound.members.add(
-          Member(
-            dartDoc: getCursorDocComment(
-              cursor,
-              nesting.length + commentPrefix.length,
-            ),
-            originalName: cursor.spelling(),
-            name: config.structDecl.renameMemberUsingConfig(
-              parsed.compound.originalName,
-              cursor.spelling(),
-            ),
-            type: mt,
+      parsed.compound.members.add(
+        Member(
+          dartDoc: getCursorDocComment(
+            cursor,
+            nesting.length + commentPrefix.length,
           ),
-        );
-
-        break;
-      case clang_types.CXCursorKind.CXCursor_PackedAttr:
-        parsed.hasPackedAttr = true;
-
-        break;
-
-      case clang_types.CXCursorKind.CXCursor_UnionDecl:
-      case clang_types.CXCursorKind.CXCursor_StructDecl:
-        String name = config.structDecl.renameMemberUsingConfig(
-          parsed.compound.originalName,
-          cursor.spelling(),
-        );
-
-        if (name.isEmpty) {
-          name = 'unnamed${parsed.compound.members.length}';
-        }
-
-        parsed.compound.members.add(
-          Member(
-            dartDoc: getCursorDocComment(
-              cursor,
-              nesting.length + commentPrefix.length,
-            ),
-            originalName: cursor.spelling(),
-            name: name,
-            type: getCodeGenType(cursor.type(), ignoreFilter: true),
+          originalName: cursor.spelling(),
+          name: config.structDecl.renameMemberUsingConfig(
+            parsed.compound.originalName,
+            cursor.spelling(),
           ),
-        );
-
-        break;
+          type: mt,
+        ),
+      );
+    } else if (cursor.kind == clang_types.CXCursorKind.CXCursor_PackedAttr) {
+      parsed.hasPackedAttr = true;
     }
   } catch (e, s) {
     _logger.severe(e);

--- a/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -299,7 +299,7 @@ int _compoundMembersVisitor(clang_types.CXCursor cursor,
 
         // If the union/struct are anonymous, then we need to add them now,
         // otherwise they will be added in the next iteration.
-        if (cursor.isAnonymousRecordDecl()) break;
+        if (!cursor.isAnonymousRecordDecl()) break;
 
         parsed.compound.members.add(
           Member(

--- a/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -44,10 +44,13 @@ class _ParsedCompound {
   // A struct without any attribute is definitely not packed. #pragma pack(...)
   // also adds an attribute, but it's unexposed and cannot be travesed.
   bool hasAttr = false;
+
   // A struct which as a __packed__ attribute is definitely packed.
   bool hasPackedAttr = false;
+
   // Stores the maximum alignment from all the children.
   int maxChildAlignment = 0;
+
   // Alignment of this struct.
   int alignment = 0;
 
@@ -240,50 +243,80 @@ int _compoundMembersVisitor(clang_types.CXCursor cursor,
     clang_types.CXCursor parent, Pointer<Void> clientData) {
   final parsed = _stack.top;
   try {
-    if (cursor.kind == clang_types.CXCursorKind.CXCursor_FieldDecl) {
-      _logger.finer('===== member: ${cursor.completeStringRepr()}');
+    switch (cursor.kind) {
+      case clang_types.CXCursorKind.CXCursor_FieldDecl:
+        _logger.finer('===== member: ${cursor.completeStringRepr()}');
 
-      // Set maxChildAlignValue.
-      final align = cursor.type().alignment();
-      if (align > parsed.maxChildAlignment) {
-        parsed.maxChildAlignment = align;
-      }
+        // Set maxChildAlignValue.
+        final align = cursor.type().alignment();
+        if (align > parsed.maxChildAlignment) {
+          parsed.maxChildAlignment = align;
+        }
 
-      final mt = cursor.type().toCodeGenType();
-      if (mt is IncompleteArray) {
-        // TODO(68): Structs with flexible Array Members are not supported.
-        parsed.flexibleArrayMember = true;
-      }
-      if (clang.clang_getFieldDeclBitWidth(cursor) != -1) {
-        // TODO(84): Struct with bitfields are not suppoorted.
-        parsed.bitFieldMember = true;
-      }
-      if (mt is HandleType) {
-        parsed.dartHandleMember = true;
-      }
-      if (mt.isIncompleteCompound) {
-        parsed.incompleteCompoundMember = true;
-      }
-      if (mt.baseType is UnimplementedType) {
-        parsed.unimplementedMemberType = true;
-      }
+        final mt = cursor.type().toCodeGenType();
+        if (mt is IncompleteArray) {
+          // TODO(68): Structs with flexible Array Members are not supported.
+          parsed.flexibleArrayMember = true;
+        }
+        if (clang.clang_getFieldDeclBitWidth(cursor) != -1) {
+          // TODO(84): Struct with bitfields are not suppoorted.
+          parsed.bitFieldMember = true;
+        }
+        if (mt is HandleType) {
+          parsed.dartHandleMember = true;
+        }
+        if (mt.isIncompleteCompound) {
+          parsed.incompleteCompoundMember = true;
+        }
+        if (mt.baseType is UnimplementedType) {
+          parsed.unimplementedMemberType = true;
+        }
 
-      parsed.compound.members.add(
-        Member(
-          dartDoc: getCursorDocComment(
-            cursor,
-            nesting.length + commentPrefix.length,
+        parsed.compound.members.add(
+          Member(
+            dartDoc: getCursorDocComment(
+              cursor,
+              nesting.length + commentPrefix.length,
+            ),
+            originalName: cursor.spelling(),
+            name: config.structDecl.renameMemberUsingConfig(
+              parsed.compound.originalName,
+              cursor.spelling(),
+            ),
+            type: mt,
           ),
-          originalName: cursor.spelling(),
-          name: config.structDecl.renameMemberUsingConfig(
-            parsed.compound.originalName,
-            cursor.spelling(),
+        );
+
+        break;
+
+      case clang_types.CXCursorKind.CXCursor_PackedAttr:
+        parsed.hasPackedAttr = true;
+
+        break;
+      case clang_types.CXCursorKind.CXCursor_UnionDecl:
+      case clang_types.CXCursorKind.CXCursor_StructDecl:
+        final mt = cursor.type().toCodeGenType();
+
+        // If the union/struct are anonymous, then we need to add them now,
+        // otherwise they will be added in the next iteration.
+        if (cursor.isAnonymousRecordDecl()) break;
+
+        parsed.compound.members.add(
+          Member(
+            dartDoc: getCursorDocComment(
+              cursor,
+              nesting.length + commentPrefix.length,
+            ),
+            originalName: cursor.spelling(),
+            name: config.structDecl.renameMemberUsingConfig(
+              parsed.compound.originalName,
+              cursor.spelling(),
+            ),
+            type: mt,
           ),
-          type: mt,
-        ),
-      );
-    } else if (cursor.kind == clang_types.CXCursorKind.CXCursor_PackedAttr) {
-      parsed.hasPackedAttr = true;
+        );
+
+        break;
     }
   } catch (e, s) {
     _logger.severe(e);

--- a/lib/src/header_parser/utils.dart
+++ b/lib/src/header_parser/utils.dart
@@ -97,6 +97,12 @@ extension CXCursorExt on clang_types.CXCursor {
     return clang.clang_getCursorType(this);
   }
 
+  /// Determine whether the given cursor
+  /// represents an anonymous record declaration.
+  bool isAnonymousRecordDecl() {
+    return clang.clang_Cursor_isAnonymousRecordDecl(this) == 1;
+  }
+
   /// Only valid for [clang.CXCursorKind.CXCursor_FunctionDecl]. Type will have
   /// kind [clang.CXTypeKind.CXType_Invalid] otherwise.
   clang_types.CXType returnType() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 7.2.4
+version: 7.2.5
 description: Generator for FFI bindings, using LibClang to parse C header files.
 repository: https://github.com/dart-lang/ffigen
 

--- a/test/header_parser_tests/nested_parsing.h
+++ b/test/header_parser_tests/nested_parsing.h
@@ -43,27 +43,20 @@ struct Struct5{
 
 struct Struct6
 {
-    // An anonymous, unnamed struct.
-    struct
-    {
-        int a;
-    };
-
-    // An unnamed struct.
-    struct
-    {
-        int b;
-    } c;
-
     // An anonymous, unnamed union.
     union
     {
-        int d;
+        float a;
     };
 
     // An unnamed union.
     union
     {
-        int e;
-    } f;
+        float b;
+    } c;
+
+    union
+    {
+        float d;
+    } e;
 };

--- a/test/header_parser_tests/nested_parsing.h
+++ b/test/header_parser_tests/nested_parsing.h
@@ -40,3 +40,30 @@ struct Struct5{
     // Incomplete struct array.
     struct EmptyStruct b[3];
 };
+
+struct Struct6
+{
+    // An anonymous, unnamed struct.
+    struct
+    {
+        int a;
+    };
+
+    // An unnamed struct.
+    struct
+    {
+        int b;
+    } c;
+
+    // An anonymous, unnamed union.
+    union
+    {
+        int d;
+    };
+
+    // An unnamed union.
+    union
+    {
+        int e;
+    } f;
+};

--- a/test/header_parser_tests/nested_parsing_test.dart
+++ b/test/header_parser_tests/nested_parsing_test.dart
@@ -57,6 +57,10 @@ ${strings.structs}:
       expect(actual.getBindingAsString('Struct5'),
           expected.getBindingAsString('Struct5'));
     });
+    test('Struct6', () {
+      expect(actual.getBindingAsString('Struct6'),
+          expected.getBindingAsString('Struct6'));
+    });
   });
 }
 
@@ -110,6 +114,59 @@ Library expectedLibrary() {
       Struct(name: 'EmptyStruct'),
       Struct(name: 'Struct4'),
       Struct(name: 'Struct5'),
+      Struct(
+        name: 'Struct6',
+        members: [
+          Member(
+            name: '',
+            type: Union(
+              name: 'UnnamedStruct2',
+              members: [
+                Member(
+                  name: 'a',
+                  type: intType,
+                ),
+              ],
+            ),
+          ),
+          Member(
+            name: 'c',
+            type: Union(
+              name: 'UnnamedStruct3',
+              members: [
+                Member(
+                  name: 'b',
+                  type: intType,
+                ),
+              ],
+            ),
+          ),
+          Member(
+            name: '',
+            type: Union(
+              name: 'UnnamedUnion1',
+              members: [
+                Member(
+                  name: 'd',
+                  type: intType,
+                ),
+              ],
+            ),
+          ),
+          Member(
+            name: 'f',
+            type: Union(
+              name: 'UnnamedUnion2',
+              members: [
+                Member(
+                  name: 'e',
+                  type: intType,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     ],
   );
 }

--- a/test/header_parser_tests/nested_parsing_test.dart
+++ b/test/header_parser_tests/nested_parsing_test.dart
@@ -120,11 +120,11 @@ Library expectedLibrary() {
           Member(
             name: '',
             type: Union(
-              name: 'UnnamedStruct2',
+              name: 'UnnamedUnion1',
               members: [
                 Member(
                   name: 'a',
-                  type: intType,
+                  type: floatType,
                 ),
               ],
             ),
@@ -132,35 +132,23 @@ Library expectedLibrary() {
           Member(
             name: 'c',
             type: Union(
-              name: 'UnnamedStruct3',
-              members: [
-                Member(
-                  name: 'b',
-                  type: intType,
-                ),
-              ],
-            ),
-          ),
-          Member(
-            name: '',
-            type: Union(
-              name: 'UnnamedUnion1',
-              members: [
-                Member(
-                  name: 'd',
-                  type: intType,
-                ),
-              ],
-            ),
-          ),
-          Member(
-            name: 'f',
-            type: Union(
               name: 'UnnamedUnion2',
               members: [
                 Member(
-                  name: 'e',
-                  type: intType,
+                  name: 'b',
+                  type: floatType,
+                ),
+              ],
+            ),
+          ),
+          Member(
+            name: 'e',
+            type: Union(
+              name: 'UnnamedUnion3',
+              members: [
+                Member(
+                  name: 'd',
+                  type: floatType,
                 ),
               ],
             ),


### PR DESCRIPTION
Some libraries contain nested anonymous unions/struct (sometimes unnamed) in order to make the API more convenient

For example:

```C
typedef struct result_of_smt {
    union {
        result_pointer* ok;
        Error err;
    };
    bool is_ok;
} result_of_smt;
```

This PR will allow parsing such constructions