### PR TITLE
fix: objc block trampoline invalid return type

### DIFF
--- a/example/objective_c/config.yaml
+++ b/example/objective_c/config.yaml
@@ -12,4 +12,4 @@ headers:
   entry-points:
     - '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/AVFAudio.framework/Headers/AVAudioPlayer.h'
 preamble: |
-  // ignore_for_file: camel_case_types, non_constant_identifier_names, unused_element, unused_field, return_of_invalid_type, void_checks, annotate_overrides, no_leading_underscores_for_local_identifiers, library_private_types_in_public_api
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, unused_element, unused_field, void_checks, annotate_overrides, no_leading_underscores_for_local_identifiers, library_private_types_in_public_api

--- a/lib/src/code_generator/objc_block.dart
+++ b/lib/src/code_generator/objc_block.dart
@@ -90,8 +90,14 @@ $voidPtr $registerClosure(Function fn) {
       s.write(', ${params[i].type.getDartType(w)} ${params[i].name}');
     }
     s.write(') {\n');
-    s.write('  ${isVoid ? '' : 'return '}$closureRegistry['
-        'block.ref.target.address]!(');
+    s.write('  ${isVoid ? '' : 'return '}');
+    s.write('($closureRegistry[block.ref.target.address]');
+    s.write(' as ${returnType.getDartType(w)} Function(');
+    for (int i = 0; i < params.length; ++i) {
+      s.write('${i == 0 ? '' : ', '}${params[i].type.getDartType(w)}');
+    }
+    s.write('))');
+    s.write('(');
     for (int i = 0; i < params.length; ++i) {
       s.write('${i == 0 ? '' : ', '}${params[i].name}');
     }

--- a/test/native_objc_test/setup.dart
+++ b/test/native_objc_test/setup.dart
@@ -119,6 +119,8 @@ Future<void> clean(List<String> testNames) async {
 }
 
 Future<void> main(List<String> arguments) async {
+  // Allow running this script directly from any path (or an IDE).
+  Directory.current = Platform.script.resolve('.').toFilePath();
   if (!Platform.isMacOS) {
     throw OSError('Objective C tests are only supported on MacOS');
   }


### PR DESCRIPTION
Fixes #591

As for updating the generated `avf_audio_bindings.dart` - I have done so locally but haven't committed because I've got a lot of unrelated changes - probably due to the different environment to the one this was originally generated on.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
