### PR TITLE
Use `@Native` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.0.0-dev.2
+
+- Use `@Native` syntax instead of deprecated `@FfiNative` syntax.
+
+
 # 8.0.0-dev.1
 
 - Fix invalid struct/enum member references due to multiple anonymous struct/enum in a declaration.

--- a/README.md
+++ b/README.md
@@ -509,10 +509,10 @@ type-map:
   <tr>
     <td>ffi-native</td>
     <td>
-      <b>WARNING:</b> FfiNative support is EXPERIMENTAL. The API may change
+      <b>WARNING:</b> Native support is EXPERIMENTAL. The API may change
       in a breaking way without notice.
       <br><br>
-      Generate `@FfiNative` bindings instead of bindings using `DynamicLibrary` or `lookup`.
+      Generate `@Native` bindings instead of bindings using `DynamicLibrary` or `lookup`.
     </td>
     <td>
 

--- a/example/ffinative/README.md
+++ b/example/ffinative/README.md
@@ -1,6 +1,6 @@
-# FfiNatives example
+# Natives example
 
-A simple example generating `FfiNative` bindings for a very small header file (`headers/example.h`).
+A simple example generating `Native` bindings for a very small header file (`headers/example.h`).
 
 ## Generating bindings
 At the root of this example (`example/simple`), run -

--- a/example/ffinative/generated_bindings.dart
+++ b/example/ffinative/generated_bindings.dart
@@ -7,36 +7,36 @@
 import 'dart:ffi' as ffi;
 
 /// Adds 2 integers.
-@ffi.FfiNative<ffi.Int Function(ffi.Int, ffi.Int)>('sum')
+@ffi.Native<ffi.Int Function(ffi.Int, ffi.Int)>(symbol: 'sum')
 external int sum(
   int a,
   int b,
 );
 
 /// Subtracts 2 integers.
-@ffi.FfiNative<ffi.Int Function(ffi.Int, ffi.Int)>('subtract')
+@ffi.Native<ffi.Int Function(ffi.Int, ffi.Int)>(symbol: 'subtract')
 external int subtract(
   int a,
   int b,
 );
 
 /// Multiplies 2 integers, returns pointer to an integer,.
-@ffi.FfiNative<ffi.Pointer<ffi.Int> Function(ffi.Int, ffi.Int)>('multiply')
+@ffi.Native<ffi.Pointer<ffi.Int> Function(ffi.Int, ffi.Int)>(symbol: 'multiply')
 external ffi.Pointer<ffi.Int> multiply(
   int a,
   int b,
 );
 
 /// Divides 2 integers, returns pointer to a float.
-@ffi.FfiNative<ffi.Pointer<ffi.Float> Function(ffi.Int, ffi.Int)>('divide')
+@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Int, ffi.Int)>(symbol: 'divide')
 external ffi.Pointer<ffi.Float> divide(
   int a,
   int b,
 );
 
 /// Divides 2 floats, returns a pointer to double.
-@ffi.FfiNative<ffi.Pointer<ffi.Double> Function(ffi.Float, ffi.Float)>(
-    'dividePrecision')
+@ffi.Native<ffi.Pointer<ffi.Double> Function(ffi.Float, ffi.Float)>(
+    symbol: 'dividePrecision')
 external ffi.Pointer<ffi.Double> dividePrecision(
   double a,
   double b,

--- a/lib/src/code_generator/func.dart
+++ b/lib/src/code_generator/func.dart
@@ -31,10 +31,10 @@ import 'writer.dart';
 /// typedef _dart_sum = int Function(int a, int b);
 /// ```
 ///
-/// When using `FfiNative`, the code is as follows.
+/// When using `Native`, the code is as follows.
 ///
 /// ```dart
-/// @ffi.FfiNative<ffi.Int32 Function(ffi.Int32 a, ffi.Int32 b)>('sum')
+/// @ffi.Native<ffi.Int32 Function(ffi.Int32 a, ffi.Int32 b)>('sum')
 /// external int sum(int a, int b);
 /// ```
 class Func extends LookUpBinding {
@@ -126,7 +126,7 @@ class Func extends LookUpBinding {
           : '';
       final isLeafString = isLeaf ? ', isLeaf: true' : '';
       s.write(
-          "@${w.ffiLibraryPrefix}.FfiNative<$cType>('$originalName'$assetString$isLeafString)\n");
+          "@${w.ffiLibraryPrefix}.Native<$cType>(symbol: '$originalName'$assetString$isLeafString)\n");
 
       s.write(
           'external ${functionType.returnType.getDartType(w)} $enclosingFuncName(\n');

--- a/lib/src/header_parser/sub_parsers/var_parser.dart
+++ b/lib/src/header_parser/sub_parsers/var_parser.dart
@@ -34,8 +34,8 @@ Global? parseVarDeclaration(clang_types.CXCursor cursor) {
   }
 
   if (config.ffiNativeConfig.enabled) {
-    _logger.warning(
-        "Skipped global variable '$name', not supported in FfiNatives.");
+    _logger
+        .warning("Skipped global variable '$name', not supported in Natives.");
     return null;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 8.0.0-dev.1
+version: 8.0.0-dev.2
 description: Generator for FFI bindings, using LibClang to parse C header files.
 repository: https://github.com/dart-lang/ffigen
 


### PR DESCRIPTION
Now that the minimum SDK is 3.0, we can use the new syntax.