### PR TITLE
Better typedefs for `NativeFunction`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix return_of_invalid_type analysis error for ObjCBlocks.
 - Fix crash in ObjC methods and blocks that return structs by value.
 - Fix ObjC methods returning instancetype having the wrong type in sublasses.
+- When generating typedefs for `Pointer<NativeFunction<Function>>`, also
+  generate a typedef for the `Function`.
 - Bump min SDK version to 3.2.0-114.0.dev.
 
 # 9.0.1

--- a/example/libclang-example/generated_bindings.dart
+++ b/example/libclang-example/generated_bindings.dart
@@ -9751,6 +9751,8 @@ typedef CXCursorVisitor = ffi.Pointer<
     ffi.NativeFunction<
         ffi.Int32 Function(
             CXCursor cursor, CXCursor parent, CXClientData client_data)>>;
+typedef CXCursorVisitor_function = ffi.Int32 Function(
+    CXCursor cursor, CXCursor parent, CXClientData client_data);
 
 /// Describes how the traversal of the children of a particular
 /// cursor should proceed after visiting a particular child cursor.
@@ -10432,6 +10434,11 @@ typedef CXInclusionVisitor = ffi.Pointer<
             ffi.Pointer<CXSourceLocation> inclusion_stack,
             ffi.UnsignedInt include_len,
             CXClientData client_data)>>;
