### PR TITLE
Use getDartType rather than getFfiDartType in ObjC block codegen

### DIFF
--- a/lib/src/code_generator/objc_block.dart
+++ b/lib/src/code_generator/objc_block.dart
@@ -73,31 +73,31 @@ class ObjCBlock extends BindingType {
     final trampFuncType = FunctionType(
         returnType: returnType,
         parameters: [Parameter(type: blockPtr, name: 'block'), ...params]);
-    final natTrampFnType = NativeFunc(trampFuncType);
+    final trampFuncCType = trampFuncType.getCType(w, writeArgumentNames: false);
+    final trampFuncFfiDartType = trampFuncType.getFfiDartType(w, writeArgumentNames: false);
+    final natTrampFnType = NativeFunc(trampFuncType).getCType(w);
     final nativeCallableType =
-        '${w.ffiLibraryPrefix}.NativeCallable<${trampFuncType.getCType(w)}>';
+        '${w.ffiLibraryPrefix}.NativeCallable<$trampFuncCType>';
+    final funcDartType = funcType.getDartType(w, writeArgumentNames: false);
+    final funcFfiDartType = funcType.getFfiDartType(w, writeArgumentNames: false);
+
+    final paramsNameOnly = params.map((p) => p.name).join(', ');
+    final paramsFfiDartType = params.map((p) => '${p.type.getFfiDartType(w)} ${p.name}').join(', ');
+    final paramsDartType = params.map((p) => '${p.type.getDartType(w)} ${p.name}').join(', ');
 
     // Write the function pointer based trampoline function.
     s.write(returnType.getFfiDartType(w));
     s.write(' $funcPtrTrampoline(${blockPtr.getCType(w)} block');
-    for (int i = 0; i < params.length; ++i) {
-      s.write(', ${params[i].type.getFfiDartType(w)} ${params[i].name}');
-    }
-    s.write(') {\n');
-    s.write('  ${isVoid ? '' : 'return '}block.ref.target.cast<'
+    s.write(', $paramsFfiDartType) =>\n');
+    s.write('block.ref.target.cast<'
         '${natFnType.getFfiDartType(w)}>().asFunction<'
-        '${funcType.getFfiDartType(w)}>()(');
-    for (int i = 0; i < params.length; ++i) {
-      s.write('${i == 0 ? '' : ', '}${params[i].name}');
-    }
-    s.write(');\n');
-    s.write('}\n');
+        '$funcFfiDartType>()($paramsNameOnly);\n\n');
 
     // Write the closure registry function.
     s.write('''
-final $closureRegistry = <int, Function>{};
+final $closureRegistry = <int, $funcFfiDartType>{};
 int $closureRegistryIndex = 0;
-$voidPtr $registerClosure(Function fn) {
+$voidPtr $registerClosure($funcFfiDartType fn) {
   final id = ++$closureRegistryIndex;
   $closureRegistry[id] = fn;
   return $voidPtr.fromAddress(id);
@@ -106,24 +106,15 @@ $voidPtr $registerClosure(Function fn) {
 
     // Write the closure based trampoline function.
     s.write(returnType.getFfiDartType(w));
-    s.write(' $closureTrampoline(${blockPtr.getCType(w)} block');
-    for (int i = 0; i < params.length; ++i) {
-      s.write(', ${params[i].type.getFfiDartType(w)} ${params[i].name}');
-    }
-    s.write(') {\n');
-    s.write('  ${isVoid ? '' : 'return '}');
-    s.write('($closureRegistry[block.ref.target.address]');
-    s.write(' as ${returnType.getFfiDartType(w)} Function(');
-    for (int i = 0; i < params.length; ++i) {
-      s.write('${i == 0 ? '' : ', '}${params[i].type.getFfiDartType(w)}');
-    }
-    s.write('))');
-    s.write('(');
-    for (int i = 0; i < params.length; ++i) {
-      s.write('${i == 0 ? '' : ', '}${params[i].name}');
-    }
-    s.write(');\n');
-    s.write('}\n');
+    s.write(' $closureTrampoline(${blockPtr.getCType(w)} block,');
+    s.write('$paramsFfiDartType) =>\n');
+    s.write('$closureRegistry[block.ref.target.address]!($paramsNameOnly);\n');
+
+    // Snippet that converts a Dart typed closure to FfiDart type. This snippet
+    // is used below. Note that the closure being converted is called `fn`.
+    final convertedFnArgs = params.map((p) => p.type.convertFfiDartTypeToDartType(w, p.name, 'lib')).join(', ');
+    final convFnInvocation = returnType.convertDartTypeToFfiDartType(w, 'fn($convertedFnArgs)');
+    final convFn = '($paramsFfiDartType) => $convFnInvocation';
 
     // Write the wrapper class.
     final defaultValue = returnType.getDefaultValue(w, '_lib');
@@ -141,7 +132,7 @@ class $name extends _ObjCBlockBase {
   $name.fromFunctionPointer(${w.className} lib, $natFnPtr ptr) :
       this._(lib.${builtInFunctions.newBlock.name}(
           _cFuncTrampoline ??= ${w.ffiLibraryPrefix}.Pointer.fromFunction<
-              ${trampFuncType.getCType(w)}>($funcPtrTrampoline
+              $trampFuncCType>($funcPtrTrampoline
                   $exceptionalReturn).cast(), ptr.cast()), lib);
   static $voidPtr? _cFuncTrampoline;
 
@@ -150,11 +141,11 @@ class $name extends _ObjCBlockBase {
   /// This block must be invoked by native code running on the same thread as
   /// the isolate that registered it. Invoking the block on the wrong thread
   /// will result in a crash.
-  $name.fromFunction(${w.className} lib, ${funcType.getFfiDartType(w)} fn) :
+  $name.fromFunction(${w.className} lib, $funcDartType fn) :
       this._(lib.${builtInFunctions.newBlock.name}(
           _dartFuncTrampoline ??= ${w.ffiLibraryPrefix}.Pointer.fromFunction<
-              ${trampFuncType.getCType(w)}>($closureTrampoline
-                  $exceptionalReturn).cast(), $registerClosure(fn)), lib);
+              $trampFuncCType>($closureTrampoline
+                  $exceptionalReturn).cast(), $registerClosure($convFn)), lib);
   static $voidPtr? _dartFuncTrampoline;
 
 ''');
@@ -171,31 +162,24 @@ class $name extends _ObjCBlockBase {
   ///
   /// Note that unlike the default behavior of NativeCallable.listener, listener
   /// blocks do not keep the isolate alive.
-  $name.listener(${w.className} lib, ${funcType.getFfiDartType(w)} fn) :
+  $name.listener(${w.className} lib, $funcDartType fn) :
       this._(lib.${builtInFunctions.newBlock.name}(
           (_dartFuncListenerTrampoline ??= $nativeCallableType.listener($closureTrampoline
                   $exceptionalReturn)..keepIsolateAlive = false).nativeFunction.cast(),
-          $registerClosure(fn)), lib);
+          $registerClosure($convFn)), lib);
   static $nativeCallableType? _dartFuncListenerTrampoline;
 
 ''');
     }
 
     // Call method.
-    s.write('  ${returnType.getFfiDartType(w)} call(');
-    for (int i = 0; i < params.length; ++i) {
-      s.write('${i == 0 ? '' : ', '}${params[i].type.getFfiDartType(w)}');
-      s.write(' ${params[i].name}');
-    }
-    s.write(''') {
-    ${isVoid ? '' : 'return '}_id.ref.invoke.cast<
-        ${natTrampFnType.getCType(w)}>().asFunction<
-            ${trampFuncType.getFfiDartType(w)}>()(_id''');
-    for (int i = 0; i < params.length; ++i) {
-      s.write(', ${params[i].name}');
-    }
-    s.write(''');
-  }''');
+    s.write('  ${returnType.getDartType(w)} call($paramsDartType) =>');
+    final callMethodArgs = params.map((p) => p.type.convertDartTypeToFfiDartType(w, p.name)).join(', ');
+    final callMethodInvocation = '''
+    _id.ref.invoke.cast<$natTrampFnType>()
+        .asFunction<$trampFuncFfiDartType>()(_id, $callMethodArgs)''';
+    s.write(returnType.convertFfiDartTypeToDartType(w, callMethodInvocation, '_lib'));
+    s.write(';\n');
 
     s.write('}\n');
     return BindingString(
@@ -226,6 +210,19 @@ class $name extends _ObjCBlockBase {
 
   @override
   bool get sameDartAndCType => false;
+
+  @override
+  String convertDartTypeToFfiDartType(Writer w, String value) => '$value._id';
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) =>
+      '$name._($value, $library)';
 
   @override
   String toString() => '($returnType (^)(${argTypes.join(', ')}))';

--- a/lib/src/code_generator/objc_interface.dart
+++ b/lib/src/code_generator/objc_interface.dart
@@ -207,12 +207,17 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
       s.write(isStatic ? '_lib.${_classObject.name}' : '_id');
       s.write(', _lib.${m.selObject!.name}');
       for (final p in m.params) {
-        s.write(', ${_doArgConversion(p)}');
+        s.write(', ${p.type.convertDartTypeToFfiDartType(w, p.name)}');
       }
       s.write(');\n');
       if (convertReturn) {
-        final result = _doReturnConversion(
-            returnType, '_ret', name, '_lib', m.isOwnedReturn);
+        final result = returnType.convertFfiDartTypeToDartType(
+          w,
+          '_ret',
+          '_lib',
+          isObjCOwnedReturn: m.isOwnedReturn,
+          objCEnclosingClass: name,
+        );
         s.write('    return $result;');
       }
 
@@ -394,6 +399,30 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
   @override
   bool get sameDartAndCType => false;
 
+  @override
+  String convertDartTypeToFfiDartType(Writer w, String value) => '$value._id';
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) =>
+      ObjCInterface.generateConstructor(
+          name, value, library, isObjCOwnedReturn);
+
+  static String generateConstructor(
+    String className,
+    String value,
+    String library,
+    bool isObjCOwnedReturn,
+  ){
+    final ownershipFlags = 'retain: ${!isObjCOwnedReturn}, release: true';
+    return '$className._($value, $library, $ownershipFlags)';
+  }
+
   // Utils for converting between the internal types passed to native code, and
   // the external types visible to the user. For example, ObjCInterfaces are
   // passed to native as Pointer<ObjCObject>, but the user sees the Dart wrapper
@@ -412,44 +441,6 @@ class $name extends ${superType?.name ?? '_ObjCWrapper'} {
       return '$enclosingClass?';
     }
     return type.getDartType(w);
-  }
-
-  String _doArgConversion(ObjCMethodParam arg) {
-    final baseType = arg.type.typealiasType;
-    if (baseType is ObjCNullable) {
-      return '${arg.name}?._id ?? ffi.nullptr';
-    } else if (arg.type is ObjCInstanceType ||
-        baseType is ObjCInterface ||
-        baseType is ObjCObjectPointer ||
-        baseType is ObjCBlock) {
-      return '${arg.name}._id';
-    }
-    return arg.name;
-  }
-
-  String _doReturnConversion(Type type, String value, String enclosingClass,
-      String library, bool isOwnedReturn) {
-    var prefix = '';
-    var baseType = type.typealiasType;
-    if (baseType is ObjCNullable) {
-      prefix = '$value.address == 0 ? null : ';
-      type = baseType.child;
-      baseType = type.typealiasType;
-    }
-    final ownerFlags = 'retain: ${!isOwnedReturn}, release: true';
-    if (type is ObjCInstanceType) {
-      return '$prefix$enclosingClass._($value, $library, $ownerFlags)';
-    }
-    if (baseType is ObjCInterface) {
-      return '$prefix${baseType.name}._($value, $library, $ownerFlags)';
-    }
-    if (baseType is ObjCBlock) {
-      return '$prefix${baseType.name}._($value, $library)';
-    }
-    if (baseType is ObjCObjectPointer) {
-      return '${prefix}NSObject._($value, $library, $ownerFlags)';
-    }
-    return prefix + value;
   }
 }
 

--- a/lib/src/code_generator/objc_nullable.dart
+++ b/lib/src/code_generator/objc_nullable.dart
@@ -45,6 +45,34 @@ class ObjCNullable extends Type {
   bool get sameDartAndCType => false;
 
   @override
+  String convertDartTypeToFfiDartType(Writer w, String value) {
+    // This is a bit of a hack, but works for all the types that are allowed to
+    // be a child type. If we add more allowed child types, we may have to start
+    // special casing each type. Turns value._id into value?._id ?? nullptr.
+    final convertedValue = child.convertDartTypeToFfiDartType(w, '$value?');
+    return '$convertedValue ?? ${w.ffiLibraryPrefix}.nullptr';
+  }
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) {
+    // All currently supported child types have a Pointer as their FfiDartType.
+    final convertedValue = child.convertFfiDartTypeToDartType(
+      w,
+      value,
+      library,
+      isObjCOwnedReturn: isObjCOwnedReturn,
+      objCEnclosingClass: objCEnclosingClass,
+    );
+    return '$value.address == 0 ? null : $convertedValue';
+  }
+
+  @override
   String toString() => '$child?';
 
   @override

--- a/lib/src/code_generator/pointer.dart
+++ b/lib/src/code_generator/pointer.dart
@@ -86,4 +86,18 @@ class ObjCObjectPointer extends PointerType {
 
   @override
   bool get sameDartAndCType => false;
+
+  @override
+  String convertDartTypeToFfiDartType(Writer w, String value) => '$value._id';
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) =>
+      ObjCInterface.generateConstructor(
+          'NSObject', value, library, isObjCOwnedReturn);
 }

--- a/lib/src/code_generator/type.dart
+++ b/lib/src/code_generator/type.dart
@@ -54,8 +54,24 @@ abstract class Type {
   /// Returns whether the dart type and C type string are same.
   bool get sameDartAndCType => sameFfiDartAndCType;
 
-  /// Returns the string representation of the Type, for debugging purposes
-  /// only. This string should not be printed as generated code.
+  /// Returns generated Dart code that converts the given value from its
+  /// DartType to its FfiDartType.
+  String convertDartTypeToFfiDartType(Writer w, String value) => value;
+
+  /// Returns generated Dart code that converts the given value from its
+  /// FfiDartType to its DartType.
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) =>
+      value;
+
+  /// Returns a human readable string representation of the Type. This is mostly
+  /// just for debugging, but it may also be used for non-functional code (eg to
+  /// name a variable or type in generated code).
   @override
   String toString();
 
@@ -106,6 +122,19 @@ abstract class BindingType extends NoLookUpBinding implements Type {
 
   @override
   bool get sameDartAndCType => sameFfiDartAndCType;
+
+  @override
+  String convertDartTypeToFfiDartType(Writer w, String value) => value;
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) =>
+      value;
 
   @override
   String toString() => originalName;

--- a/lib/src/code_generator/typealias.dart
+++ b/lib/src/code_generator/typealias.dart
@@ -151,6 +151,26 @@ class Typealias extends BindingType {
   bool get sameDartAndCType => type.sameDartAndCType;
 
   @override
+  String convertDartTypeToFfiDartType(Writer w, String value) =>
+      type.convertDartTypeToFfiDartType(w, value);
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) =>
+      type.convertFfiDartTypeToDartType(
+        w,
+        value,
+        library,
+        isObjCOwnedReturn: isObjCOwnedReturn,
+        objCEnclosingClass: objCEnclosingClass,
+      );
+
+  @override
   String cacheKey() => type.cacheKey();
 
   @override
@@ -173,4 +193,18 @@ class ObjCInstanceType extends Typealias {
     super.genFfiDartType,
     super.isInternal,
   }) : super._();
+
+  @override
+  String convertDartTypeToFfiDartType(Writer w, String value) => '$value._id';
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Writer w,
+    String value,
+    String library, {
+    bool isObjCOwnedReturn = false,
+    String? objCEnclosingClass,
+  }) =>
+      ObjCInterface.generateConstructor(
+          objCEnclosingClass ?? 'NSObject', value, library, isObjCOwnedReturn);
 }

--- a/test/native_objc_test/block_test.dart
+++ b/test/native_objc_test/block_test.dart
@@ -21,6 +21,9 @@ typedef FloatBlock = ObjCBlock_ffiFloat_ffiFloat;
 typedef DoubleBlock = ObjCBlock_ffiDouble_ffiDouble;
 typedef Vec4Block = ObjCBlock_Vec4_Vec4;
 typedef VoidBlock = ObjCBlock_ffiVoid;
+typedef ObjectBlock = ObjCBlock_DummyObject_DummyObject;
+typedef NullableBlock = ObjCBlock_DummyObject_DummyObject1;
+typedef BlockBlock = ObjCBlock_Int32Int32_Int32Int32;
 
 void main() {
   late BlockTestObjCLibrary lib;
@@ -160,6 +163,25 @@ void main() {
       calloc.free(inputPtr);
       calloc.free(tempPtr);
       calloc.free(result2Ptr);
+    });
+
+    test('Object block', () {
+      bool isCalled = false;
+      final block = ObjectBlock.fromFunction(lib, (DummyObject x) {
+        isCalled = true;
+        return x;
+      });
+
+      final obj = DummyObject.new1(lib);
+      final result1 = block(obj);
+      expect(result1, obj);
+      expect(isCalled, isTrue);
+
+      isCalled = false;
+      final result2 = BlockTester.callObjectBlock_(lib, block);
+      expect(result2, isNot(obj));
+      expect(result2.pointer, isNot(nullptr));
+      expect(isCalled, isTrue);
     });
 
     Pointer<Void> funcPointerBlockRefCountTest() {

--- a/test/native_objc_test/block_test.dart
+++ b/test/native_objc_test/block_test.dart
@@ -184,6 +184,41 @@ void main() {
       expect(isCalled, isTrue);
     });
 
+    test('Nullable block', () {
+      bool isCalled = false;
+      final block = NullableBlock.fromFunction(lib, (DummyObject? x) {
+        isCalled = true;
+        return x;
+      });
+
+      final obj = DummyObject.new1(lib);
+      final result1 = block(obj);
+      expect(result1, obj);
+      expect(isCalled, isTrue);
+
+      isCalled = false;
+      final result2 = BlockTester.callNullableBlock_(lib, block);
+      expect(result2, isNull);
+      expect(isCalled, isTrue);
+    });
+
+    test('Block block', () {
+      final blockBlock = BlockBlock.fromFunction(lib, (IntBlock intBlock) {
+        return IntBlock.fromFunction(lib, (int x) {
+          return 3 * intBlock(x);
+        });
+      });
+
+      final intBlock = IntBlock.fromFunction(lib, (int x) {
+        return 5 * x;
+      });
+      final result1 = blockBlock(intBlock);
+      expect(result1(1), 15);
+
+      final result2 = BlockTester.callBlockBlock_(lib, blockBlock);
+      expect(result2(1), 6);
+    });
+
     Pointer<Void> funcPointerBlockRefCountTest() {
       final block =
           IntBlock.fromFunctionPointer(lib, Pointer.fromFunction(_add100, 999));
@@ -203,7 +238,7 @@ void main() {
       return block.pointer.cast();
     }
 
-    test('Function pointer block ref counting', () {
+    test('Function block ref counting', () {
       final rawBlock = funcBlockRefCountTest();
       doGC();
       expect(BlockTester.getBlockRetainCount_(lib, rawBlock.cast()), 0);

--- a/test/native_objc_test/block_test.m
+++ b/test/native_objc_test/block_test.m
@@ -12,11 +12,20 @@ typedef struct {
   double w;
 } Vec4;
 
+@interface DummyObject : NSObject {}
+@end
+@implementation DummyObject
+@end
+
+
 typedef int32_t (^IntBlock)(int32_t);
 typedef float (^FloatBlock)(float);
 typedef double (^DoubleBlock)(double);
 typedef Vec4 (^Vec4Block)(Vec4);
 typedef void (^VoidBlock)();
+typedef DummyObject* (^ObjectBlock)(DummyObject*);
+typedef DummyObject* _Nullable (^NullableBlock)(DummyObject* _Nullable);
+typedef IntBlock (^BlockBlock)(IntBlock);
 
 // Wrapper around a block, so that our Dart code can test creating and invoking
 // blocks in Objective C code.
@@ -34,6 +43,9 @@ typedef void (^VoidBlock)();
 + (float)callFloatBlock:(FloatBlock)block;
 + (double)callDoubleBlock:(DoubleBlock)block;
 + (Vec4)callVec4Block:(Vec4Block)block;
++ (DummyObject*)callObjectBlock:(ObjectBlock)block;
++ (DummyObject* _Nullable)callNullableBlock:(NullableBlock)block;
++ (IntBlock)callBlockBlock:(BlockBlock)block;
 @end
 
 @implementation BlockTester
@@ -114,6 +126,20 @@ void* valid_block_isa = NULL;
   vec4.z = 5.6;
   vec4.w = 7.8;
   return block(vec4);
+}
+
++ (DummyObject*)callObjectBlock:(ObjectBlock)block {
+  return block([DummyObject new]);
+}
+
++ (DummyObject* _Nullable)callNullableBlock:(NullableBlock)block {
+  return block(nil);
+}
+
++ (IntBlock)callBlockBlock:(BlockBlock)block {
+  return block(^int(int x) {
+    return 2 * x;
+  });
 }
 
 @end


### PR DESCRIPTION
Improves the codegen for blocks with arguments or return types that are objects, nullables, or blocks. Users can now pass or receive the Dart wrapper object, rather than dealing with pointers.

Fixes #531