### PR TITLE
Fix null inference weirdness

### DIFF
--- a/lib/src/config_provider/config_spec.dart
+++ b/lib/src/config_provider/config_spec.dart
@@ -591,7 +591,7 @@ class StringConfigSpec<RE extends Object?> extends ConfigSpec<String, RE> {
     if (!o.checkType<String>(log: log)) {
       return false;
     }
-    if (_regexp != null && !_regexp.hasMatch(o.value as String)) {
+    if (!(_regexp?.hasMatch(o.value as String) ?? true)) {
       if (log) {
         _logger.severe(
             "Expected value of key '${o.pathString}' to match pattern $pattern (Input - ${o.value}).");


### PR DESCRIPTION
The change to lib/src/config_provider/config_spec.dart in #601 only works on the very latest SDK snapshot. This will make it hard for people to contribute until it hits stable. Better to just rewrite the line to sidestep the inference.