### PR TITLE
Add description to typedef test

### DIFF
--- a/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
@@ -6,6 +6,7 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
+/// Typedef Test
 class Bindings {
   /// Holds the symbol lookup function.
   final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)

--- a/test/header_parser_tests/typedef_test.dart
+++ b/test/header_parser_tests/typedef_test.dart
@@ -19,6 +19,7 @@ void main() {
       actual = parser.parse(
         testConfig('''
 ${strings.name}: 'Bindings'
+${strings.description}: 'Typedef Test'
 ${strings.output}: 'unused'
 
 ${strings.headers}:


### PR DESCRIPTION
Adds a description to the config for typedef_test.dart for consistency with the other tests.