### PR TITLE
Enable and fix `use_super_parameters` lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -19,5 +19,7 @@ linter:
     directives_ordering: true
     prefer_final_locals: true
     prefer_final_in_for_each: true
+    use_super_parameters: true
+    
     # Disabled.
     constant_identifier_names: false

--- a/lib/src/code_generator/binding.dart
+++ b/lib/src/code_generator/binding.dart
@@ -44,15 +44,12 @@ abstract class LookUpBinding extends Binding {
   LookUpBinding({
     String? usr,
     String? originalName,
-    required String name,
-    String? dartDoc,
-    bool isInternal = false,
+    required super.name,
+    super.dartDoc,
+    super.isInternal,
   }) : super(
           usr: usr ?? name,
           originalName: originalName ?? name,
-          name: name,
-          dartDoc: dartDoc,
-          isInternal: isInternal,
         );
 }
 
@@ -61,14 +58,11 @@ abstract class NoLookUpBinding extends Binding {
   NoLookUpBinding({
     String? usr,
     String? originalName,
-    required String name,
-    String? dartDoc,
-    bool isInternal = false,
+    required super.name,
+    super.dartDoc,
+    super.isInternal,
   }) : super(
           usr: usr ?? name,
           originalName: originalName ?? name,
-          name: name,
-          dartDoc: dartDoc,
-          isInternal: isInternal,
         );
 }

