### PR TITLE
fix: roll back SDK dependency of the generator to v3.0.0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -11,21 +11,23 @@ on:
 
 env:
   PUB_ENVIRONMENT: bot.github
+  # This is the Dart SDK version the code generator requires to run.
+  # Increase this with care as it limits who can use ffigen, regardless of what code the generator produces for them.
+  GENERATOR_MIN_SDK: 3.0.0
+
+  # This is the Dart SDK version we test against because some
+  # of the generated code may require the features provided in a newer SDK.
+  CODE_MIN_SDK: 3.2.0
 
 jobs:
   # Check code formatting and static analysis on a single OS (macos).
   analyze:
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # TODO: Change to 3.2.0 stable once it's released.
-        sdk: [3.2.0-114.0.dev]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: ${{ matrix.sdk }}
+          sdk: ${{ env.GENERATOR_MIN_SDK }}
       - id: install
         name: Install dependencies
         run: dart pub get && dart pub get --directory="example/shared_bindings"
@@ -45,7 +47,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: 3.2.0-114.0.dev
+          sdk: ${{ env.CODE_MIN_SDK }}
       - name: Install dependencies
         run: dart pub get
       - name: Install libclang-14-dev
@@ -62,7 +64,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: 3.2.0-114.0.dev
+          sdk: ${{ env.CODE_MIN_SDK }}
       - name: Install dependencies
         run: dart pub get
       - name: Build test dylib and bindings
@@ -84,7 +86,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: 3.2.0-114.0.dev
+          sdk: ${{ env.CODE_MIN_SDK }}
       - name: Install dependencies
         run: dart pub get
       - name: Build test dylib and bindings

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
  - codegen
 
 environment:
-  sdk: ">=3.2.0-114.0.dev <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   ffi: ^2.0.1


### PR DESCRIPTION
AFAICT the generator doesn't need to be updated with the higher SDK dependency (done by 416fccdf97b74b20f531dd386621e65ca9a9d2b4)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
