### PR TITLE
Read LLVM path from environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ output:
     for `lib/libclang.so` on linux, `lib/libclang.dylib` on macOs and
     `bin\libclang.dll` on windows, in the specified paths.<br><br>
     Complete path to the dynamic library can also be supplied.<br>
+    Alternatively, `FFIGEN_LLVM_PATH` environment variable can be set in
+    situations where it's desired to use a different path on current system only.<br>
     <i>Required</i> if ffigen is unable to find this at default locations.</td>
     <td>
 

--- a/lib/src/README.md
+++ b/lib/src/README.md
@@ -22,7 +22,7 @@ This is the main entry point for the user-  `dart run ffigen`.
     - `--verbose`: Sets log level.
     - `--config`: Specifies a config file.
 - The internal modules are called by `ffigen.dart` in the following way:
-- `ffigen.dart` will try to find dynamic library in default locations. If that fails, the user must excplicitly specify location in ffigen's config under the key `llvm-path`, or set an environment variable `FFIGEN_LLVM_PATH` pointing to the directory which contains the `libclang` dynamic library.
+- `ffigen.dart` will try to find dynamic library in default locations. If that fails, the user must excplicitly specify location in ffigen's config under the key `llvm-path`, or set an environment variable `FFIGEN_LLVM_PATH`.
     - It first creates a `Config` object from an input Yaml file. This is used by other modules.
     - The `parse` method is then invoked to generate a `Library` object.
     - Finally, the code is generated from the `Library` object to the specified file.

--- a/lib/src/README.md
+++ b/lib/src/README.md
@@ -22,7 +22,7 @@ This is the main entry point for the user-  `dart run ffigen`.
     - `--verbose`: Sets log level.
     - `--config`: Specifies a config file.
 - The internal modules are called by `ffigen.dart` in the following way:
-- `ffigen.dart` will try to find dynamic library in default locations. If that fails, the user must excplicitly specify location in ffigen's config under the key `llvm-path`.
+- `ffigen.dart` will try to find dynamic library in default locations. If that fails, the user must excplicitly specify location in ffigen's config under the key `llvm-path`, or set an environment variable `FFIGEN_LLVM_PATH` pointing to the directory which contains the `libclang` dynamic library.
     - It first creates a `Config` object from an input Yaml file. This is used by other modules.
     - The `parse` method is then invoked to generate a `Library` object.
     - Finally, the code is generated from the `Library` object to the specified file.

--- a/lib/src/config_provider/spec_utils.dart
+++ b/lib/src/config_provider/spec_utils.dart
@@ -475,6 +475,22 @@ bool headersValidator(List<String> name, dynamic value) {
 /// error and throws an Exception if not found.
 String findDylibAtDefaultLocations() {
   String? k;
+  // Dylib locations specified by environment variable
+  final llvmPathEnv = Platform.environment[strings.llvmPathEnv];
+  if (llvmPathEnv != null) {
+    if (p.extension(llvmPathEnv).isNotEmpty && File(llvmPathEnv).existsSync()) {
+      k = llvmPathEnv;
+    } else {
+      k = findLibclangDylib(p.join(llvmPathEnv, strings.dynamicLibParentName));
+    }
+    if (k != null) {
+      _logger.info("Found libclang: $k");
+      return k;
+    } else {
+      _logger.warning("Cannot find libclang "
+          "in the path specified by ${strings.llvmPathEnv}");
+    }
+  }
   if (Platform.isLinux) {
     for (final l in strings.linuxDylibLocations) {
       k = findLibclangDylib(l);

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -23,6 +23,7 @@ String get dylibFileName {
 }
 
 const llvmPath = 'llvm-path';
+const llvmPathEnv = 'FFIGEN_LLVM_PATH';
 
 /// Name of the parent folder of dynamic library `lib` or `bin` (on windows).
 String get dynamicLibParentName => Platform.isWindows ? 'bin' : 'lib';


### PR DESCRIPTION
Closes: #520 

What is a recommended place to adding test case for this? I think we can't set environment variables from within Dart.