### PR TITLE
Use correct exceptional return in float blocks

### DIFF
--- a/lib/src/code_generator/imports.dart
+++ b/lib/src/code_generator/imports.dart
@@ -86,8 +86,8 @@ final unsignedLongLongType =
     ImportedType(ffiImport, 'UnsignedLongLong', 'int', '0');
 final longLongType = ImportedType(ffiImport, 'LongLong', 'int', '0');
 
-final floatType = ImportedType(ffiImport, 'Float', 'double', '0');
-final doubleType = ImportedType(ffiImport, 'Double', 'double', '0');
+final floatType = ImportedType(ffiImport, 'Float', 'double', '0.0');
+final doubleType = ImportedType(ffiImport, 'Double', 'double', '0.0');
 
 final sizeType = ImportedType(ffiImport, 'Size', 'int', '0');
 final wCharType = ImportedType(ffiImport, 'WChar', 'int', '0');

--- a/lib/src/code_generator/native_type.dart
+++ b/lib/src/code_generator/native_type.dart
@@ -36,8 +36,8 @@ class NativeType extends Type {
     SupportedNativeType.Uint16: NativeType._('Uint16', 'int', '0'),
     SupportedNativeType.Uint32: NativeType._('Uint32', 'int', '0'),
     SupportedNativeType.Uint64: NativeType._('Uint64', 'int', '0'),
-    SupportedNativeType.Float: NativeType._('Float', 'double', '0'),
-    SupportedNativeType.Double: NativeType._('Double', 'double', '0'),
+    SupportedNativeType.Float: NativeType._('Float', 'double', '0.0'),
+    SupportedNativeType.Double: NativeType._('Double', 'double', '0.0'),
     SupportedNativeType.IntPtr: NativeType._('IntPtr', 'int', '0'),
     SupportedNativeType.UintPtr: NativeType._('UintPtr', 'int', '0'),
   };

--- a/test/native_objc_test/block_test.dart
+++ b/test/native_objc_test/block_test.dart
@@ -101,6 +101,14 @@ void main() {
       expect(value, 123);
     });
 
+    test('Float block', () {
+      final block = ObjCBlock2.fromFunction(lib, (double x) {
+        return x + 4.56;
+      });
+      expect(block(1.23), closeTo(5.79, 1e-6));
+      expect(BlockTester.callFloatBlock_(lib, block), closeTo(5.79, 1e-6));
+    });
+
     Pointer<Void> funcPointerBlockRefCountTest() {
       final block = ObjCBlock1.fromFunctionPointer(
           lib, Pointer.fromFunction(_add100, 999));

--- a/test/native_objc_test/block_test.m
+++ b/test/native_objc_test/block_test.m
@@ -6,6 +6,7 @@
 #import <Foundation/NSThread.h>
 
 typedef int32_t (^IntBlock)(int32_t);
+typedef float (^FloatBlock)(float);
 typedef void (^VoidBlock)();
 
 // Wrapper around a block, so that our Dart code can test creating and invoking
@@ -21,6 +22,7 @@ typedef void (^VoidBlock)();
 - (void)pokeBlock;
 + (void)callOnSameThread:(VoidBlock)block;
 + (NSThread*)callOnNewThread:(VoidBlock)block;
++ (float)callFloatBlock:(FloatBlock)block;
 @end
 
 @implementation BlockTester
@@ -84,6 +86,10 @@ void* valid_block_isa = NULL;
 
 + (NSThread*)callOnNewThread:(VoidBlock)block {
   return [[NSThread alloc] initWithBlock: block];
+}
+
++ (float)callFloatBlock:(FloatBlock)block {
+  return block(1.23);
 }
 
 @end


### PR DESCRIPTION
We were generating `0` as the exceptional return for float blocks, but we should be generating `0.0`. Fixes #577