### PR TITLE
Fix invalid code generated due to anoymous structs/unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.0.1
+
+- Fixe invalid code generated due to anonymous structs/unions with unsupported types.
+
 # 8.0.0
 
 - Stable release for Dart 3.0 with support for class modifers, variadic arguments, and `@Native`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 8.0.1
 
-- Fixe invalid code generated due to anonymous structs/unions with unsupported types.
+- Fixed invalid code generated due to anonymous structs/unions with unsupported types.
 
 # 8.0.0
 

--- a/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -294,11 +294,14 @@ int _compoundMembersVisitor(clang_types.CXCursor cursor,
         break;
       case clang_types.CXCursorKind.CXCursor_UnionDecl:
       case clang_types.CXCursorKind.CXCursor_StructDecl:
-        final mt = cursor.toCodeGenType();
-
         // If the union/struct are anonymous, then we need to add them now,
         // otherwise they will be added in the next iteration.
         if (!cursor.isAnonymousRecordDecl()) break;
+
+        final mt = cursor.toCodeGenType();
+        if (mt.isIncompleteCompound) {
+          parsed.incompleteCompoundMember = true;
+        }
 
         // Anonymous members are always unnamed. To avoid environment-
         // dependent naming issues with the generated code, we explicitly

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 8.0.0
+version: 8.0.1
 description: Generator for FFI bindings, using LibClang to parse C header files.
 repository: https://github.com/dart-lang/ffigen
 

--- a/test/header_parser_tests/expected_bindings/_expected_unions_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_unions_bindings.dart
@@ -79,3 +79,5 @@ final class UnnamedUnion2 extends ffi.Union {
   @ffi.Float()
   external double b;
 }
+
+final class Union7 extends ffi.Opaque {}

--- a/test/header_parser_tests/unions.h
+++ b/test/header_parser_tests/unions.h
@@ -46,6 +46,21 @@ union Union6
     };
 };
 
+// Multiple anonymous declarations with incomplete members
+union Union7
+{
+    union
+    {
+        float a;
+    };
+
+    union
+    {
+        float b;
+        int c[];
+    };
+};
+
 void func1(union Union2 *s);
 
 // Incomplete array parameter will be treated as a pointer.


### PR DESCRIPTION
Closes #570 

- Add missing incomplete member check for anonymous structs
- Update version, changelog, test
