### PR TITLE
Explicit '' as name for anon structs/unions

### DIFF
--- a/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -300,16 +300,21 @@ int _compoundMembersVisitor(clang_types.CXCursor cursor,
         // otherwise they will be added in the next iteration.
         if (!cursor.isAnonymousRecordDecl()) break;
 
+        // Anonymous members are always unnamed. To avoid environment-
+        // dependent naming issues with the generated code, we explicitly
+        // use the empty string as spelling.
+        final spelling = '';
+
         parsed.compound.members.add(
           Member(
             dartDoc: getCursorDocComment(
               cursor,
               nesting.length + commentPrefix.length,
             ),
-            originalName: cursor.spelling(),
+            originalName: spelling,
             name: config.structDecl.renameMemberUsingConfig(
               parsed.compound.originalName,
-              cursor.spelling(),
+              spelling,
             ),
             type: mt,
           ),


### PR DESCRIPTION
The C11 spec states that anonymous unions / structs imply they are unnamed:

> An unnamed member whose type specifier is a structure specifier with no tag is called an anonymous structure; an unnamed member whose type specifier is a union specifier with no tag is called an anonymous union.

(See https://port70.net/~nsz/c/c11/n1570.pdf)

That said, in some environments, I noticed the `nested_parsing_test` failing with a union in `Struct6` that should be called `unnamed` instead called `union (anonymous at /.../ffigen/test/header_parser_tests/nested_parsing.h:47:5)`

This CL explicitly uses an empty string for the name of an anonymous union or struct