### PR TITLE
Refactor `sameFfiDartAndCType` to not require a `Writer`

### DIFF
--- a/lib/src/code_generator/compound.dart
+++ b/lib/src/code_generator/compound.dart
@@ -145,7 +145,7 @@ abstract class Compound extends BindingType {
         s.write('${depth}external ${_getInlineArrayTypeString(m.type, w)} ');
         s.write('${m.name};\n\n');
       } else {
-        if (!sameDartAndCType(m.type, w)) {
+        if (!m.type.sameFfiDartAndCType) {
           s.write('$depth@${m.type.getCType(w)}()\n');
         }
         s.write('${depth}external ${m.type.getFfiDartType(w)} ${m.name};\n\n');
@@ -173,6 +173,9 @@ abstract class Compound extends BindingType {
 
   @override
   String getCType(Writer w) => name;
+
+  @override
+  bool get sameFfiDartAndCType => true;
 }
 
 class Member {

--- a/lib/src/code_generator/enum_class.dart
+++ b/lib/src/code_generator/enum_class.dart
@@ -87,6 +87,12 @@ class EnumClass extends BindingType {
   String getFfiDartType(Writer w) => nativeType.getFfiDartType(w);
 
   @override
+  bool get sameFfiDartAndCType => nativeType.sameFfiDartAndCType;
+
+  @override
+  bool get sameDartAndCType => nativeType.sameDartAndCType;
+
+  @override
   String? getDefaultValue(Writer w, String nativeLib) => '0';
 }
 

--- a/lib/src/code_generator/func_type.dart
+++ b/lib/src/code_generator/func_type.dart
@@ -82,6 +82,18 @@ class FunctionType extends Type {
   }
 
   @override
+  bool get sameFfiDartAndCType =>
+      returnType.sameFfiDartAndCType &&
+      parameters.every((p) => p.type.sameFfiDartAndCType) &&
+      varArgParameters.every((p) => p.type.sameFfiDartAndCType);
+
+  @override
+  bool get sameDartAndCType =>
+      returnType.sameDartAndCType &&
+      parameters.every((p) => p.type.sameDartAndCType) &&
+      varArgParameters.every((p) => p.type.sameDartAndCType);
+
+  @override
   String toString() => _getCacheKeyString(false, (Type t) => t.toString());
 
   @override
@@ -138,6 +150,9 @@ class NativeFunc extends Type {
 
   @override
   String getFfiDartType(Writer w) => getCType(w);
+
+  @override
+  bool get sameFfiDartAndCType => true;
 
   @override
   String toString() => 'NativeFunction<${_type.toString()}>';

--- a/lib/src/code_generator/handle.dart
+++ b/lib/src/code_generator/handle.dart
@@ -19,5 +19,8 @@ class HandleType extends Type {
   String getFfiDartType(Writer w) => 'Object';
 
   @override
+  bool get sameFfiDartAndCType => false;
+
+  @override
   String toString() => 'Handle';
 }

--- a/lib/src/code_generator/imports.dart
+++ b/lib/src/code_generator/imports.dart
@@ -43,6 +43,9 @@ class ImportedType extends Type {
   String getFfiDartType(Writer w) => cType == dartType ? getCType(w) : dartType;
 
   @override
+  bool get sameFfiDartAndCType => cType == dartType;
+
+  @override
   String toString() => '${libraryImport.name}.$cType';
 
   @override
@@ -63,6 +66,9 @@ class SelfImportedType extends Type {
 
   @override
   String getFfiDartType(Writer w) => dartType;
+
+  @override
+  bool get sameFfiDartAndCType => cType == dartType;
 
   @override
   String toString() => cType;

--- a/lib/src/code_generator/native_type.dart
+++ b/lib/src/code_generator/native_type.dart
@@ -57,6 +57,9 @@ class NativeType extends Type {
   String getFfiDartType(Writer w) => _dartType;
 
   @override
+  bool get sameFfiDartAndCType => _cType == _dartType;
+
+  @override
   String toString() => _cType;
 
   @override

--- a/lib/src/code_generator/objc_block.dart
+++ b/lib/src/code_generator/objc_block.dart
@@ -226,5 +226,11 @@ class $name extends _ObjCBlockBase {
   String getDartType(Writer w) => name;
 
   @override
+  bool get sameFfiDartAndCType => true;
+
+  @override
+  bool get sameDartAndCType => false;
+
+  @override
   String toString() => '($returnType (^)(${argTypes.join(', ')}))';
 }

--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -389,6 +389,12 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
   @override
   String getDartType(Writer w) => name;
 
+  @override
+  bool get sameFfiDartAndCType => true;
+
+  @override
+  bool get sameDartAndCType => false;
+
   // Utils for converting between the internal types passed to native code, and
   // the external types visible to the user. For example, ObjCInterfaces are
   // passed to native as Pointer<ObjCObject>, but the user sees the Dart wrapper

--- a/lib/src/code_generator/objc_nullable.dart
+++ b/lib/src/code_generator/objc_nullable.dart
@@ -39,6 +39,12 @@ class ObjCNullable extends Type {
   String getDartType(Writer w) => '${child.getDartType(w)}?';
 
   @override
+  bool get sameFfiDartAndCType => child.sameFfiDartAndCType;
+
+  @override
+  bool get sameDartAndCType => false;
+
+  @override
   String toString() => '$child?';
 
   @override

--- a/lib/src/code_generator/pointer.dart
+++ b/lib/src/code_generator/pointer.dart
@@ -31,6 +31,10 @@ class PointerType extends Type {
   String getCType(Writer w) =>
       '${w.ffiLibraryPrefix}.Pointer<${child.getCType(w)}>';
 
+  // Both the C type and the FFI Dart type are 'Pointer<$cType>'.
+  @override
+  bool get sameFfiDartAndCType => true;
+
   @override
   String toString() => '$child*';
 
@@ -79,4 +83,7 @@ class ObjCObjectPointer extends PointerType {
 
   @override
   String getDartType(Writer w) => 'NSObject';
+
+  @override
+  bool get sameDartAndCType => false;
 }

--- a/lib/src/code_generator/type.dart
+++ b/lib/src/code_generator/type.dart
@@ -48,6 +48,12 @@ abstract class Type {
   /// as getFfiDartType. For ObjC bindings this refers to the wrapper object.
   String getDartType(Writer w) => getFfiDartType(w);
 
+  /// Returns whether the FFI dart type and C type string are same.
+  bool get sameFfiDartAndCType;
+
+  /// Returns whether the dart type and C type string are same.
+  bool get sameDartAndCType => sameFfiDartAndCType;
+
   /// Returns the string representation of the Type, for debugging purposes
   /// only. This string should not be printed as generated code.
   @override
@@ -65,9 +71,6 @@ abstract class Type {
   /// that default values aren't supported for this type, eg void.
   String? getDefaultValue(Writer w, String nativeLib) => null;
 }
-
-/// Function to check if the dart and C type string are same.
-bool sameDartAndCType(Type t, Writer w) => t.getCType(w) == t.getFfiDartType(w);
 
 /// Base class for all Type bindings.
 ///
@@ -108,6 +111,9 @@ abstract class BindingType extends NoLookUpBinding implements Type {
   String getDartType(Writer w) => getFfiDartType(w);
 
   @override
+  bool get sameDartAndCType => sameFfiDartAndCType;
+
+  @override
   String toString() => originalName;
 
   @override
@@ -125,4 +131,7 @@ class UnimplementedType extends Type {
 
   @override
   String toString() => '(Unimplemented: $reason)';
+
+  @override
+  bool get sameFfiDartAndCType => true;
 }

--- a/lib/src/code_generator/typealias.dart
+++ b/lib/src/code_generator/typealias.dart
@@ -121,12 +121,18 @@ class Typealias extends BindingType {
   String getFfiDartType(Writer w) {
     // Typealias cannot be used by name in Dart types unless both the C and Dart
     // type of the underlying types are same.
-    if (sameDartAndCType(type, w)) {
+    if (type.sameFfiDartAndCType) {
       return name;
     } else {
       return type.getFfiDartType(w);
     }
   }
+
+  @override
+  bool get sameFfiDartAndCType => type.sameFfiDartAndCType;
+
+  @override
+  bool get sameDartAndCType => type.sameDartAndCType;
 
   @override
   String cacheKey() => type.cacheKey();


### PR DESCRIPTION
Ran into this while working on other refactors, and pulled it out into its own PR. Instead of `sameFfiDartAndCType` comparing `getFfiDartType` and `getCType`, just make it a first class method on `Type` that subclasses have to override. This means we don't need a `Writer`, so we can use this function outside of `toBindingString`. If I did it right, there should be no codegen differences.