### PR TITLE
Fixed invalid code generated due to zero-length arrays in structs/union.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 8.0.1
 
+- Fixed invalid code generated due to zero-length arrays in structs/union.
+
+# 8.0.1
+
 - Fixed invalid code generated due to anonymous structs/unions with unsupported types.
 
 # 8.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 8.0.1
+# 8.0.2
 
 - Fixed invalid code generated due to zero-length arrays in structs/union.
 

--- a/lib/src/header_parser/type_extractor/extractor.dart
+++ b/lib/src/header_parser/type_extractor/extractor.dart
@@ -118,10 +118,13 @@ Type getCodeGenType(
       return _extractFromFunctionProto(cxtype, cursor: originalCursor);
     case clang_types.CXTypeKind
           .CXType_ConstantArray: // Primarily used for constant array in struct members.
-      return ConstantArray(
-        clang.clang_getNumElements(cxtype),
-        clang.clang_getArrayElementType(cxtype).toCodeGenType(),
-      );
+      final numElements = clang.clang_getNumElements(cxtype);
+      final elementType =
+          clang.clang_getArrayElementType(cxtype).toCodeGenType();
+      // Handle numElements being 0 as an incomplete array.
+      return numElements == 0
+          ? IncompleteArray(elementType)
+          : ConstantArray(numElements, elementType);
     case clang_types.CXTypeKind
           .CXType_IncompleteArray: // Primarily used for incomplete array in function parameters.
       return IncompleteArray(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 8.0.1
+version: 8.0.2
 description: Generator for FFI bindings, using LibClang to parse C header files.
 repository: https://github.com/dart-lang/ffigen
 

--- a/test/header_parser_tests/function_n_struct.h
+++ b/test/header_parser_tests/function_n_struct.h
@@ -40,6 +40,14 @@ struct Struct6
     arr10 a[2];
 };
 
+// All members should be removed, Zero-length arrays are equivalent to
+// flexible arrays members (by an extension) are not supported.
+struct Struct7
+{
+    int a;
+    int b[0]; // Flexible array member.
+};
+
 void func1(struct Struct2 *s);
 
 // Incomplete array parameter will be treated as a pointer.

--- a/test/header_parser_tests/function_n_struct_test.dart
+++ b/test/header_parser_tests/function_n_struct_test.dart
@@ -120,6 +120,7 @@ Library expectedLibrary() {
       Struct(name: 'Struct6', members: [
         Member(name: 'a', type: ConstantArray(2, ConstantArray(10, intType)))
       ]),
+      Struct(name: 'Struct7'),
     ],
   );
 }

--- a/test/header_parser_tests/function_n_struct_test.dart
+++ b/test/header_parser_tests/function_n_struct_test.dart
@@ -58,6 +58,9 @@ ${strings.headers}:
       expect(actual.getBindingAsString('Struct6'),
           expected.getBindingAsString('Struct6'));
     });
+    test('Struct7 zero length array (extension on flexible array member)', () {
+      expect((actual.getBinding('Struct7') as Struct).members.isEmpty, true);
+    });
     test('func3 constant typedef array parameter', () {
       expect(actual.getBindingAsString('func3'),
           expected.getBindingAsString('func3'));


### PR DESCRIPTION
Closes #571 

Ref: https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html

- Handle zero-length arrays as flexible array members in struct (not supported)
- Update version, changelog, tests