--- a/lib/src/code_generator/compound.dart
+++ b/lib/src/code_generator/compound.dart
@@ -35,23 +35,16 @@ abstract class Compound extends BindingType {
   bool get isUnion => compoundType == CompoundType.union;
 
   Compound({
-    String? usr,
-    String? originalName,
-    required String name,
+    super.usr,
+    super.originalName,
+    required super.name,
     required this.compoundType,
     this.isIncomplete = false,
     this.pack,
-    String? dartDoc,
+    super.dartDoc,
     List<Member>? members,
-    bool isInternal = false,
-  })  : members = members ?? [],
-        super(
-          usr: usr,
-          originalName: originalName,
-          name: name,
-          dartDoc: dartDoc,
-          isInternal: isInternal,
-        );
+    super.isInternal,
+  }) : members = members ?? [];
 
   factory Compound.fromType({
     required CompoundType type,

--- a/lib/src/code_generator/constant.dart
+++ b/lib/src/code_generator/constant.dart
@@ -28,18 +28,13 @@ class Constant extends NoLookUpBinding {
   final String rawValue;
 
   Constant({
-    String? usr,
-    String? originalName,
-    required String name,
-    String? dartDoc,
+    super.usr,
+    super.originalName,
+    required super.name,
+    super.dartDoc,
     required this.rawType,
     required this.rawValue,
-  }) : super(
-          usr: usr,
-          originalName: originalName,
-          name: name,
-          dartDoc: dartDoc,
-        );
+  });
 
   @override
   BindingString toBindingString(Writer w) {

--- a/lib/src/code_generator/enum_class.dart
+++ b/lib/src/code_generator/enum_class.dart
@@ -29,18 +29,12 @@ class EnumClass extends BindingType {
   final List<EnumConstant> enumConstants;
 
   EnumClass({
-    String? usr,
-    String? originalName,
-    required String name,
-    String? dartDoc,
+    super.usr,
+    super.originalName,
+    required super.name,
+    super.dartDoc,
     List<EnumConstant>? enumConstants,
-  })  : enumConstants = enumConstants ?? [],
-        super(
-          usr: usr,
-          originalName: originalName,
-          name: name,
-          dartDoc: dartDoc,
-        );
+  }) : enumConstants = enumConstants ?? [];
 
   @override
   BindingString toBindingString(Writer w) {

--- a/lib/src/code_generator/func.dart
+++ b/lib/src/code_generator/func.dart
@@ -51,17 +51,17 @@ class Func extends LookUpBinding {
   /// [originalName] is looked up in dynamic library, if not
   /// provided, takes the value of [name].
   Func({
-    String? usr,
+    super.usr,
     required String name,
-    String? originalName,
-    String? dartDoc,
+    super.originalName,
+    super.dartDoc,
     required Type returnType,
     List<Parameter>? parameters,
     List<Parameter>? varArgParameters,
     this.exposeSymbolAddress = false,
     this.exposeFunctionTypedefs = false,
     this.isLeaf = false,
-    bool isInternal = false,
+    super.isInternal,
     this.ffiNativeConfig = const FfiNativeConfig(enabled: false),
   })  : functionType = FunctionType(
           returnType: returnType,
@@ -69,11 +69,7 @@ class Func extends LookUpBinding {
           varArgParameters: varArgParameters ?? const [],
         ),
         super(
-          usr: usr,
-          originalName: originalName,
           name: name,
-          dartDoc: dartDoc,
-          isInternal: isInternal,
         ) {
     for (var i = 0; i < functionType.parameters.length; i++) {
       if (functionType.parameters[i].name.trim() == '') {

--- a/lib/src/code_generator/global.dart
+++ b/lib/src/code_generator/global.dart
@@ -24,18 +24,13 @@ class Global extends LookUpBinding {
   final bool exposeSymbolAddress;
 
   Global({
-    String? usr,
-    String? originalName,
-    required String name,
+    super.usr,
+    super.originalName,
+    required super.name,
     required this.type,
-    String? dartDoc,
+    super.dartDoc,
     this.exposeSymbolAddress = false,
-  }) : super(
-          usr: usr,
-          originalName: originalName,
-          name: name,
-          dartDoc: dartDoc,
-        );
+  });
 
   @override
   BindingString toBindingString(Writer w) {

--- a/lib/src/code_generator/objc_block.dart
+++ b/lib/src/code_generator/objc_block.dart
@@ -26,16 +26,12 @@ class ObjCBlock extends BindingType {
         );
 
   ObjCBlock._({
-    required String usr,
-    required String name,
+    required String super.usr,
+    required super.name,
     required this.returnType,
     required this.argTypes,
     required this.builtInFunctions,
-  }) : super(
-          usr: usr,
-          originalName: name,
-          name: name,
-        );
+  }) : super(originalName: name);
 
   // Generates a human readable name for the block based on the args and return
   // type. These names will be pretty verbose and unweildy, but they're at least

--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -48,18 +48,15 @@ class ObjCInterface extends BindingType {
   late final ObjCMsgSendFunc _isKindOfClassMsgSend;
 
   ObjCInterface({
-    String? usr,
-    required String originalName,
+    super.usr,
+    required String super.originalName,
     String? name,
     String? lookupName,
-    String? dartDoc,
+    super.dartDoc,
     required this.builtInFunctions,
   })  : lookupName = lookupName ?? originalName,
         super(
-          usr: usr,
-          originalName: originalName,
           name: name ?? originalName,
-          dartDoc: dartDoc,
         ) {
     builtInFunctions.registerInterface(this);
   }

--- a/lib/src/code_generator/pointer.dart
+++ b/lib/src/code_generator/pointer.dart
@@ -62,7 +62,7 @@ class ConstantArray extends PointerType {
 
 /// Represents an incomplete array, which has an unknown size.
 class IncompleteArray extends PointerType {
-  IncompleteArray(Type child) : super._(child);
+  IncompleteArray(super.child) : super._();
 
   @override
   Type get baseArrayType => child.baseArrayType;

--- a/lib/src/code_generator/struct.dart
+++ b/lib/src/code_generator/struct.dart
@@ -30,23 +30,13 @@ import 'package:ffigen/src/code_generator/compound.dart';
 /// ```
 class Struct extends Compound {
   Struct({
-    String? usr,
-    String? originalName,
-    required String name,
-    bool isIncomplete = false,
-    int? pack,
-    String? dartDoc,
-    List<Member>? members,
-    bool isInternal = false,
-  }) : super(
-          usr: usr,
-          originalName: originalName,
-          name: name,
-          dartDoc: dartDoc,
-          isIncomplete: isIncomplete,
-          members: members,
-          pack: pack,
-          compoundType: CompoundType.struct,
-          isInternal: isInternal,
-        );
+    super.usr,
+    super.originalName,
+    required super.name,
+    super.isIncomplete,
+    super.pack,
+    super.dartDoc,
+    super.members,
+    super.isInternal,
+  }) : super(compoundType: CompoundType.struct);
 }

--- a/lib/src/code_generator/type.dart
+++ b/lib/src/code_generator/type.dart
@@ -79,18 +79,12 @@ abstract class Type {
 /// to extend both NoLookUpBinding and Type.
 abstract class BindingType extends NoLookUpBinding implements Type {
   BindingType({
-    String? usr,
-    String? originalName,
-    required String name,
-    String? dartDoc,
-    bool isInternal = false,
-  }) : super(
-          usr: usr,
-          originalName: originalName,
-          name: name,
-          dartDoc: dartDoc,
-          isInternal: isInternal,
-        );
+    super.usr,
+    super.originalName,
+    required super.name,
+    super.dartDoc,
+    super.isInternal,
+  });
 
   @override
   Type get baseType => this;

--- a/lib/src/code_generator/typealias.dart
+++ b/lib/src/code_generator/typealias.dart
@@ -66,24 +66,20 @@ class Typealias extends BindingType {
   }
 
   Typealias._({
-    String? usr,
-    String? originalName,
-    String? dartDoc,
+    super.usr,
+    super.originalName,
+    super.dartDoc,
     required String name,
     required this.type,
     bool genFfiDartType = false,
-    bool isInternal = false,
+    super.isInternal,
   })  : _ffiDartAliasName = genFfiDartType ? 'Dart$name' : null,
         _dartAliasName =
             (!genFfiDartType && type is! Typealias && !type.sameDartAndCType)
                 ? 'Dart$name'
                 : null,
         super(
-          usr: usr,
           name: genFfiDartType ? 'Native$name' : name,
-          dartDoc: dartDoc,
-          originalName: originalName,
-          isInternal: isInternal,
         );
 
   @override
@@ -169,20 +165,12 @@ class Typealias extends BindingType {
 /// enclosing class's type, even in inherited methods.
 class ObjCInstanceType extends Typealias {
   ObjCInstanceType._({
-    String? usr,
-    String? originalName,
-    String? dartDoc,
-    required String name,
-    required Type type,
-    bool genFfiDartType = false,
-    bool isInternal = false,
-  }) : super._(
-          usr: usr,
-          originalName: originalName,
-          dartDoc: dartDoc,
-          name: name,
-          type: type,
-          genFfiDartType: genFfiDartType,
-          isInternal: isInternal,
-        );
+    super.usr,
+    super.originalName,
+    super.dartDoc,
+    required super.name,
+    required super.type,
+    super.genFfiDartType,
+    super.isInternal,
+  }) : super._();
 }

--- a/lib/src/code_generator/union.dart
+++ b/lib/src/code_generator/union.dart
@@ -29,21 +29,12 @@ import 'package:ffigen/src/code_generator/compound.dart';
 /// ```
 class Union extends Compound {
   Union({
-    String? usr,
-    String? originalName,
-    required String name,
-    bool isIncomplete = false,
-    int? pack,
-    String? dartDoc,
-    List<Member>? members,
-  }) : super(
-          usr: usr,
-          originalName: originalName,
-          name: name,
-          dartDoc: dartDoc,
-          isIncomplete: isIncomplete,
-          members: members,
-          pack: pack,
-          compoundType: CompoundType.union,
-        );
+    super.usr,
+    super.originalName,
+    required super.name,
+    super.isIncomplete,
+    super.pack,
+    super.dartDoc,
+    super.members,
+  }) : super(compoundType: CompoundType.union);
 }


### PR DESCRIPTION
I was taking a look through the ffigen code and noticed quite a few of these huge constructors. So I enabled the `use_super_parameters` lint to make them a bit easier to visually parse :) 