+typedef CXInclusionVisitor_function = ffi.Void Function(
+    CXFile included_file,
+    ffi.Pointer<CXSourceLocation> inclusion_stack,
+    ffi.UnsignedInt include_len,
+    CXClientData client_data);
 typedef NativeClang_getInclusions = ffi.Void Function(
     CXTranslationUnit tu, CXInclusionVisitor visitor, CXClientData client_data);
 typedef DartClang_getInclusions = void Function(
@@ -11106,6 +11113,8 @@ typedef DartClang_indexLoc_getCXSourceLocation = CXSourceLocation Function(
 typedef CXFieldVisitor = ffi.Pointer<
     ffi
     .NativeFunction<ffi.Int32 Function(CXCursor C, CXClientData client_data)>>;
+typedef CXFieldVisitor_function = ffi.Int32 Function(
+    CXCursor C, CXClientData client_data);
 typedef NativeClang_Type_visitFields = ffi.UnsignedInt Function(
     CXType T, CXFieldVisitor visitor, CXClientData client_data);
 typedef DartClang_Type_visitFields = int Function(

--- a/example/libclang-example/generated_bindings.dart
+++ b/example/libclang-example/generated_bindings.dart
@@ -9747,10 +9747,8 @@ typedef DartClang_getIBOutletCollectionType = CXType Function(CXCursor arg0);
 ///
 /// The visitor should return one of the \c CXChildVisitResult values
 /// to direct clang_visitCursorChildren().
-typedef CXCursorVisitor = ffi.Pointer<
-    ffi.NativeFunction<
-        ffi.Int32 Function(
-            CXCursor cursor, CXCursor parent, CXClientData client_data)>>;
+typedef CXCursorVisitor
+    = ffi.Pointer<ffi.NativeFunction<CXCursorVisitor_function>>;
 typedef CXCursorVisitor_function = ffi.Int32 Function(
     CXCursor cursor, CXCursor parent, CXClientData client_data);
 
@@ -10427,13 +10425,8 @@ typedef DartClang_toggleCrashRecovery = void Function(int isEnabled);
 /// the second and third arguments provide the inclusion stack.  The
 /// array is sorted in order of immediate inclusion.  For example,
 /// the first element refers to the location that included 'included_file'.
-typedef CXInclusionVisitor = ffi.Pointer<
-    ffi.NativeFunction<
-        ffi.Void Function(
-            CXFile included_file,
-            ffi.Pointer<CXSourceLocation> inclusion_stack,
-            ffi.UnsignedInt include_len,
-            CXClientData client_data)>>;
+typedef CXInclusionVisitor
+    = ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_function>>;
 typedef CXInclusionVisitor_function = ffi.Void Function(
     CXFile included_file,
     ffi.Pointer<CXSourceLocation> inclusion_stack,
@@ -11110,9 +11103,8 @@ typedef DartClang_indexLoc_getCXSourceLocation = CXSourceLocation Function(
 ///
 /// The visitor should return one of the \c CXVisitorResult values
 /// to direct \c clang_Type_visitFields.
-typedef CXFieldVisitor = ffi.Pointer<
-    ffi
-    .NativeFunction<ffi.Int32 Function(CXCursor C, CXClientData client_data)>>;
+typedef CXFieldVisitor
+    = ffi.Pointer<ffi.NativeFunction<CXFieldVisitor_function>>;
 typedef CXFieldVisitor_function = ffi.Int32 Function(
     CXCursor C, CXClientData client_data);
 typedef NativeClang_Type_visitFields = ffi.UnsignedInt Function(

--- a/lib/src/code_generator/func_type.dart
+++ b/lib/src/code_generator/func_type.dart
@@ -117,7 +117,7 @@ class NativeFunc extends Type {
   final Type _type;
 
   NativeFunc(this._type) {
-    assert(type is FunctionType);
+    assert(_type is FunctionType || _type is Typealias);
   }
 
   FunctionType get type {

--- a/lib/src/code_generator/func_type.dart
+++ b/lib/src/code_generator/func_type.dart
@@ -122,7 +122,7 @@ class NativeFunc extends Type {
 
   FunctionType get type {
     if (_type is Typealias) {
-      return (_type as Typealias).typealiasType as FunctionType;
+      return _type.typealiasType as FunctionType;
     }
     return _type as FunctionType;
   }

--- a/lib/src/code_generator/func_type.dart
+++ b/lib/src/code_generator/func_type.dart
@@ -113,26 +113,35 @@ class FunctionType extends Type {
 
 /// Represents a NativeFunction<Function>.
 class NativeFunc extends Type {
-  final FunctionType type;
+  // Either a FunctionType or a Typealias of a FunctionType.
+  final Type _type;
 
-  NativeFunc(this.type);
+  NativeFunc(this._type) {
+    assert(type is FunctionType);
+  }
+
+  FunctionType get type {
+    if (_type is Typealias) {
+      return (_type as Typealias).typealiasType as FunctionType;
+    }
+    return _type as FunctionType;
+  }
 
   @override
   void addDependencies(Set<Binding> dependencies) {
-    type.addDependencies(dependencies);
+    _type.addDependencies(dependencies);
   }
 
   @override
   String getCType(Writer w) =>
-      '${w.ffiLibraryPrefix}.NativeFunction<${type.getCType(w)}>';
+      '${w.ffiLibraryPrefix}.NativeFunction<${_type.getCType(w)}>';
 
   @override
-  String getDartType(Writer w) =>
-      '${w.ffiLibraryPrefix}.NativeFunction<${type.getCType(w)}>';
+  String getDartType(Writer w) => getCType(w);
 
   @override
-  String toString() => 'NativeFunction<${type.toString()}>';
+  String toString() => 'NativeFunction<${_type.toString()}>';
 
   @override
-  String cacheKey() => 'NatFn(${type.cacheKey()})';
+  String cacheKey() => 'NatFn(${_type.cacheKey()})';
 }

--- a/lib/src/code_generator/typealias.dart
+++ b/lib/src/code_generator/typealias.dart
@@ -47,14 +47,28 @@ class Typealias extends BindingType {
     type.addDependencies(dependencies);
   }
 
+  String _getTypeString(Writer w, Type type) =>
+      _useDartType ? type.getDartType(w) : type.getCType(w);
+
+  static FunctionType? _getFunctionTypeFromPointer(Type type) {
+    if (type is! PointerType) return null;
+    final pointee = type.child;
+    if (pointee is! NativeFunc) return null;
+    return pointee.type;
+  }
+
   @override
   BindingString toBindingString(Writer w) {
     final sb = StringBuffer();
     if (dartDoc != null) {
       sb.write(makeDartDoc(dartDoc!));
     }
-    sb.write('typedef $name = ');
-    sb.write('${_useDartType ? type.getDartType(w) : type.getCType(w)};\n');
+    sb.write('typedef $name = ${_getTypeString(w, type)};\n');
+    final funcType = _getFunctionTypeFromPointer(type);
+    if (funcType != null) {
+      final funcName = w.topLevelUniqueNamer.makeUnique('${name}Function');
+      sb.write('typedef $funcName = ${_getTypeString(w, funcType)};\n');
+    }
     return BindingString(
         type: BindingStringType.typeDef, string: sb.toString());
   }

--- a/lib/src/code_generator/typealias.dart
+++ b/lib/src/code_generator/typealias.dart
@@ -66,7 +66,7 @@ class Typealias extends BindingType {
     sb.write('typedef $name = ${_getTypeString(w, type)};\n');
     final funcType = _getFunctionTypeFromPointer(type);
     if (funcType != null) {
-      final funcName = w.topLevelUniqueNamer.makeUnique('${name}Function');
+      final funcName = w.topLevelUniqueNamer.makeUnique('${name}_function');
       sb.write('typedef $funcName = ${_getTypeString(w, funcType)};\n');
     }
     return BindingString(

--- a/lib/src/code_generator/typealias.dart
+++ b/lib/src/code_generator/typealias.dart
@@ -63,12 +63,14 @@ class Typealias extends BindingType {
     if (dartDoc != null) {
       sb.write(makeDartDoc(dartDoc!));
     }
-    sb.write('typedef $name = ${_getTypeString(w, type)};\n');
+    String typeString = _getTypeString(w, type);
     final funcType = _getFunctionTypeFromPointer(type);
     if (funcType != null) {
       final funcName = w.topLevelUniqueNamer.makeUnique('${name}_function');
       sb.write('typedef $funcName = ${_getTypeString(w, funcType)};\n');
+      typeString = '${w.ffiLibraryPrefix}.Pointer<${w.ffiLibraryPrefix}.NativeFunction<$funcName>>';
     }
+    sb.write('typedef $name = $typeString;\n');
     return BindingString(
         type: BindingStringType.typeDef, string: sb.toString());
   }

--- a/lib/src/code_generator/typealias.dart
+++ b/lib/src/code_generator/typealias.dart
@@ -59,7 +59,7 @@ class Typealias extends BindingType {
     required this.type,
     bool useDartType = false,
     bool isInternal = false,
-  }) : _useDartType = useDartType,
+  })  : _useDartType = useDartType,
         super(
           usr: usr,
           name: name,

--- a/test/header_parser_tests/expected_bindings/_expected_dart_handle_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_dart_handle_bindings.dart
@@ -70,6 +70,7 @@ class NativeLibrary {
 
 typedef Typedef1
     = ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Handle)>>;
+typedef Typedef1_function = ffi.Void Function(ffi.Handle);
 
 final class Struct1 extends ffi.Opaque {}
 

--- a/test/header_parser_tests/expected_bindings/_expected_dart_handle_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_dart_handle_bindings.dart
@@ -68,8 +68,7 @@ class NativeLibrary {
   late final _func4 = _func4Ptr.asFunction<void Function(Typedef1)>();
 }
 
-typedef Typedef1
-    = ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Handle)>>;
+typedef Typedef1 = ffi.Pointer<ffi.NativeFunction<Typedef1_function>>;
 typedef Typedef1_function = ffi.Void Function(ffi.Handle);
 
 final class Struct1 extends ffi.Opaque {}

--- a/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
@@ -73,14 +73,16 @@ final class Struct extends ffi.Struct {
 }
 
 typedef WithTypedefReturnType
-    = ffi.Pointer<ffi.NativeFunction<InsideReturnType Function()>>;
+    = ffi.Pointer<ffi.NativeFunction<WithTypedefReturnType_function>>;
 typedef WithTypedefReturnType_function = InsideReturnType Function();
-typedef InsideReturnType = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
+typedef InsideReturnType
+    = ffi.Pointer<ffi.NativeFunction<InsideReturnType_function>>;
 typedef InsideReturnType_function = ffi.Void Function();
 
 final class Struct2 extends ffi.Struct {
   external VoidFuncPointer constFuncPointer;
 }
 
-typedef VoidFuncPointer = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
+typedef VoidFuncPointer =
+    ffi.Pointer<ffi.NativeFunction<VoidFuncPointer_function>>;
 typedef VoidFuncPointer_function = ffi.Void Function();

--- a/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
@@ -83,6 +83,6 @@ final class Struct2 extends ffi.Struct {
   external VoidFuncPointer constFuncPointer;
 }
 
-typedef VoidFuncPointer =
-    ffi.Pointer<ffi.NativeFunction<VoidFuncPointer_function>>;
+typedef VoidFuncPointer
+    = ffi.Pointer<ffi.NativeFunction<VoidFuncPointer_function>>;
 typedef VoidFuncPointer_function = ffi.Void Function();

--- a/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_native_func_typedef_bindings.dart
@@ -74,10 +74,13 @@ final class Struct extends ffi.Struct {
 
 typedef WithTypedefReturnType
     = ffi.Pointer<ffi.NativeFunction<InsideReturnType Function()>>;
+typedef WithTypedefReturnType_function = InsideReturnType Function();
 typedef InsideReturnType = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
+typedef InsideReturnType_function = ffi.Void Function();
 
 final class Struct2 extends ffi.Struct {
   external VoidFuncPointer constFuncPointer;
 }
 
 typedef VoidFuncPointer = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
+typedef VoidFuncPointer_function = ffi.Void Function();

--- a/test/header_parser_tests/expected_bindings/_expected_struct_fptr_fields_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_struct_fptr_fields_bindings.dart
@@ -70,3 +70,4 @@ final class S extends ffi.Struct {
 
 typedef ArithmeticOperation
     = ffi.Pointer<ffi.NativeFunction<ffi.Int Function(ffi.Int a, ffi.Int b)>>;
+typedef ArithmeticOperation_function = ffi.Int Function(ffi.Int a, ffi.Int b);

--- a/test/header_parser_tests/expected_bindings/_expected_struct_fptr_fields_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_struct_fptr_fields_bindings.dart
@@ -69,5 +69,5 @@ final class S extends ffi.Struct {
 }
 
 typedef ArithmeticOperation
-    = ffi.Pointer<ffi.NativeFunction<ffi.Int Function(ffi.Int a, ffi.Int b)>>;
+    = ffi.Pointer<ffi.NativeFunction<ArithmeticOperation_function>>;
 typedef ArithmeticOperation_function = ffi.Int Function(ffi.Int a, ffi.Int b);

--- a/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
@@ -93,7 +93,7 @@ final class Struct1 extends ffi.Struct {
 
 typedef NamedFunctionProto
     = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
-typedef NamedFunctionProtoFunction = ffi.Void Function();
+typedef NamedFunctionProto_function = ffi.Void Function();
 
 final class AnonymousStructInTypedef extends ffi.Opaque {}
 

--- a/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
@@ -91,9 +91,9 @@ final class Struct1 extends ffi.Struct {
   external ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> unnamed;
 }
 
-typedef NamedFunctionProto
-    = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
 typedef NamedFunctionProto_function = ffi.Void Function();
+typedef NamedFunctionProto
+    = ffi.Pointer<ffi.NativeFunction<NamedFunctionProto_function>>;
 
 final class AnonymousStructInTypedef extends ffi.Opaque {}
 

--- a/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
@@ -91,9 +91,9 @@ final class Struct1 extends ffi.Struct {
   external ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> unnamed;
 }
 
-typedef NamedFunctionProto_function = ffi.Void Function();
 typedef NamedFunctionProto
     = ffi.Pointer<ffi.NativeFunction<NamedFunctionProto_function>>;
+typedef NamedFunctionProto_function = ffi.Void Function();
 
 final class AnonymousStructInTypedef extends ffi.Opaque {}
 

--- a/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
+++ b/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
@@ -93,6 +93,7 @@ final class Struct1 extends ffi.Struct {
 
 typedef NamedFunctionProto
     = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
+typedef NamedFunctionProtoFunction = ffi.Void Function();
 
 final class AnonymousStructInTypedef extends ffi.Opaque {}
 

--- a/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -7430,10 +7430,8 @@ abstract class CXChildVisitResult {
 }
 
 /// Visitor invoked for each cursor found by a traversal.
-typedef CXCursorVisitor = ffi.Pointer<
-    ffi.NativeFunction<
-        ffi.Int32 Function(
-            CXCursor cursor, CXCursor parent, CXClientData client_data)>>;
+typedef CXCursorVisitor =
+    ffi.Pointer<ffi.NativeFunction<CXCursorVisitor_function>>;
 typedef CXCursorVisitor_function = ffi.Int32 Function(
     CXCursor cursor, CXCursor parent, CXClientData client_data);
 
@@ -7763,13 +7761,8 @@ abstract class CXCompletionContext {
 
 /// Visitor invoked for each file in a translation unit (used with
 /// clang_getInclusions()).
-typedef CXInclusionVisitor = ffi.Pointer<
-    ffi.NativeFunction<
-        ffi.Void Function(
-            CXFile included_file,
-            ffi.Pointer<CXSourceLocation> inclusion_stack,
-            ffi.UnsignedInt include_len,
-            CXClientData client_data)>>;
+typedef CXInclusionVisitor =
+    ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_function>>;
 typedef CXInclusionVisitor_function = ffi.Void Function(
     CXFile included_file,
     ffi.Pointer<CXSourceLocation> inclusion_stack,
@@ -8231,9 +8224,8 @@ abstract class CXIndexOptFlags {
 }
 
 /// Visitor invoked for each field found by a traversal.
-typedef CXFieldVisitor = ffi.Pointer<
-    ffi
-    .NativeFunction<ffi.Int32 Function(CXCursor C, CXClientData client_data)>>;
+typedef CXFieldVisitor =
+    ffi.Pointer<ffi.NativeFunction<CXFieldVisitor_function>>;
 typedef CXFieldVisitor_function = ffi.Int32 Function(
     CXCursor C, CXClientData client_data);
 

--- a/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -7434,6 +7434,8 @@ typedef CXCursorVisitor = ffi.Pointer<
     ffi.NativeFunction<
         ffi.Int32 Function(
             CXCursor cursor, CXCursor parent, CXClientData client_data)>>;
+typedef CXCursorVisitor_function = ffi.Int32 Function(
+    CXCursor cursor, CXCursor parent, CXClientData client_data);
 
 /// Opaque pointer representing client data that will be passed through to
 /// various callbacks and visitors.
@@ -7768,6 +7770,11 @@ typedef CXInclusionVisitor = ffi.Pointer<
             ffi.Pointer<CXSourceLocation> inclusion_stack,
             ffi.UnsignedInt include_len,
             CXClientData client_data)>>;
+typedef CXInclusionVisitor_function = ffi.Void Function(
+    CXFile included_file,
+    ffi.Pointer<CXSourceLocation> inclusion_stack,
+    ffi.UnsignedInt include_len,
+    CXClientData client_data);
 
 abstract class CXEvalResultKind {
   static const int CXEval_Int = 1;
@@ -8227,6 +8234,8 @@ abstract class CXIndexOptFlags {
 typedef CXFieldVisitor = ffi.Pointer<
     ffi
     .NativeFunction<ffi.Int32 Function(CXCursor C, CXClientData client_data)>>;
+typedef CXFieldVisitor_function = ffi.Int32 Function(
+    CXCursor C, CXClientData client_data);
 
 const int CINDEX_VERSION_MAJOR = 0;
 

--- a/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -7430,8 +7430,8 @@ abstract class CXChildVisitResult {
 }
 
 /// Visitor invoked for each cursor found by a traversal.
-typedef CXCursorVisitor =
-    ffi.Pointer<ffi.NativeFunction<CXCursorVisitor_function>>;
+typedef CXCursorVisitor
+    = ffi.Pointer<ffi.NativeFunction<CXCursorVisitor_function>>;
 typedef CXCursorVisitor_function = ffi.Int32 Function(
     CXCursor cursor, CXCursor parent, CXClientData client_data);
 
@@ -7761,8 +7761,8 @@ abstract class CXCompletionContext {
 
 /// Visitor invoked for each file in a translation unit (used with
 /// clang_getInclusions()).
-typedef CXInclusionVisitor =
-    ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_function>>;
+typedef CXInclusionVisitor
+    = ffi.Pointer<ffi.NativeFunction<CXInclusionVisitor_function>>;
 typedef CXInclusionVisitor_function = ffi.Void Function(
     CXFile included_file,
     ffi.Pointer<CXSourceLocation> inclusion_stack,
@@ -8224,8 +8224,8 @@ abstract class CXIndexOptFlags {
 }
 
 /// Visitor invoked for each field found by a traversal.
-typedef CXFieldVisitor =
-    ffi.Pointer<ffi.NativeFunction<CXFieldVisitor_function>>;
+typedef CXFieldVisitor
+    = ffi.Pointer<ffi.NativeFunction<CXFieldVisitor_function>>;
 typedef CXFieldVisitor_function = ffi.Int32 Function(
     CXCursor C, CXClientData client_data);
 

--- a/test/large_integration_tests/_expected_sqlite_bindings.dart
+++ b/test/large_integration_tests/_expected_sqlite_bindings.dart
@@ -10855,7 +10855,7 @@ final class sqlite3_vfs extends ffi.Struct {
 typedef sqlite3_int64 = sqlite_int64;
 typedef sqlite_int64 = ffi.LongLong;
 typedef sqlite3_syscall_ptr
-    = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
+    = ffi.Pointer<ffi.NativeFunction<sqlite3_syscall_ptr_function>;
 typedef sqlite3_syscall_ptr_function = ffi.Void Function();
 
 final class sqlite3_mem_methods extends ffi.Struct {
@@ -12009,14 +12009,8 @@ final class fts5_api extends ffi.Struct {
                   xDestroy)>> xCreateFunction;
 }
 
-typedef fts5_extension_function = ffi.Pointer<
-    ffi.NativeFunction<
-        ffi.Void Function(
-            ffi.Pointer<Fts5ExtensionApi> pApi,
-            ffi.Pointer<Fts5Context> pFts,
-            ffi.Pointer<sqlite3_context> pCtx,
-            ffi.Int nVal,
-            ffi.Pointer<ffi.Pointer<sqlite3_value>> apVal)>>;
+typedef fts5_extension_function =
+    ffi.Pointer<ffi.NativeFunction<fts5_extension_function_function>>;
 typedef fts5_extension_function_function = ffi.Void Function(
     ffi.Pointer<Fts5ExtensionApi> pApi,
     ffi.Pointer<Fts5Context> pFts,

--- a/test/large_integration_tests/_expected_sqlite_bindings.dart
+++ b/test/large_integration_tests/_expected_sqlite_bindings.dart
@@ -10855,7 +10855,7 @@ final class sqlite3_vfs extends ffi.Struct {
 typedef sqlite3_int64 = sqlite_int64;
 typedef sqlite_int64 = ffi.LongLong;
 typedef sqlite3_syscall_ptr
-    = ffi.Pointer<ffi.NativeFunction<sqlite3_syscall_ptr_function>;
+    = ffi.Pointer<ffi.NativeFunction<sqlite3_syscall_ptr_function>>;
 typedef sqlite3_syscall_ptr_function = ffi.Void Function();
 
 final class sqlite3_mem_methods extends ffi.Struct {
@@ -12009,8 +12009,8 @@ final class fts5_api extends ffi.Struct {
                   xDestroy)>> xCreateFunction;
 }
 
-typedef fts5_extension_function =
-    ffi.Pointer<ffi.NativeFunction<fts5_extension_function_function>>;
+typedef fts5_extension_function
+    = ffi.Pointer<ffi.NativeFunction<fts5_extension_function_function>>;
 typedef fts5_extension_function_function = ffi.Void Function(
     ffi.Pointer<Fts5ExtensionApi> pApi,
     ffi.Pointer<Fts5Context> pFts,

--- a/test/large_integration_tests/_expected_sqlite_bindings.dart
+++ b/test/large_integration_tests/_expected_sqlite_bindings.dart
@@ -10856,6 +10856,7 @@ typedef sqlite3_int64 = sqlite_int64;
 typedef sqlite_int64 = ffi.LongLong;
 typedef sqlite3_syscall_ptr
     = ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>;
+typedef sqlite3_syscall_ptr_function = ffi.Void Function();
 
 final class sqlite3_mem_methods extends ffi.Struct {
   /// Memory allocation function
@@ -12016,6 +12017,12 @@ typedef fts5_extension_function = ffi.Pointer<
             ffi.Pointer<sqlite3_context> pCtx,
             ffi.Int nVal,
             ffi.Pointer<ffi.Pointer<sqlite3_value>> apVal)>>;
+typedef fts5_extension_function_function = ffi.Void Function(
+    ffi.Pointer<Fts5ExtensionApi> pApi,
+    ffi.Pointer<Fts5Context> pFts,
+    ffi.Pointer<sqlite3_context> pCtx,
+    ffi.Int nVal,
+    ffi.Pointer<ffi.Pointer<sqlite3_value>> apVal);
 
 const String SQLITE_VERSION = '3.32.3';
 


### PR DESCRIPTION
When generating typedefs for `Pointer<NativeFunction<Function>>`, also  generate a typedef for the `Function`.

Fixes #614.